### PR TITLE
feat(sre): observability, CI pipeline, and status command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,31 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: "-Dwarnings"
+
+jobs:
+  check:
+    name: Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Format
+        run: cargo fmt --all -- --check
+
+      - name: Clippy
+        run: cargo clippy --all-targets --all-features
+
+      - name: Test
+        run: cargo test --all

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 .DS_Store
+.worktrees/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -824,6 +824,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "toml",
+ "tracing",
 ]
 
 [[package]]

--- a/crates/lw-cli/src/main.rs
+++ b/crates/lw-cli/src/main.rs
@@ -2,6 +2,7 @@ mod ingest;
 mod init;
 mod output;
 mod query;
+mod status;
 
 use clap::Parser;
 use output::Format;
@@ -76,6 +77,16 @@ enum Commands {
         #[arg(long)]
         yes: bool,
     },
+
+    /// Show wiki health status and freshness report
+    #[command(
+        after_help = "Examples:\n  lw status\n  lw status --format json"
+    )]
+    Status {
+        /// Output format
+        #[arg(short, long, default_value = "human")]
+        format: Format,
+    },
 }
 
 fn resolve_root(cli_root: Option<PathBuf>) -> Result<PathBuf, String> {
@@ -92,6 +103,11 @@ fn resolve_root(cli_root: Option<PathBuf>) -> Result<PathBuf, String> {
 }
 
 fn main() {
+    tracing_subscriber::fmt()
+        .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+        .with_writer(std::io::stderr)
+        .init();
+
     let cli = Cli::parse();
 
     let result = match cli.command {
@@ -133,6 +149,13 @@ fn main() {
                 &raw_type,
                 yes,
             ),
+            Err(e) => {
+                eprintln!("Error: {e}");
+                process::exit(1);
+            }
+        },
+        Commands::Status { format } => match resolve_root(cli.root) {
+            Ok(root) => status::run(&root, &format),
             Err(e) => {
                 eprintln!("Error: {e}");
                 process::exit(1);

--- a/crates/lw-cli/src/status.rs
+++ b/crates/lw-cli/src/status.rs
@@ -1,0 +1,115 @@
+use crate::output::Format;
+use lw_core::status::gather_status;
+use serde::Serialize;
+use std::path::Path;
+
+#[derive(Serialize)]
+struct StatusJson {
+    command: String,
+    root: String,
+    wiki_name: String,
+    total_pages: usize,
+    categories: Vec<CategoryJson>,
+    freshness: FreshnessJson,
+    index_present: bool,
+}
+
+#[derive(Serialize)]
+struct CategoryJson {
+    name: String,
+    page_count: usize,
+}
+
+#[derive(Serialize)]
+struct FreshnessJson {
+    fresh: usize,
+    suspect: usize,
+    stale: usize,
+    unknown: usize,
+}
+
+pub fn run(root: &Path, format: &Format) -> anyhow::Result<()> {
+    let status = gather_status(root)?;
+
+    match format {
+        Format::Json => {
+            let json = StatusJson {
+                command: "status".into(),
+                root: status.root,
+                wiki_name: status.wiki_name,
+                total_pages: status.total_pages,
+                categories: status
+                    .categories
+                    .iter()
+                    .map(|c| CategoryJson {
+                        name: c.name.clone(),
+                        page_count: c.page_count,
+                    })
+                    .collect(),
+                freshness: FreshnessJson {
+                    fresh: status.freshness.fresh,
+                    suspect: status.freshness.suspect,
+                    stale: status.freshness.stale,
+                    unknown: status.freshness.unknown,
+                },
+                index_present: status.index_present,
+            };
+            println!("{}", serde_json::to_string_pretty(&json)?);
+        }
+        Format::Human => {
+            println!();
+            println!("  Wiki:   {} ({})", status.wiki_name, status.root);
+            println!("  Pages:  {}", status.total_pages);
+            println!(
+                "  Index:  {}",
+                if status.index_present {
+                    "present"
+                } else {
+                    "missing"
+                }
+            );
+            println!();
+            println!("  Freshness:");
+            let total = status.total_pages.max(1);
+            println!(
+                "    FRESH {:<4}  SUSPECT {:<4}  STALE {:<4}  unknown {:<4}",
+                status.freshness.fresh,
+                status.freshness.suspect,
+                status.freshness.stale,
+                status.freshness.unknown,
+            );
+            // Bar visualization
+            let bar_width = 40;
+            let fresh_w = (status.freshness.fresh * bar_width) / total;
+            let suspect_w = (status.freshness.suspect * bar_width) / total;
+            let stale_w = (status.freshness.stale * bar_width) / total;
+            let unknown_w = bar_width - fresh_w - suspect_w - stale_w;
+            println!(
+                "    [{}{}{}{}]",
+                "=".repeat(fresh_w),
+                "~".repeat(suspect_w),
+                "!".repeat(stale_w),
+                ".".repeat(unknown_w),
+            );
+            println!();
+            println!("  Categories:");
+            for cat in &status.categories {
+                println!("    {:<20} {:>4} pages", cat.name, cat.page_count);
+            }
+            println!();
+        }
+        Format::Brief => {
+            println!(
+                "{}\t{}\t{}\t{}/{}/{}/{}",
+                status.root,
+                status.wiki_name,
+                status.total_pages,
+                status.freshness.fresh,
+                status.freshness.suspect,
+                status.freshness.stale,
+                status.freshness.unknown,
+            );
+        }
+    }
+    Ok(())
+}

--- a/crates/lw-core/Cargo.toml
+++ b/crates/lw-core/Cargo.toml
@@ -12,6 +12,7 @@ serde_yml = "0.0.12"
 gray_matter = "0.3"
 tantivy = "0.26"
 regex = "1"
+tracing = { workspace = true }
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/lw-core/src/error.rs
+++ b/crates/lw-core/src/error.rs
@@ -34,6 +34,9 @@ pub enum WikiError {
 
     #[error("LLM error: {0}")]
     Llm(String),
+
+    #[error("git error: {0}")]
+    Git(String),
 }
 
 pub type Result<T> = std::result::Result<T, WikiError>;

--- a/crates/lw-core/src/fs.rs
+++ b/crates/lw-core/src/fs.rs
@@ -3,6 +3,7 @@ use crate::schema::WikiSchema;
 use crate::{Result, WikiError};
 use std::path::{Path, PathBuf};
 
+#[tracing::instrument(skip(schema))]
 pub fn init_wiki(root: &Path, schema: &WikiSchema) -> Result<()> {
     let lw_dir = root.join(".lw");
     std::fs::create_dir_all(&lw_dir)?;
@@ -16,6 +17,7 @@ pub fn init_wiki(root: &Path, schema: &WikiSchema) -> Result<()> {
     Ok(())
 }
 
+#[tracing::instrument]
 pub fn read_page(path: &Path) -> Result<Page> {
     let content =
         std::fs::read_to_string(path).map_err(|_| WikiError::PageNotFound(path.to_path_buf()))?;
@@ -28,6 +30,7 @@ pub fn read_page(path: &Path) -> Result<Page> {
     })
 }
 
+#[tracing::instrument(skip(page))]
 pub fn write_page(path: &Path, page: &Page) -> Result<()> {
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent)?;
@@ -36,6 +39,7 @@ pub fn write_page(path: &Path, page: &Page) -> Result<()> {
     Ok(())
 }
 
+#[tracing::instrument]
 pub fn list_pages(wiki_dir: &Path) -> Result<Vec<PathBuf>> {
     let mut pages = Vec::new();
     walk_md(wiki_dir, wiki_dir, &mut pages)?;
@@ -59,6 +63,7 @@ fn walk_md(base: &Path, dir: &Path, out: &mut Vec<PathBuf>) -> Result<()> {
     Ok(())
 }
 
+#[tracing::instrument]
 pub fn load_schema(root: &Path) -> Result<WikiSchema> {
     let schema_path = root.join(".lw/schema.toml");
     if !schema_path.exists() {
@@ -78,6 +83,7 @@ pub fn category_from_path(rel_path: &Path) -> Option<String> {
 
 /// Walk up from `start` to find the wiki root (directory containing `.lw/schema.toml`).
 /// Similar to how git finds `.git/`.
+#[tracing::instrument]
 pub fn discover_wiki_root(start: &Path) -> Option<PathBuf> {
     let mut current = if start.is_file() {
         start.parent()?.to_path_buf()

--- a/crates/lw-core/src/git.rs
+++ b/crates/lw-core/src/git.rs
@@ -3,6 +3,7 @@ use std::process::Command;
 
 /// Get the age in days of a file based on its last git commit.
 /// Returns None if not in a git repo or file has no git history.
+#[tracing::instrument]
 pub fn page_age_days(path: &Path) -> Option<i64> {
     let output = Command::new("git")
         .args([
@@ -17,6 +18,7 @@ pub fn page_age_days(path: &Path) -> Option<i64> {
         .ok()?;
 
     if !output.status.success() {
+        tracing::debug!(path = %path.display(), "git log returned non-zero");
         return None;
     }
 
@@ -47,6 +49,7 @@ pub fn page_age_days(path: &Path) -> Option<i64> {
         .ok()?;
 
     if !git_ts.status.success() {
+        tracing::debug!(path = %path.display(), "git log timestamp returned non-zero");
         return None;
     }
 
@@ -76,6 +79,7 @@ impl std::fmt::Display for FreshnessLevel {
 /// - fast: stale after 30 days
 /// - normal: stale after `default_days` (usually 90)
 /// - evergreen: never stale by time
+#[tracing::instrument]
 pub fn compute_freshness(decay: &str, age_days: i64, default_days: u32) -> FreshnessLevel {
     let threshold = match decay {
         "fast" => 30,

--- a/crates/lw-core/src/ingest.rs
+++ b/crates/lw-core/src/ingest.rs
@@ -8,6 +8,7 @@ pub struct IngestResult {
     pub draft: Option<Page>,
 }
 
+#[tracing::instrument(skip(llm))]
 pub async fn ingest_source<L: LlmBackend>(
     wiki_root: &Path,
     source: &Path,

--- a/crates/lw-core/src/lib.rs
+++ b/crates/lw-core/src/lib.rs
@@ -7,5 +7,6 @@ pub mod llm;
 pub mod page;
 pub mod schema;
 pub mod search;
+pub mod status;
 pub mod tag;
 pub use error::{Result, WikiError};

--- a/crates/lw-core/src/search.rs
+++ b/crates/lw-core/src/search.rs
@@ -68,6 +68,7 @@ pub struct TantivySearcher {
 }
 
 impl TantivySearcher {
+    #[tracing::instrument]
     pub fn new(index_dir: &Path) -> Result<Self> {
         let mut schema_builder = Schema::builder();
         let f_path = schema_builder.add_text_field("path", STRING | STORED);
@@ -111,6 +112,7 @@ impl TantivySearcher {
 }
 
 impl Searcher for TantivySearcher {
+    #[tracing::instrument(skip(self, page))]
     fn index_page(&self, rel_path: &str, page: &Page) -> Result<()> {
         let writer = self.writer.lock().unwrap();
 
@@ -134,6 +136,7 @@ impl Searcher for TantivySearcher {
         Ok(())
     }
 
+    #[tracing::instrument(skip(self))]
     fn remove_page(&self, rel_path: &str) -> Result<()> {
         let writer = self.writer.lock().unwrap();
         let path_term = Term::from_field_text(self.f_path, rel_path);
@@ -141,6 +144,7 @@ impl Searcher for TantivySearcher {
         Ok(())
     }
 
+    #[tracing::instrument(skip(self))]
     fn commit(&self) -> Result<()> {
         let mut writer = self.writer.lock().unwrap();
         writer.commit()?;
@@ -148,6 +152,7 @@ impl Searcher for TantivySearcher {
         Ok(())
     }
 
+    #[tracing::instrument(skip(self))]
     fn search(&self, query: &SearchQuery) -> Result<SearchResults> {
         let searcher = self.reader.searcher();
 
@@ -235,6 +240,7 @@ impl Searcher for TantivySearcher {
         Ok(SearchResults { hits, total })
     }
 
+    #[tracing::instrument(skip(self))]
     fn rebuild(&self, wiki_dir: &Path) -> Result<()> {
         // Clear all documents.
         {

--- a/crates/lw-core/src/status.rs
+++ b/crates/lw-core/src/status.rs
@@ -1,0 +1,85 @@
+use crate::fs::{list_pages, load_schema, read_page};
+use crate::git::{compute_freshness, page_age_days, FreshnessLevel};
+use std::collections::HashMap;
+use std::path::Path;
+
+#[derive(Debug)]
+pub struct WikiStatus {
+    pub root: String,
+    pub wiki_name: String,
+    pub total_pages: usize,
+    pub categories: Vec<CategoryStatus>,
+    pub freshness: FreshnessDistribution,
+    pub index_present: bool,
+}
+
+#[derive(Debug)]
+pub struct CategoryStatus {
+    pub name: String,
+    pub page_count: usize,
+}
+
+#[derive(Debug, Default)]
+pub struct FreshnessDistribution {
+    pub fresh: usize,
+    pub suspect: usize,
+    pub stale: usize,
+    pub unknown: usize,
+}
+
+#[tracing::instrument]
+pub fn gather_status(root: &Path) -> crate::Result<WikiStatus> {
+    let schema = load_schema(root)?;
+    let wiki_dir = root.join("wiki");
+    let pages = list_pages(&wiki_dir)?;
+
+    let mut cat_counts: HashMap<String, usize> = HashMap::new();
+    let mut freshness = FreshnessDistribution::default();
+
+    for rel_path in &pages {
+        // Category from first path component
+        let cat = rel_path
+            .iter()
+            .next()
+            .filter(|_| rel_path.components().count() > 1)
+            .map(|c| c.to_string_lossy().to_string())
+            .unwrap_or_else(|| "_uncategorized".to_string());
+        *cat_counts.entry(cat).or_default() += 1;
+
+        // Freshness
+        let abs_path = wiki_dir.join(rel_path);
+        let decay = read_page(&abs_path)
+            .ok()
+            .and_then(|p| p.decay.clone())
+            .unwrap_or_else(|| "normal".to_string());
+
+        match page_age_days(&abs_path) {
+            Some(age) => {
+                let level = compute_freshness(&decay, age, schema.wiki.default_review_days);
+                match level {
+                    FreshnessLevel::Fresh => freshness.fresh += 1,
+                    FreshnessLevel::Suspect => freshness.suspect += 1,
+                    FreshnessLevel::Stale => freshness.stale += 1,
+                }
+            }
+            None => freshness.unknown += 1,
+        }
+    }
+
+    let mut categories: Vec<CategoryStatus> = cat_counts
+        .into_iter()
+        .map(|(name, page_count)| CategoryStatus { name, page_count })
+        .collect();
+    categories.sort_by(|a, b| b.page_count.cmp(&a.page_count));
+
+    let index_present = root.join(".lw/search").exists();
+
+    Ok(WikiStatus {
+        root: root.display().to_string(),
+        wiki_name: schema.wiki.name,
+        total_pages: pages.len(),
+        categories,
+        freshness,
+        index_present,
+    })
+}


### PR DESCRIPTION
## Summary

- **Tracing**: Instrument lw-core key functions with `#[tracing::instrument]`, init `tracing-subscriber` in CLI (stderr, `RUST_LOG` env filter)
- **GitHub Actions CI**: `ci.yml` with fmt check + clippy + test on push/PR to main
- **`lw status` command**: Wiki health diagnostic — page count, category breakdown, freshness distribution (fresh/suspect/stale) with bar visualization, index presence. Supports human/json/brief output.
- **Error context**: Add `WikiError::Git` variant, `tracing::debug!` on git failures

## Test plan

- [ ] `cargo test --all` passes (38 tests, verified locally)
- [ ] `cargo clippy --all-targets` clean (no new warnings)
- [ ] `RUST_LOG=debug lw query "test"` shows tracing spans on stderr
- [ ] `lw status` on an initialized wiki shows freshness report
- [ ] `lw status --format json` returns structured JSON
- [ ] CI workflow triggers on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)