### PR TITLE
feat(devops): CI/CD, Docker, test harness with concurrent stress tests

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+target/
+.git/
+.worktrees/
+.DS_Store
+docs/
+*.md
+!README.md

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,21 +11,49 @@ env:
   RUSTFLAGS: "-Dwarnings"
 
 jobs:
-  check:
-    name: Check
+  fmt:
+    name: Format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: rustfmt
+      - run: cargo fmt --all --check
+
+  clippy:
+    name: Clippy
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
         with:
-          components: clippy, rustfmt
+          components: clippy
       - uses: Swatinem/rust-cache@v2
+      - run: cargo clippy --workspace --all-targets
 
-      - name: Format
-        run: cargo fmt --all -- --check
+  test:
+    name: Test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo test --workspace
 
-      - name: Clippy
-        run: cargo clippy --all-targets --all-features
-
-      - name: Test
-        run: cargo test --all
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo build --release --workspace
+      - uses: actions/upload-artifact@v4
+        with:
+          name: lw-linux-x86_64
+          path: target/release/lw

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,82 @@
+name: Release
+
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: write
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    name: Build (${{ matrix.target }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+            artifact: lw-x86_64-linux
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+            artifact: lw-aarch64-linux
+          - target: x86_64-apple-darwin
+            os: macos-latest
+            artifact: lw-x86_64-darwin
+          - target: aarch64-apple-darwin
+            os: macos-latest
+            artifact: lw-aarch64-darwin
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Install cross-compilation tools
+        if: matrix.target == 'aarch64-unknown-linux-gnu'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu
+          echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> "$GITHUB_ENV"
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.target }}
+
+      - name: Build release binary
+        run: cargo build --release --target ${{ matrix.target }} -p lw-cli
+
+      - name: Package binary
+        run: |
+          mkdir -p dist
+          cp target/${{ matrix.target }}/release/lw dist/
+          cd dist
+          tar czf ${{ matrix.artifact }}.tar.gz lw
+          shasum -a 256 ${{ matrix.artifact }}.tar.gz > ${{ matrix.artifact }}.tar.gz.sha256
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}
+          path: dist/${{ matrix.artifact }}.tar.gz*
+
+  release:
+    name: Create Release
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: artifacts/*

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /target
 .DS_Store
 .worktrees/
+dist/
+*.tar.gz

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+FROM rust:1.92-slim AS builder
+
+WORKDIR /build
+COPY Cargo.toml Cargo.lock ./
+COPY crates/ crates/
+
+RUN cargo build --release -p lw-cli \
+    && strip target/release/lw
+
+FROM debian:bookworm-slim
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends git ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /build/target/release/lw /usr/local/bin/lw
+
+RUN useradd --create-home lw
+USER lw
+WORKDIR /home/lw
+
+ENTRYPOINT ["lw"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,35 @@
+.PHONY: build release test fmt clippy lint check clean docker
+
+build:
+	cargo build --workspace
+
+release:
+	cargo build --release -p lw-cli
+
+test:
+	cargo test --workspace
+
+fmt:
+	cargo fmt --all
+
+fmt-check:
+	cargo fmt --all --check
+
+clippy:
+	cargo clippy --workspace --all-targets -- -D warnings
+
+lint: fmt-check clippy
+
+check: lint test
+
+clean:
+	cargo clean
+
+docker:
+	docker build -t lw:latest .
+
+docker-run:
+	docker run --rm -v "$(PWD):/wiki" lw:latest --help
+
+install:
+	cargo install --path crates/lw-cli

--- a/crates/lw-cli/src/ingest.rs
+++ b/crates/lw-cli/src/ingest.rs
@@ -5,6 +5,7 @@ use lw_core::page::Page;
 use std::io::{self, BufRead, Read, Write};
 use std::path::Path;
 
+#[allow(clippy::too_many_arguments)]
 pub fn run(
     root: &Path,
     source: Option<&Path>,

--- a/crates/lw-cli/src/main.rs
+++ b/crates/lw-cli/src/main.rs
@@ -79,9 +79,7 @@ enum Commands {
     },
 
     /// Show wiki health status and freshness report
-    #[command(
-        after_help = "Examples:\n  lw status\n  lw status --format json"
-    )]
+    #[command(after_help = "Examples:\n  lw status\n  lw status --format json")]
     Status {
         /// Output format
         #[arg(short, long, default_value = "human")]

--- a/crates/lw-core/src/fs.rs
+++ b/crates/lw-core/src/fs.rs
@@ -54,10 +54,10 @@ fn walk_md(base: &Path, dir: &Path, out: &mut Vec<PathBuf>) -> Result<()> {
         let path = entry.path();
         if path.is_dir() {
             walk_md(base, &path, out)?;
-        } else if path.extension().is_some_and(|ext| ext == "md") {
-            if let Ok(rel) = path.strip_prefix(base) {
-                out.push(rel.to_path_buf());
-            }
+        } else if path.extension().is_some_and(|ext| ext == "md")
+            && let Ok(rel) = path.strip_prefix(base)
+        {
+            out.push(rel.to_path_buf());
         }
     }
     Ok(())

--- a/crates/lw-core/src/ingest.rs
+++ b/crates/lw-core/src/ingest.rs
@@ -1,6 +1,6 @@
+use crate::Result;
 use crate::llm::LlmBackend;
 use crate::page::Page;
-use crate::Result;
 use std::path::{Path, PathBuf};
 
 pub struct IngestResult {
@@ -16,14 +16,12 @@ pub async fn ingest_source<L: LlmBackend>(
     llm: &L,
 ) -> Result<IngestResult> {
     // Copy source to raw/
-    let filename = source
-        .file_name()
-        .ok_or_else(|| {
-            crate::WikiError::Io(std::io::Error::new(
-                std::io::ErrorKind::InvalidInput,
-                "source has no filename",
-            ))
-        })?;
+    let filename = source.file_name().ok_or_else(|| {
+        crate::WikiError::Io(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "source has no filename",
+        ))
+    })?;
     let dest_dir = wiki_root.join("raw").join(raw_subdir);
     std::fs::create_dir_all(&dest_dir)?;
     let raw_path = dest_dir.join(filename);

--- a/crates/lw-core/src/page.rs
+++ b/crates/lw-core/src/page.rs
@@ -1,5 +1,5 @@
 use crate::{Result, WikiError};
-use gray_matter::{engine::YAML, Matter, ParsedEntity};
+use gray_matter::{Matter, ParsedEntity, engine::YAML};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/lw-core/src/search.rs
+++ b/crates/lw-core/src/search.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 use std::sync::Mutex;
 use tantivy::collector::TopDocs;
 use tantivy::query::{BooleanQuery, Occur, QueryParser, TermQuery};
-use tantivy::schema::{Field, IndexRecordOption, Schema, Value, STORED, STRING, TEXT};
+use tantivy::schema::{Field, IndexRecordOption, STORED, STRING, Schema, TEXT, Value};
 use tantivy::snippet::SnippetGenerator;
 use tantivy::{Index, IndexReader, IndexWriter, ReloadPolicy, TantivyDocument, Term};
 

--- a/crates/lw-core/src/status.rs
+++ b/crates/lw-core/src/status.rs
@@ -1,5 +1,5 @@
 use crate::fs::{list_pages, load_schema, read_page};
-use crate::git::{compute_freshness, page_age_days, FreshnessLevel};
+use crate::git::{FreshnessLevel, compute_freshness, page_age_days};
 use std::collections::HashMap;
 use std::path::Path;
 

--- a/crates/lw-core/tests/common/mod.rs
+++ b/crates/lw-core/tests/common/mod.rs
@@ -1,0 +1,160 @@
+//! Shared test harness for lw-core integration tests.
+//!
+//! `TestWiki` owns a `TempDir` and provides helpers to set up an isolated wiki
+//! environment. Every test gets its own filesystem — no shared state, safe for
+//! `--test-threads=N` with any N.
+
+use lw_core::fs::{init_wiki, write_page};
+use lw_core::page::Page;
+use lw_core::schema::WikiSchema;
+use lw_core::search::TantivySearcher;
+use std::path::{Path, PathBuf};
+use tempfile::TempDir;
+
+/// An isolated wiki environment backed by a temporary directory.
+/// Dropped automatically at end of test scope.
+pub struct TestWiki {
+    _tmp: TempDir,
+    root: PathBuf,
+    #[allow(dead_code)]
+    schema: WikiSchema,
+}
+
+impl TestWiki {
+    /// Create a bare, initialized wiki with default schema.
+    pub fn new() -> Self {
+        Self::with_schema(WikiSchema::default())
+    }
+
+    /// Create with a custom schema.
+    pub fn with_schema(schema: WikiSchema) -> Self {
+        let tmp = TempDir::new().expect("failed to create temp dir");
+        let root = tmp.path().to_path_buf();
+        init_wiki(&root, &schema).expect("failed to init wiki");
+        Self {
+            _tmp: tmp,
+            root,
+            schema,
+        }
+    }
+
+    /// Wiki root path.
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    /// Path to the wiki/ subdirectory.
+    pub fn wiki_dir(&self) -> PathBuf {
+        self.root.join("wiki")
+    }
+
+    /// The schema this wiki was initialized with.
+    #[allow(dead_code)]
+    pub fn schema(&self) -> &WikiSchema {
+        &self.schema
+    }
+
+    /// Write a page into the wiki. `rel_path` is relative to wiki/, e.g.
+    /// `"architecture/transformer.md"`.
+    pub fn write_page(&self, rel_path: &str, page: &Page) {
+        let abs = self.root.join("wiki").join(rel_path);
+        write_page(&abs, page).expect("failed to write page");
+    }
+
+    /// Write the canonical 5-page sample set. Returns the (rel_path, Page) pairs.
+    pub fn with_sample_pages(&self) -> Vec<(String, Page)> {
+        let pages = sample_pages();
+        for (rel, page) in &pages {
+            self.write_page(rel, page);
+        }
+        pages
+    }
+
+    /// Create a TantivySearcher with its index isolated inside this wiki's temp dir.
+    pub fn searcher(&self) -> TantivySearcher {
+        let index_dir = self.root.join(".lw/search");
+        std::fs::create_dir_all(&index_dir).expect("failed to create index dir");
+        TantivySearcher::new(&index_dir).expect("failed to create searcher")
+    }
+
+    /// Create a file at an arbitrary path under the temp root (useful for ingest sources).
+    /// Returns the absolute path.
+    pub fn create_file(&self, rel_path: &str, content: &str) -> PathBuf {
+        let abs = self.root.join(rel_path);
+        if let Some(parent) = abs.parent() {
+            std::fs::create_dir_all(parent).expect("failed to create parent dirs");
+        }
+        std::fs::write(&abs, content).expect("failed to write file");
+        abs
+    }
+}
+
+/// Build a Page with the given metadata.
+pub fn make_page(title: &str, tags: &[&str], decay: &str, body: &str) -> Page {
+    Page {
+        title: title.to_string(),
+        tags: tags.iter().map(|s| s.to_string()).collect(),
+        decay: Some(decay.to_string()),
+        sources: vec![],
+        author: None,
+        generator: None,
+        body: body.to_string(),
+    }
+}
+
+/// The canonical 5-page sample set for integration tests.
+pub fn sample_pages() -> Vec<(String, Page)> {
+    vec![
+        (
+            "architecture/transformer-architecture.md".into(),
+            make_page(
+                "Transformer Architecture",
+                &["architecture", "attention", "deep-learning"],
+                "evergreen",
+                "The Transformer architecture uses multi-head self-attention \
+                 layers interleaved with feed-forward networks. Key innovations: \
+                 scaled dot-product attention, positional encoding, layer normalization.",
+            ),
+        ),
+        (
+            "architecture/flash-attention-2.md".into(),
+            make_page(
+                "Flash Attention 2",
+                &["architecture", "attention", "optimization"],
+                "normal",
+                "Flash Attention 2 reduces memory from O(N^2) to O(N) with 2-4x speedup \
+                 by tiling attention computation in SRAM instead of materializing the full matrix.",
+            ),
+        ),
+        (
+            "training/rlhf-training.md".into(),
+            make_page(
+                "RLHF Training",
+                &["training", "rlhf", "alignment"],
+                "normal",
+                "RLHF aligns LLMs with human preferences via three stages: SFT, reward model, \
+                 PPO. Builds on [[transformer-architecture]]. Uses [[flash-attention-2]] for speed.",
+            ),
+        ),
+        (
+            "tools/pytorch.md".into(),
+            make_page(
+                "PyTorch",
+                &["tools", "pytorch", "framework"],
+                "fast",
+                "PyTorch is the dominant DL framework. Features: torch.distributed, FSDP, \
+                 torch.compile, native mixed-precision (bf16, fp16).",
+            ),
+        ),
+        (
+            "training/lora-fine-tuning.md".into(),
+            make_page(
+                "LoRA Fine-tuning",
+                &["training", "finetuning", "efficiency"],
+                "normal",
+                "LoRA injects trainable low-rank matrices into frozen model layers, \
+                 reducing parameters by 10,000x. Variants: QLoRA, DoRA, AdaLoRA.",
+            ),
+        ),
+    ]
+}

--- a/crates/lw-core/tests/concurrent_test.rs
+++ b/crates/lw-core/tests/concurrent_test.rs
@@ -6,7 +6,7 @@
 
 mod common;
 
-use common::{make_page, TestWiki};
+use common::{TestWiki, make_page};
 use lw_core::fs::{list_pages, read_page};
 use lw_core::link::{find_broken_links, resolve_link};
 use lw_core::search::{SearchQuery, Searcher};
@@ -27,22 +27,37 @@ fn parallel_wikis_full_lifecycle() {
 
                 // Verify page count is exactly 5 (no cross-wiki bleed)
                 let listed = list_pages(&wiki.wiki_dir()).unwrap();
-                assert_eq!(listed.len(), 5, "wiki {i}: expected 5 pages, got {}", listed.len());
+                assert_eq!(
+                    listed.len(),
+                    5,
+                    "wiki {i}: expected 5 pages, got {}",
+                    listed.len()
+                );
 
                 // Read back and verify content belongs to this wiki
-                let p = read_page(&wiki.wiki_dir().join("architecture/transformer-architecture.md")).unwrap();
+                let p = read_page(
+                    &wiki
+                        .wiki_dir()
+                        .join("architecture/transformer-architecture.md"),
+                )
+                .unwrap();
                 assert_eq!(p.title, "Transformer Architecture");
 
                 // Taxonomy is purely in-memory, but verify no cross-contamination
                 let all: Vec<_> = pages.iter().map(|(_, p)| p.clone()).collect();
                 let tax = Taxonomy::from_pages(&all);
-                assert_eq!(tax.tag_count("architecture"), 2, "wiki {i}: tag count wrong");
+                assert_eq!(
+                    tax.tag_count("architecture"),
+                    2,
+                    "wiki {i}: tag count wrong"
+                );
             })
         })
         .collect();
 
     for (i, h) in handles.into_iter().enumerate() {
-        h.join().unwrap_or_else(|e| panic!("wiki thread {i} panicked: {e:?}"));
+        h.join()
+            .unwrap_or_else(|e| panic!("wiki thread {i} panicked: {e:?}"));
     }
 }
 
@@ -99,7 +114,8 @@ fn parallel_search_indexes() {
         .collect();
 
     for (i, h) in handles.into_iter().enumerate() {
-        h.join().unwrap_or_else(|e| panic!("search thread {i} panicked: {e:?}"));
+        h.join()
+            .unwrap_or_else(|e| panic!("search thread {i} panicked: {e:?}"));
     }
 }
 
@@ -172,7 +188,8 @@ fn parallel_link_resolution() {
         .collect();
 
     for (i, h) in handles.into_iter().enumerate() {
-        h.join().unwrap_or_else(|e| panic!("link thread {i} panicked: {e:?}"));
+        h.join()
+            .unwrap_or_else(|e| panic!("link thread {i} panicked: {e:?}"));
     }
 }
 
@@ -262,6 +279,7 @@ fn shared_searcher_across_threads() {
         .collect();
 
     for (i, h) in handles.into_iter().enumerate() {
-        h.join().unwrap_or_else(|e| panic!("query thread {i} panicked: {e:?}"));
+        h.join()
+            .unwrap_or_else(|e| panic!("query thread {i} panicked: {e:?}"));
     }
 }

--- a/crates/lw-core/tests/concurrent_test.rs
+++ b/crates/lw-core/tests/concurrent_test.rs
@@ -1,0 +1,267 @@
+//! Concurrent stress tests — run wiki operations in parallel threads/tasks
+//! to surface shared-state bugs early.
+//!
+//! These tests are designed to be **inherently concurrent**: they don't just
+//! tolerate parallelism, they *require* it to exercise the isolation boundaries.
+
+mod common;
+
+use common::{make_page, TestWiki};
+use lw_core::fs::{list_pages, read_page};
+use lw_core::link::{find_broken_links, resolve_link};
+use lw_core::search::{SearchQuery, Searcher};
+use lw_core::tag::Taxonomy;
+use std::sync::Arc;
+use std::thread;
+
+/// N independent wikis running full CRUD in parallel threads.
+/// If any global state leaks between wikis, this test will catch it.
+#[test]
+fn parallel_wikis_full_lifecycle() {
+    let n = 16;
+    let handles: Vec<_> = (0..n)
+        .map(|i| {
+            thread::spawn(move || {
+                let wiki = TestWiki::new();
+                let pages = wiki.with_sample_pages();
+
+                // Verify page count is exactly 5 (no cross-wiki bleed)
+                let listed = list_pages(&wiki.wiki_dir()).unwrap();
+                assert_eq!(listed.len(), 5, "wiki {i}: expected 5 pages, got {}", listed.len());
+
+                // Read back and verify content belongs to this wiki
+                let p = read_page(&wiki.wiki_dir().join("architecture/transformer-architecture.md")).unwrap();
+                assert_eq!(p.title, "Transformer Architecture");
+
+                // Taxonomy is purely in-memory, but verify no cross-contamination
+                let all: Vec<_> = pages.iter().map(|(_, p)| p.clone()).collect();
+                let tax = Taxonomy::from_pages(&all);
+                assert_eq!(tax.tag_count("architecture"), 2, "wiki {i}: tag count wrong");
+            })
+        })
+        .collect();
+
+    for (i, h) in handles.into_iter().enumerate() {
+        h.join().unwrap_or_else(|e| panic!("wiki thread {i} panicked: {e:?}"));
+    }
+}
+
+/// N independent search indexes built and queried in parallel.
+/// Tantivy uses mmap — this catches any path/lock collision.
+#[test]
+fn parallel_search_indexes() {
+    let n = 16;
+    let handles: Vec<_> = (0..n)
+        .map(|i| {
+            thread::spawn(move || {
+                let wiki = TestWiki::new();
+                let pages = wiki.with_sample_pages();
+                let searcher = wiki.searcher();
+
+                for (rel, page) in &pages {
+                    searcher.index_page(rel, page).unwrap();
+                }
+                searcher.commit().unwrap();
+
+                let results = searcher
+                    .search(&SearchQuery {
+                        text: "attention".into(),
+                        tags: vec![],
+                        category: None,
+                        limit: 10,
+                    })
+                    .unwrap();
+                assert!(
+                    results.total >= 2,
+                    "wiki {i}: expected >=2 hits for 'attention', got {}",
+                    results.total
+                );
+
+                // Tag-filtered search
+                let filtered = searcher
+                    .search(&SearchQuery {
+                        text: "training".into(),
+                        tags: vec!["training".into()],
+                        category: None,
+                        limit: 10,
+                    })
+                    .unwrap();
+                for hit in &filtered.hits {
+                    let page = pages.iter().find(|(_, p)| p.title == hit.title).unwrap();
+                    assert!(
+                        page.1.tags.contains(&"training".to_string()),
+                        "wiki {i}: hit '{}' missing 'training' tag",
+                        hit.title
+                    );
+                }
+            })
+        })
+        .collect();
+
+    for (i, h) in handles.into_iter().enumerate() {
+        h.join().unwrap_or_else(|e| panic!("search thread {i} panicked: {e:?}"));
+    }
+}
+
+/// Parallel ingest operations — each wiki ingests its own source file.
+#[tokio::test]
+async fn parallel_ingest() {
+    let n = 16;
+    let mut tasks = Vec::with_capacity(n);
+
+    for i in 0..n {
+        tasks.push(tokio::spawn(async move {
+            let wiki = TestWiki::new();
+            let source = wiki.create_file(
+                &format!("incoming/paper-{i}.md"),
+                &format!("# Paper {i}\n\nContent for parallel ingest test."),
+            );
+
+            let llm = lw_core::llm::NoopLlm;
+            let result = lw_core::ingest::ingest_source(wiki.root(), &source, "papers", &llm)
+                .await
+                .unwrap();
+
+            assert!(result.raw_path.exists(), "task {i}: raw file missing");
+            assert!(
+                result.raw_path.starts_with(wiki.root().join("raw/papers")),
+                "task {i}: raw file in wrong location"
+            );
+            assert_eq!(
+                result.raw_path.file_name().unwrap().to_str().unwrap(),
+                format!("paper-{i}.md"),
+                "task {i}: wrong filename"
+            );
+        }));
+    }
+
+    for (i, t) in tasks.into_iter().enumerate() {
+        t.await
+            .unwrap_or_else(|e| panic!("ingest task {i} panicked: {e:?}"));
+    }
+}
+
+/// Parallel link resolution — verify no cross-wiki path leakage.
+#[test]
+fn parallel_link_resolution() {
+    let n = 16;
+    let handles: Vec<_> = (0..n)
+        .map(|i| {
+            thread::spawn(move || {
+                let wiki = TestWiki::new();
+                wiki.with_sample_pages();
+
+                let wiki_dir = wiki.wiki_dir();
+
+                // Resolve valid links
+                let resolved = resolve_link("transformer-architecture", &wiki_dir);
+                assert!(resolved.is_some(), "wiki {i}: failed to resolve valid link");
+
+                // Detect broken links
+                let broken = find_broken_links(
+                    "See [[transformer-architecture]] and [[nonexistent-page]]",
+                    &wiki_dir,
+                );
+                assert_eq!(
+                    broken,
+                    vec!["nonexistent-page"],
+                    "wiki {i}: broken link detection wrong"
+                );
+            })
+        })
+        .collect();
+
+    for (i, h) in handles.into_iter().enumerate() {
+        h.join().unwrap_or_else(|e| panic!("link thread {i} panicked: {e:?}"));
+    }
+}
+
+/// Interleaved read-write: one thread writes pages while another reads.
+/// Catches filesystem-level race conditions.
+#[test]
+fn concurrent_read_write() {
+    let wiki = TestWiki::new();
+    let root = wiki.root().to_path_buf();
+    let wiki_dir = wiki.wiki_dir();
+
+    // Writer thread: write 50 pages sequentially
+    let writer_root = root.clone();
+    let writer = thread::spawn(move || {
+        for i in 0..50 {
+            let page = make_page(
+                &format!("Page {i}"),
+                &["concurrent"],
+                "normal",
+                &format!("Body for concurrent page {i}"),
+            );
+            let abs = writer_root
+                .join("wiki/architecture")
+                .join(format!("page-{i}.md"));
+            lw_core::fs::write_page(&abs, &page).unwrap();
+        }
+    });
+
+    // Reader thread: continuously list pages (may see partial state — that's OK)
+    let reader_dir = wiki_dir.clone();
+    let reader = thread::spawn(move || {
+        let mut max_seen = 0;
+        for _ in 0..100 {
+            if let Ok(pages) = list_pages(&reader_dir) {
+                max_seen = max_seen.max(pages.len());
+            }
+            thread::yield_now();
+        }
+        max_seen
+    });
+
+    writer.join().expect("writer panicked");
+    let max_seen = reader.join().expect("reader panicked");
+
+    // After writer completes, all 50 should be visible
+    let final_count = list_pages(&wiki_dir).unwrap().len();
+    assert_eq!(final_count, 50, "expected 50 pages after writer done");
+    // Reader should have seen *something* being written
+    assert!(max_seen > 0, "reader never saw any pages");
+}
+
+/// Build and query the same search index from an Arc across threads.
+/// This tests TantivySearcher's thread safety (it uses interior Mutex).
+#[test]
+fn shared_searcher_across_threads() {
+    let wiki = TestWiki::new();
+    let pages = wiki.with_sample_pages();
+    let searcher = Arc::new(wiki.searcher());
+
+    // Index from main thread
+    for (rel, page) in &pages {
+        searcher.index_page(rel, page).unwrap();
+    }
+    searcher.commit().unwrap();
+
+    // Query from N threads simultaneously
+    let n = 16;
+    let handles: Vec<_> = (0..n)
+        .map(|i| {
+            let s = Arc::clone(&searcher);
+            thread::spawn(move || {
+                let results = s
+                    .search(&SearchQuery {
+                        text: "attention".into(),
+                        tags: vec![],
+                        category: None,
+                        limit: 10,
+                    })
+                    .unwrap();
+                assert!(
+                    results.total >= 2,
+                    "thread {i}: expected >=2 results, got {}",
+                    results.total
+                );
+            })
+        })
+        .collect();
+
+    for (i, h) in handles.into_iter().enumerate() {
+        h.join().unwrap_or_else(|e| panic!("query thread {i} panicked: {e:?}"));
+    }
+}

--- a/crates/lw-core/tests/dogfood_test.rs
+++ b/crates/lw-core/tests/dogfood_test.rs
@@ -1,0 +1,202 @@
+//! Dogfood integration test: exercises lw-core end-to-end from an agent's perspective.
+//!
+//! Uses the shared TestWiki harness for consistent isolation.
+
+mod common;
+
+use common::{sample_pages, TestWiki};
+use lw_core::fs::{list_pages, read_page};
+use lw_core::ingest::ingest_source;
+use lw_core::link::{extract_wiki_links, find_broken_links, resolve_link};
+use lw_core::llm::NoopLlm;
+use lw_core::search::{SearchQuery, Searcher};
+use lw_core::tag::Taxonomy;
+
+#[test]
+fn step1_init_wiki_and_write_pages() {
+    let wiki = TestWiki::new();
+    assert!(wiki.root().join(".lw/schema.toml").exists());
+    assert!(wiki.root().join("wiki/architecture").is_dir());
+    assert!(wiki.root().join("raw/papers").is_dir());
+
+    wiki.with_sample_pages();
+    let listed = list_pages(&wiki.wiki_dir()).unwrap();
+    assert_eq!(listed.len(), 5, "Expected 5 pages, got: {listed:?}");
+
+    let read_back =
+        read_page(&wiki.wiki_dir().join("architecture/transformer-architecture.md")).unwrap();
+    assert_eq!(read_back.title, "Transformer Architecture");
+    assert!(read_back.tags.contains(&"attention".to_string()));
+    assert_eq!(read_back.decay.as_deref(), Some("evergreen"));
+}
+
+#[test]
+fn step3_search_text_and_tag_filter() {
+    let wiki = TestWiki::new();
+    let pages = wiki.with_sample_pages();
+    let searcher = wiki.searcher();
+    for (rel, page) in &pages {
+        searcher.index_page(rel, page).unwrap();
+    }
+    searcher.commit().unwrap();
+
+    let results = searcher
+        .search(&SearchQuery {
+            text: "attention".into(),
+            tags: vec![],
+            category: None,
+            limit: 10,
+        })
+        .unwrap();
+    assert!(
+        results.total >= 2,
+        "Expected >=2 hits, got {}",
+        results.total
+    );
+    let titles: Vec<&str> = results.hits.iter().map(|h| h.title.as_str()).collect();
+    assert!(titles.contains(&"Transformer Architecture"));
+    assert!(titles.contains(&"Flash Attention 2"));
+
+    let filtered = searcher
+        .search(&SearchQuery {
+            text: "training".into(),
+            tags: vec!["training".into()],
+            category: None,
+            limit: 10,
+        })
+        .unwrap();
+    for hit in &filtered.hits {
+        let page = pages.iter().find(|(_, p)| p.title == hit.title).unwrap();
+        assert!(page.1.tags.contains(&"training".to_string()));
+    }
+}
+
+#[test]
+fn step4_tag_taxonomy() {
+    let pages = sample_pages();
+    let all: Vec<_> = pages.into_iter().map(|(_, p)| p).collect();
+    let taxonomy = Taxonomy::from_pages(&all);
+
+    assert_eq!(taxonomy.tag_count("architecture"), 2);
+    assert_eq!(taxonomy.tag_count("training"), 2);
+    assert_eq!(taxonomy.tag_count("attention"), 2);
+    assert_eq!(taxonomy.tag_count("tools"), 1);
+
+    let arch = taxonomy.pages_with_tag("architecture");
+    assert!(arch.contains(&"Transformer Architecture".to_string()));
+    assert!(arch.contains(&"Flash Attention 2".to_string()));
+
+    let all_tags = taxonomy.all_tags();
+    assert!(all_tags.contains(&"rlhf".to_string()));
+    assert!(all_tags.contains(&"pytorch".to_string()));
+}
+
+#[test]
+fn step5_wiki_links_extract_and_resolve() {
+    let wiki = TestWiki::new();
+    let pages = wiki.with_sample_pages();
+
+    let rlhf = pages
+        .iter()
+        .find(|(_, p)| p.title == "RLHF Training")
+        .unwrap();
+    let links = extract_wiki_links(&rlhf.1.body);
+    assert!(links.contains(&"transformer-architecture".to_string()));
+    assert!(links.contains(&"flash-attention-2".to_string()));
+
+    let resolved = resolve_link("transformer-architecture", &wiki.wiki_dir());
+    assert_eq!(
+        resolved,
+        Some(std::path::PathBuf::from(
+            "architecture/transformer-architecture.md"
+        ))
+    );
+}
+
+#[tokio::test]
+async fn step6_ingest_source_file() {
+    let wiki = TestWiki::new();
+    let source = wiki.create_file(
+        "incoming/llm-survey-2024.md",
+        "# A Survey of Large Language Models (2024)\n\nComprehensive survey covering...",
+    );
+
+    let result = ingest_source(wiki.root(), &source, "papers", &NoopLlm)
+        .await
+        .unwrap();
+    assert!(result.raw_path.exists());
+    assert!(result.raw_path.starts_with(wiki.root().join("raw/papers")));
+    assert!(result.draft.is_none());
+}
+
+#[test]
+fn step7_broken_link_detection() {
+    let wiki = TestWiki::new();
+    wiki.with_sample_pages();
+
+    let broken = find_broken_links(
+        "See [[transformer-architecture]] and [[nonexistent-page]]",
+        &wiki.wiki_dir(),
+    );
+    assert_eq!(broken, vec!["nonexistent-page"]);
+    assert!(!broken.contains(&"transformer-architecture".to_string()));
+
+    let no_broken = find_broken_links(
+        "[[transformer-architecture]] and [[flash-attention-2]]",
+        &wiki.wiki_dir(),
+    );
+    assert!(no_broken.is_empty());
+}
+
+#[tokio::test]
+async fn full_agent_workflow() {
+    let wiki = TestWiki::new();
+    let loaded = lw_core::fs::load_schema(wiki.root()).unwrap();
+    assert_eq!(loaded.wiki.name, "LLM Wiki");
+
+    let pages = wiki.with_sample_pages();
+
+    // Search
+    let searcher = wiki.searcher();
+    for (rel, page) in &pages {
+        searcher.index_page(rel, page).unwrap();
+    }
+    searcher.commit().unwrap();
+    let results = searcher
+        .search(&SearchQuery {
+            text: "attention".into(),
+            tags: vec![],
+            category: None,
+            limit: 10,
+        })
+        .unwrap();
+    assert!(results.total >= 2);
+
+    // Taxonomy
+    let all: Vec<_> = pages.iter().map(|(_, p)| p.clone()).collect();
+    let tax = Taxonomy::from_pages(&all);
+    assert_eq!(tax.tag_count("architecture"), 2);
+
+    // Links
+    let rlhf = pages
+        .iter()
+        .find(|(_, p)| p.title == "RLHF Training")
+        .unwrap();
+    let links = extract_wiki_links(&rlhf.1.body);
+    assert!(links.contains(&"transformer-architecture".to_string()));
+    assert!(resolve_link("transformer-architecture", &wiki.wiki_dir()).is_some());
+
+    // Ingest
+    let source = wiki.create_file("incoming/paper.txt", "Raw paper content.");
+    let ingest = ingest_source(wiki.root(), &source, "papers", &NoopLlm)
+        .await
+        .unwrap();
+    assert!(ingest.raw_path.exists());
+
+    // Broken links
+    let broken = find_broken_links(
+        "[[transformer-architecture]] and [[ghost-page]]",
+        &wiki.wiki_dir(),
+    );
+    assert_eq!(broken, vec!["ghost-page"]);
+}

--- a/crates/lw-core/tests/dogfood_test.rs
+++ b/crates/lw-core/tests/dogfood_test.rs
@@ -4,7 +4,7 @@
 
 mod common;
 
-use common::{sample_pages, TestWiki};
+use common::{TestWiki, sample_pages};
 use lw_core::fs::{list_pages, read_page};
 use lw_core::ingest::ingest_source;
 use lw_core::link::{extract_wiki_links, find_broken_links, resolve_link};
@@ -23,8 +23,12 @@ fn step1_init_wiki_and_write_pages() {
     let listed = list_pages(&wiki.wiki_dir()).unwrap();
     assert_eq!(listed.len(), 5, "Expected 5 pages, got: {listed:?}");
 
-    let read_back =
-        read_page(&wiki.wiki_dir().join("architecture/transformer-architecture.md")).unwrap();
+    let read_back = read_page(
+        &wiki
+            .wiki_dir()
+            .join("architecture/transformer-architecture.md"),
+    )
+    .unwrap();
     assert_eq!(read_back.title, "Transformer Architecture");
     assert!(read_back.tags.contains(&"attention".to_string()));
     assert_eq!(read_back.decay.as_deref(), Some("evergreen"));

--- a/crates/lw-core/tests/git_test.rs
+++ b/crates/lw-core/tests/git_test.rs
@@ -1,4 +1,4 @@
-use lw_core::git::{compute_freshness, FreshnessLevel};
+use lw_core::git::{FreshnessLevel, compute_freshness};
 
 #[test]
 fn fast_decay_stale_after_30() {

--- a/crates/lw-core/tests/link_test.rs
+++ b/crates/lw-core/tests/link_test.rs
@@ -3,8 +3,7 @@ use std::path::PathBuf;
 
 #[test]
 fn extract_links_from_body() {
-    let body =
-        "See [[transformer]] for details. Also related: [[scaling-laws]] and [[attention-mechanism]].";
+    let body = "See [[transformer]] for details. Also related: [[scaling-laws]] and [[attention-mechanism]].";
     let links = extract_wiki_links(body);
     assert_eq!(
         links,


### PR DESCRIPTION
## Summary

- **GitHub Actions CI**: separate jobs for fmt (nightly), clippy, test (Linux + macOS matrix), build with artifact upload
- **GitHub Actions Release**: cross-compile on `v*` tag push for 4 targets (x86_64/aarch64 × Linux/macOS), auto-creates GitHub Release with checksums
- **Dockerfile**: multi-stage build (`rust:1.92-slim` → `debian:bookworm-slim`), non-root user, git included for wiki ops
- **Makefile**: `build`, `release`, `test`, `fmt`, `clippy`, `lint`, `check`, `docker`, `install` targets
- **TestWiki harness** (`tests/common/mod.rs`): owns TempDir, provides isolated wiki root, searcher, sample pages, file creation
- **6 concurrent stress tests** (16 threads/tasks each): parallel wiki CRUD, search indexing, ingest, link resolution, concurrent read-write, shared searcher
- **dogfood_test.rs** migrated to TestWiki harness
- Pre-existing fmt drift and clippy warnings fixed

## Test plan

- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` — 51 tests, all green
- [x] `cargo test --workspace -- --test-threads=16` — stress tested, all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)