### PR TITLE
refactor: simplify — dedup, dead code, fix errors

### DIFF
--- a/crates/lw-cli/src/ingest.rs
+++ b/crates/lw-cli/src/ingest.rs
@@ -1,7 +1,7 @@
 use lw_core::fs::{load_schema, write_page};
 use lw_core::ingest::ingest_source;
 use lw_core::llm::NoopLlm;
-use lw_core::page::Page;
+use lw_core::page::{Page, slugify};
 use std::io::{self, BufRead, Read, Write};
 use std::path::Path;
 
@@ -128,16 +128,4 @@ fn confirm(prompt: &str, default_yes: bool) -> io::Result<bool> {
     } else {
         trimmed == "y" || trimmed == "yes"
     })
-}
-
-fn slugify(title: &str) -> String {
-    title
-        .to_lowercase()
-        .chars()
-        .map(|c| if c.is_alphanumeric() { c } else { '-' })
-        .collect::<String>()
-        .split('-')
-        .filter(|s| !s.is_empty())
-        .collect::<Vec<&str>>()
-        .join("-")
 }

--- a/crates/lw-cli/src/query.rs
+++ b/crates/lw-cli/src/query.rs
@@ -11,12 +11,14 @@ pub fn run(
     limit: usize,
     format: &Format,
 ) -> anyhow::Result<()> {
-    let _schema = load_schema(root)?;
+    // Validate wiki exists (produces actionable error message)
+    load_schema(root)?;
     let index_dir = root.join(".lw/search");
     std::fs::create_dir_all(&index_dir)?;
     let searcher = TantivySearcher::new(&index_dir)?;
 
-    // Rebuild index (Phase 2: incremental)
+    // CLI rebuilds on every query. The MCP server (lw serve) holds a persistent
+    // index with incremental updates — use that for repeated queries.
     let wiki_dir = root.join("wiki");
     searcher.rebuild(&wiki_dir)?;
 

--- a/crates/lw-core/src/error.rs
+++ b/crates/lw-core/src/error.rs
@@ -17,14 +17,14 @@ pub enum WikiError {
     #[error("YAML parse error: {0}")]
     YamlParse(String),
 
+    #[error("JSON parse error: {0}")]
+    JsonParse(String),
+
     #[error("invalid frontmatter in {path}: {reason}")]
     Frontmatter { path: PathBuf, reason: String },
 
     #[error("page not found: {0}")]
     PageNotFound(PathBuf),
-
-    #[error("schema not found: {0}")]
-    SchemaNotFound(PathBuf),
 
     #[error("not a wiki directory: {0} (missing .lw/schema.toml)\n  Run: lw init --root <path>")]
     NotAWiki(PathBuf),

--- a/crates/lw-core/src/fs.rs
+++ b/crates/lw-core/src/fs.rs
@@ -73,12 +73,15 @@ pub fn load_schema(root: &Path) -> Result<WikiSchema> {
     WikiSchema::parse(&content)
 }
 
+/// Extract category from a wiki-relative path (first path component).
+/// e.g. "architecture/transformer.md" → Some("architecture")
+/// e.g. "test.md" → None (no category directory)
 pub fn category_from_path(rel_path: &Path) -> Option<String> {
-    rel_path
-        .parent()
-        .filter(|p| !p.as_os_str().is_empty())
-        .and_then(|p| p.file_name())
-        .map(|s| s.to_string_lossy().to_string())
+    let mut components = rel_path.components();
+    let first = components.next()?;
+    // Only return category if there's at least one more component (the filename)
+    components.next()?;
+    Some(first.as_os_str().to_string_lossy().to_string())
 }
 
 /// Walk up from `start` to find the wiki root (directory containing `.lw/schema.toml`).

--- a/crates/lw-core/src/git.rs
+++ b/crates/lw-core/src/git.rs
@@ -10,37 +10,6 @@ pub fn page_age_days(path: &Path) -> Option<i64> {
             "log",
             "--follow",
             "-1",
-            "--format=%aI",
-            "--",
-            path.to_str()?,
-        ])
-        .output()
-        .ok()?;
-
-    if !output.status.success() {
-        tracing::debug!(path = %path.display(), "git log returned non-zero");
-        return None;
-    }
-
-    let date_str = String::from_utf8(output.stdout).ok()?.trim().to_string();
-    if date_str.is_empty() {
-        return None;
-    }
-
-    // Parse ISO 8601 date manually (avoid chrono dependency)
-    // Format: 2026-04-06T12:00:00+08:00
-    // We just need the date part for day-level granularity
-    let now = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .ok()?
-        .as_secs() as i64;
-
-    // Parse the date using git's own timestamp conversion
-    let git_ts = Command::new("git")
-        .args([
-            "log",
-            "--follow",
-            "-1",
             "--format=%at",
             "--",
             path.to_str()?,
@@ -48,12 +17,19 @@ pub fn page_age_days(path: &Path) -> Option<i64> {
         .output()
         .ok()?;
 
-    if !git_ts.status.success() {
-        tracing::debug!(path = %path.display(), "git log timestamp returned non-zero");
+    if !output.status.success() {
         return None;
     }
 
-    let ts: i64 = String::from_utf8(git_ts.stdout).ok()?.trim().parse().ok()?;
+    let ts: i64 = String::from_utf8(output.stdout).ok()?.trim().parse().ok()?;
+    if ts == 0 {
+        return None;
+    }
+
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .ok()?
+        .as_secs() as i64;
     Some((now - ts) / 86400)
 }
 

--- a/crates/lw-core/src/import.rs
+++ b/crates/lw-core/src/import.rs
@@ -1,4 +1,4 @@
-use crate::page::Page;
+use crate::page::{Page, slugify};
 use crate::{Result, WikiError};
 use serde::Deserialize;
 
@@ -32,14 +32,14 @@ struct Tweet {
 /// Parse a Twitter JSON export into ImportedPage entries.
 pub fn parse_twitter_json(json_str: &str, limit: Option<usize>) -> Result<Vec<ImportedPage>> {
     let tweets: Vec<Tweet> = serde_json::from_str(json_str)
-        .map_err(|e| WikiError::YamlParse(format!("Invalid Twitter JSON: {e}")))?;
+        .map_err(|e| WikiError::JsonParse(format!("Invalid Twitter JSON: {e}")))?;
 
     let mut pages = Vec::new();
     for tweet in &tweets {
-        if let Some(max) = limit {
-            if pages.len() >= max {
-                break;
-            }
+        if let Some(max) = limit
+            && pages.len() >= max
+        {
+            break;
         }
 
         if tweet.full_text.len() < 20 {
@@ -54,7 +54,7 @@ pub fn parse_twitter_json(json_str: &str, limit: Option<usize>) -> Result<Vec<Im
             .replace('\n', " ");
         let title = title.trim().to_string();
 
-        let slug = slugify_title(&title);
+        let slug = slugify(&title);
 
         let engagement = format!(
             "likes:{} bookmarks:{} views:{}",
@@ -89,22 +89,4 @@ pub fn parse_twitter_json(json_str: &str, limit: Option<usize>) -> Result<Vec<Im
     }
 
     Ok(pages)
-}
-
-fn slugify_title(title: &str) -> String {
-    title
-        .to_lowercase()
-        .chars()
-        .map(|c| {
-            if c.is_alphanumeric() || c > '\u{2E7F}' {
-                c
-            } else {
-                '-'
-            }
-        })
-        .collect::<String>()
-        .split('-')
-        .filter(|s| !s.is_empty())
-        .collect::<Vec<&str>>()
-        .join("-")
 }

--- a/crates/lw-core/src/page.rs
+++ b/crates/lw-core/src/page.rs
@@ -1,5 +1,5 @@
 use crate::{Result, WikiError};
-use gray_matter::{engine::YAML, Matter, ParsedEntity};
+use gray_matter::{Matter, ParsedEntity, engine::YAML};
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/lw-core/src/search.rs
+++ b/crates/lw-core/src/search.rs
@@ -117,14 +117,8 @@ impl TantivySearcher {
         })
     }
 
-    /// Extract category from a relative path (first path component).
     fn category_from_path(rel_path: &str) -> String {
-        let p = std::path::Path::new(rel_path);
-        p.iter()
-            .next()
-            .filter(|_| p.components().count() > 1)
-            .map(|c| c.to_string_lossy().to_string())
-            .unwrap_or_default()
+        crate::fs::category_from_path(std::path::Path::new(rel_path)).unwrap_or_default()
     }
 }
 

--- a/crates/lw-core/src/status.rs
+++ b/crates/lw-core/src/status.rs
@@ -37,13 +37,8 @@ pub fn gather_status(root: &Path) -> crate::Result<WikiStatus> {
     let mut freshness = FreshnessDistribution::default();
 
     for rel_path in &pages {
-        // Category from first path component
-        let cat = rel_path
-            .iter()
-            .next()
-            .filter(|_| rel_path.components().count() > 1)
-            .map(|c| c.to_string_lossy().to_string())
-            .unwrap_or_else(|| "_uncategorized".to_string());
+        let cat =
+            crate::fs::category_from_path(rel_path).unwrap_or_else(|| "_uncategorized".to_string());
         *cat_counts.entry(cat).or_default() += 1;
 
         // Freshness

--- a/crates/lw-core/tests/import_test.rs
+++ b/crates/lw-core/tests/import_test.rs
@@ -1,4 +1,4 @@
-use lw_core::import::{ImportedPage, parse_twitter_json};
+use lw_core::import::parse_twitter_json;
 
 #[test]
 fn parse_twitter_json_basic() {

--- a/crates/lw-mcp/src/lib.rs
+++ b/crates/lw-mcp/src/lib.rs
@@ -102,6 +102,7 @@ pub struct WikiLintArgs {
 pub struct WikiMcpServer {
     wiki_root: PathBuf,
     searcher: Arc<TantivySearcher>,
+    default_review_days: u32,
     tool_router: ToolRouter<Self>,
 }
 
@@ -219,7 +220,9 @@ impl WikiMcpServer {
                         let age = git::page_age_days(&abs_path);
                         let decay = page.decay.as_deref().unwrap_or("normal");
                         let level = match age {
-                            Some(days) => git::compute_freshness(decay, days, 90),
+                            Some(days) => {
+                                git::compute_freshness(decay, days, self.default_review_days)
+                            }
                             None => FreshnessLevel::Fresh,
                         };
                         if level == FreshnessLevel::Fresh {
@@ -388,7 +391,7 @@ impl WikiMcpServer {
                     let decay = page.decay.as_deref().unwrap_or("normal");
                     let age_days = git::page_age_days(&abs_path);
                     let level = match age_days {
-                        Some(days) => git::compute_freshness(decay, days, 90),
+                        Some(days) => git::compute_freshness(decay, days, self.default_review_days),
                         None => FreshnessLevel::Fresh, // no git history = treat as fresh
                     };
 
@@ -445,6 +448,9 @@ impl ServerHandler for WikiMcpServer {
 
 impl WikiMcpServer {
     pub fn new(wiki_root: PathBuf) -> anyhow::Result<Self> {
+        let schema = lw_core::fs::load_schema(&wiki_root)?;
+        let default_review_days = schema.wiki.default_review_days;
+
         let index_dir = wiki_root.join(".lw/index");
         std::fs::create_dir_all(&index_dir)?;
 
@@ -461,6 +467,7 @@ impl WikiMcpServer {
         Ok(Self {
             wiki_root,
             searcher,
+            default_review_days,
             tool_router: Self::tool_router(),
         })
     }


### PR DESCRIPTION
## Summary
- Remove duplicate `slugify` (3→1). **Fixes CJK bug** in `lw ingest` where Chinese titles produced broken slugs
- Consolidate `category_from_path` (3→1). Fix to use first path component
- `git.rs`: remove dead first subprocess call (2→1 git call per page, halves `lw status`/`wiki_lint` time)
- MCP: read `default_review_days` from schema instead of hardcoding 90
- `error.rs`: add `JsonParse` variant, remove unused `SchemaNotFound`
- `import.rs`: use `JsonParse` for JSON errors (was misleadingly using `YamlParse`)

## Test plan
- [x] `cargo test` — all pass
- [x] `cargo clippy` — clean
- [x] `cargo fmt` — clean

Net: -53 lines