### PR TITLE
docs(cli): rewrite top-level --help examples for v0.2.0+ user journey

### DIFF
--- a/crates/lw-cli/src/main.rs
+++ b/crates/lw-cli/src/main.rs
@@ -29,7 +29,7 @@ use std::process;
     name = "lw",
     version,
     about = "LLM Wiki — team knowledge base toolkit",
-    after_help = "Examples:\n  lw init\n  lw query \"attention mechanism\" --format json\n  lw ingest paper.pdf --category architecture --yes"
+    after_help = "First-time setup:\n  lw workspace add my-vault ~/wiki --template general\n  lw integrate --auto       # wire your agent tool (Claude Code / Codex / OpenClaw)\n  lw doctor                 # verify everything is healthy\n\nDay-to-day (typically driven by your agent tool, not by hand):\n  lw query \"attention mechanism\"\n  lw ingest paper.pdf --category architecture --yes\n  lw read architecture/transformer.md\n  lw lint\n\nMaintenance:\n  lw upgrade --check\n  lw workspace list\n  lw uninstall              # vault data preserved"
 )]
 struct Cli {
     /// Wiki root directory (default: auto-discover from cwd, or LW_WIKI_ROOT env)


### PR DESCRIPTION
Brings `lw --help` examples in line with v0.2.0's installer-first user journey.

Old examples only mentioned `init` / `query` / `ingest` — fine for the pre-wrapper era, but now misleading because `init` is no longer the typical first command (templates do the job).

New three-section grouping:
- **First-time setup**: `workspace add --template general` + `integrate --auto` + `doctor`
- **Day-to-day**: `query` / `ingest` / `read` / `lint` (driven by agent tool, not by hand)
- **Maintenance**: `upgrade --check` / `workspace list` / `uninstall`

🤖 Generated with [Claude Code](https://claude.com/claude-code)