### PR TITLE
docs: absorb llm-wiki-mono spec/plans + add dev-checkout instructions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,22 @@ Vaults (wiki content) are **separate git repos** of markdown files; users bring 
 
 The release tarball (built by `.github/workflows/release.yml` on `v*` tag push) bundles `lw` + `skills/` + `templates/` + `integrations/` + `installer/` + a `VERSION` file into one per-platform archive. `install.sh` and `uninstall.sh` are also published as separate top-level release assets so the curl line works without first downloading the binary.
 
+## Dev workspace (replacing the deprecated mono)
+
+`llm-wiki-mono` was previously used as a checkout convenience that bundled `llm-wiki` + `llm-wiki-agents` + `codebridge` + a private `wiki` content repo as submodules. **It is now archived.** Contributors who want all four repos visible at once should clone them as siblings:
+
+```bash
+mkdir -p ~/dev/llm-wiki && cd ~/dev/llm-wiki
+git clone git@github.com:Pawpaw-Technology/llm-wiki.git
+git clone git@github.com:Pawpaw-Technology/llm-wiki-agents.git
+git clone git@github.com:64andrewwalker/codebridge.git
+# (private wiki repo only if you have access)
+```
+
+Each repo is self-contained and CI'd independently. There is no longer a "meta repo" to update — code, PRs, and releases happen in each repo individually.
+
+Spec, plans, and smoke transcripts that documented the v0.2.0 product wrapper rollout (formerly under `mono/docs/superpowers/`) now live in this repo under `docs/specs/`, `docs/plans/`, `docs/smoke-tests/`.
+
 ## Key Design Rules
 
 - Only one trait: `Searcher`; everything else is concrete types

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,24 @@
+# llm-wiki docs
+
+Architecture decisions, implementation plans, and verification artifacts for the llm-wiki product.
+
+## Specs
+
+- [2026-04-19 — Product wrapper design](specs/2026-04-19-product-wrapper-design.md) — turning lw from a Rust tool into an installable open-source product
+
+## Plans
+
+- [Plan A — Workspace foundation](plans/2026-04-20-wrapper-plan-a-workspace.md) — `lw workspace add/list/use/current/remove`, `~/.llm-wiki/config.toml`, 4-layer root resolution
+- [Plan B — Skills, templates, integrations engine](plans/2026-04-20-wrapper-plan-b-skills-integrations.md) — `llm-wiki:import` skill, 3 starter templates, TOML descriptor adapter, atomic MCP merge
+- [Plan C — Installer + upgrade + uninstall + CI](plans/2026-04-20-wrapper-plan-c-installer.md) — `install.sh`, `uninstall.sh`, `lw upgrade/uninstall`, release pipeline
+- [Plan D — Multi-tool, doctor, 1.0 gate](plans/2026-04-20-wrapper-plan-d-doctor-1.0-gate.md) — Codex/OpenClaw descriptors, `lw doctor`, README rewrite, smoke gate
+
+## Smoke tests
+
+- [v0.2.0-rc.1](smoke-tests/v0.2.0-rc.1/SUMMARY.md) — first composite gate (found B1+B2+M1+M2)
+- [v0.2.0-rc.2](smoke-tests/v0.2.0-rc.2/SUMMARY.md) — fixes verified (verdict: GREEN)
+
+## Releases
+
+- [v0.2.0](https://github.com/Pawpaw-Technology/llm-wiki/releases/tag/v0.2.0) — first product wrapper release
+- [v0.2.1](https://github.com/Pawpaw-Technology/llm-wiki/releases/tag/v0.2.1) — `--help` examples updated for installer-first flow

--- a/docs/plans/2026-04-20-wrapper-plan-a-workspace.md
+++ b/docs/plans/2026-04-20-wrapper-plan-a-workspace.md
@@ -1,0 +1,1007 @@
+# Plan A — Workspace Foundation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `lw workspace add | list | use | current | remove` subcommands backed by `~/.llm-wiki/config.toml`, plus a 4-layer root resolution chain, so users can register multiple wiki vaults and switch between them. Preserves existing single-vault `cwd` auto-discover behavior.
+
+**Architecture:** New `config` module owns `~/.llm-wiki/config.toml` schema and I/O. New `workspace` module implements CRUD subcommands. `main.rs::resolve_root` is upgraded from 2 layers (`--root` > env > cwd) to 4 layers (`--root` > env > current registered workspace > cwd). All logic lives in `lw-cli` since it's user-config (not wiki-internal); `lw-core` stays focused on wiki content.
+
+**Tech Stack:** Rust 2024, `clap` 4.6 derive, `toml` 1, `dirs` 5, `serde`, `assert_cmd` for CLI integration tests.
+
+**Working dir:** All commands run from `tool/llm-wiki/` (the llm-wiki submodule inside the mono repo). Per memory `feedback_worktree_submodule.md`, do not use worktree isolation for submodule changes — work directly in `tool/llm-wiki/`.
+
+**Spec reference:** `docs/superpowers/specs/2026-04-19-llm-wiki-product-wrapper-design.md` §4.1, §8.
+
+---
+
+## File structure
+
+| File                                   | Status | Responsibility                                         |
+| -------------------------------------- | ------ | ------------------------------------------------------ |
+| `crates/lw-cli/Cargo.toml`             | modify | Add `dirs` and `toml` deps                             |
+| `crates/lw-cli/src/config.rs`          | create | `Config` type + TOML I/O for `~/.llm-wiki/config.toml` |
+| `crates/lw-cli/src/workspace.rs`       | create | CRUD command handlers                                  |
+| `crates/lw-cli/src/main.rs`            | modify | Wire `Workspace` subcommand; upgrade `resolve_root`    |
+| `crates/lw-cli/tests/workspace_cli.rs` | create | End-to-end CLI integration tests                       |
+
+---
+
+## Task 1: Add dependencies
+
+**Files:**
+
+- Modify: `crates/lw-cli/Cargo.toml`
+
+- [ ] **Step 1: Add deps**
+
+Edit `crates/lw-cli/Cargo.toml`, append to `[dependencies]` (preserve existing entries):
+
+```toml
+dirs = "5"
+toml = "1"
+```
+
+- [ ] **Step 2: Verify build still passes**
+
+Run from `tool/llm-wiki/`:
+
+```bash
+cargo build -p lw-cli
+```
+
+Expected: clean build, no warnings about new deps.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/lw-cli/Cargo.toml Cargo.lock
+git commit -m "build(lw-cli): add dirs and toml deps for workspace registry"
+```
+
+---
+
+## Task 2: Config types + TOML round-trip
+
+**Files:**
+
+- Create: `crates/lw-cli/src/config.rs`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `crates/lw-cli/src/config.rs`:
+
+```rust
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+#[derive(Debug, Default, Serialize, Deserialize, PartialEq)]
+pub struct Config {
+    #[serde(default)]
+    pub workspace: WorkspaceState,
+    #[serde(default)]
+    pub workspaces: BTreeMap<String, WorkspaceEntry>,
+}
+
+#[derive(Debug, Default, Serialize, Deserialize, PartialEq)]
+pub struct WorkspaceState {
+    pub current: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+pub struct WorkspaceEntry {
+    pub path: PathBuf,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn empty_config_roundtrips() {
+        let cfg = Config::default();
+        let s = toml::to_string(&cfg).unwrap();
+        let back: Config = toml::from_str(&s).unwrap();
+        assert_eq!(back, cfg);
+    }
+
+    #[test]
+    fn config_with_workspaces_roundtrips() {
+        let mut workspaces = BTreeMap::new();
+        workspaces.insert(
+            "personal".into(),
+            WorkspaceEntry { path: PathBuf::from("/tmp/personal") },
+        );
+        workspaces.insert(
+            "work".into(),
+            WorkspaceEntry { path: PathBuf::from("/tmp/work") },
+        );
+        let cfg = Config {
+            workspace: WorkspaceState { current: Some("personal".into()) },
+            workspaces,
+        };
+        let s = toml::to_string(&cfg).unwrap();
+        let back: Config = toml::from_str(&s).unwrap();
+        assert_eq!(back, cfg);
+    }
+
+    #[test]
+    fn missing_workspace_section_defaults() {
+        let s = "";
+        let cfg: Config = toml::from_str(s).unwrap();
+        assert!(cfg.workspace.current.is_none());
+        assert!(cfg.workspaces.is_empty());
+    }
+}
+```
+
+Add `mod config;` near the top of `crates/lw-cli/src/main.rs` (alphabetic order with other `mod` lines).
+
+- [ ] **Step 2: Run tests and verify they pass**
+
+```bash
+cargo test -p lw-cli config::tests
+```
+
+Expected: 3 passed. (Tests pass because the type defs already match — this is a structural test guarding against accidental schema changes.)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/lw-cli/src/config.rs crates/lw-cli/src/main.rs
+git commit -m "feat(lw-cli): add Config schema for ~/.llm-wiki/config.toml"
+```
+
+---
+
+## Task 3: Config load / save with home dir resolution
+
+**Files:**
+
+- Modify: `crates/lw-cli/src/config.rs`
+
+- [ ] **Step 1: Write failing tests**
+
+Append to `crates/lw-cli/src/config.rs`:
+
+```rust
+use std::fs;
+use std::io;
+use std::path::Path;
+
+/// Default location: $LW_HOME/config.toml, where LW_HOME falls back to ~/.llm-wiki/.
+pub fn config_path() -> anyhow::Result<PathBuf> {
+    if let Ok(custom) = std::env::var("LW_HOME") {
+        return Ok(PathBuf::from(custom).join("config.toml"));
+    }
+    let home = dirs::home_dir()
+        .ok_or_else(|| anyhow::anyhow!("Cannot resolve home directory"))?;
+    Ok(home.join(".llm-wiki").join("config.toml"))
+}
+
+impl Config {
+    /// Load from disk. Returns Default if file does not exist.
+    pub fn load_from(path: &Path) -> anyhow::Result<Self> {
+        match fs::read_to_string(path) {
+            Ok(s) => Ok(toml::from_str(&s)?),
+            Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(Self::default()),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    /// Atomic write: stage to .tmp sibling, fsync, rename.
+    pub fn save_to(&self, path: &Path) -> anyhow::Result<()> {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        let tmp = path.with_extension("toml.tmp");
+        let body = toml::to_string_pretty(self)?;
+        fs::write(&tmp, body)?;
+        // fsync the file so rename is durable
+        let f = fs::File::open(&tmp)?;
+        f.sync_all()?;
+        fs::rename(&tmp, path)?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod io_tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn load_returns_default_when_file_missing() {
+        let dir = TempDir::new().unwrap();
+        let cfg = Config::load_from(&dir.path().join("nope.toml")).unwrap();
+        assert_eq!(cfg, Config::default());
+    }
+
+    #[test]
+    fn save_creates_parent_dir() {
+        let dir = TempDir::new().unwrap();
+        let nested = dir.path().join("a/b/c/config.toml");
+        Config::default().save_to(&nested).unwrap();
+        assert!(nested.exists());
+    }
+
+    #[test]
+    fn save_then_load_preserves_data() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("config.toml");
+        let mut cfg = Config::default();
+        cfg.workspace.current = Some("foo".into());
+        cfg.workspaces.insert(
+            "foo".into(),
+            WorkspaceEntry { path: PathBuf::from("/tmp/foo") },
+        );
+        cfg.save_to(&path).unwrap();
+        let back = Config::load_from(&path).unwrap();
+        assert_eq!(back, cfg);
+    }
+
+    #[test]
+    fn save_is_atomic_no_tmp_left_behind() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("config.toml");
+        Config::default().save_to(&path).unwrap();
+        let entries: Vec<_> = fs::read_dir(dir.path())
+            .unwrap()
+            .map(|e| e.unwrap().file_name().to_string_lossy().to_string())
+            .collect();
+        assert_eq!(entries, vec!["config.toml".to_string()]);
+    }
+}
+```
+
+Add to `crates/lw-cli/Cargo.toml` under `[dev-dependencies]` (verify `tempfile = "3"` is already present — it is per the existing file).
+
+- [ ] **Step 2: Run tests**
+
+```bash
+cargo test -p lw-cli config::
+```
+
+Expected: 7 passed (3 schema + 4 I/O).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/lw-cli/src/config.rs
+git commit -m "feat(lw-cli): add Config::load_from / save_to with atomic write"
+```
+
+---
+
+## Task 4: Workspace add — name + path validation
+
+**Files:**
+
+- Create: `crates/lw-cli/src/workspace.rs`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `crates/lw-cli/src/workspace.rs`:
+
+```rust
+use crate::config::{Config, WorkspaceEntry, config_path};
+use std::path::{Path, PathBuf};
+
+/// Validate workspace name: lowercase alphanumeric + dashes, 1-32 chars.
+fn validate_name(name: &str) -> anyhow::Result<()> {
+    if name.is_empty() || name.len() > 32 {
+        anyhow::bail!("workspace name must be 1-32 chars (got {})", name.len());
+    }
+    if !name
+        .chars()
+        .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-')
+    {
+        anyhow::bail!(
+            "workspace name must be lowercase alphanumeric + dashes (got '{name}')"
+        );
+    }
+    Ok(())
+}
+
+/// Resolve to absolute path; canonicalize if it exists, else absolute-ize.
+fn resolve_path(path: &Path) -> anyhow::Result<PathBuf> {
+    if path.exists() {
+        Ok(path.canonicalize()?)
+    } else if path.is_absolute() {
+        Ok(path.to_path_buf())
+    } else {
+        Ok(std::env::current_dir()?.join(path))
+    }
+}
+
+pub fn add(name: &str, path: &Path, init: bool) -> anyhow::Result<()> {
+    validate_name(name)?;
+    let abs = resolve_path(path)?;
+
+    let cfg_path = config_path()?;
+    let mut cfg = Config::load_from(&cfg_path)?;
+
+    if cfg.workspaces.contains_key(name) {
+        anyhow::bail!("workspace '{name}' already exists");
+    }
+
+    if init {
+        if !abs.exists() {
+            std::fs::create_dir_all(&abs)?;
+        }
+        let is_empty = std::fs::read_dir(&abs)?.next().is_none();
+        if !is_empty && !abs.join(".lw/schema.toml").exists() {
+            anyhow::bail!(
+                "--init requires an empty directory or an existing wiki (got non-empty non-wiki at {})",
+                abs.display()
+            );
+        }
+        if !abs.join(".lw/schema.toml").exists() {
+            let schema = lw_core::schema::WikiSchema::default();
+            lw_core::fs::init_wiki(&abs, &schema)?;
+        }
+    }
+
+    let first_workspace = cfg.workspaces.is_empty();
+    cfg.workspaces.insert(name.into(), WorkspaceEntry { path: abs.clone() });
+    if first_workspace {
+        cfg.workspace.current = Some(name.into());
+    }
+    cfg.save_to(&cfg_path)?;
+
+    println!("Added workspace '{name}' at {}", abs.display());
+    if first_workspace {
+        println!("  set as current (first workspace)");
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn with_lw_home<F: FnOnce()>(home: &Path, f: F) {
+        let prev = std::env::var("LW_HOME").ok();
+        // SAFETY: tests are single-threaded for this env-var section. cargo test
+        // runs tests in parallel by default; serialize with --test-threads=1 in CI.
+        unsafe { std::env::set_var("LW_HOME", home) };
+        f();
+        match prev {
+            Some(p) => unsafe { std::env::set_var("LW_HOME", p) },
+            None => unsafe { std::env::remove_var("LW_HOME") },
+        }
+    }
+
+    #[test]
+    fn name_validation_rejects_uppercase() {
+        assert!(validate_name("Foo").is_err());
+    }
+
+    #[test]
+    fn name_validation_rejects_spaces() {
+        assert!(validate_name("foo bar").is_err());
+    }
+
+    #[test]
+    fn name_validation_rejects_empty() {
+        assert!(validate_name("").is_err());
+    }
+
+    #[test]
+    fn name_validation_accepts_dashes_and_digits() {
+        assert!(validate_name("my-vault-2").is_ok());
+    }
+
+    #[test]
+    fn add_first_workspace_sets_current() {
+        let home = TempDir::new().unwrap();
+        let vault = TempDir::new().unwrap();
+        with_lw_home(home.path(), || {
+            add("personal", vault.path(), false).unwrap();
+            let cfg = Config::load_from(&config_path().unwrap()).unwrap();
+            assert_eq!(cfg.workspace.current.as_deref(), Some("personal"));
+            assert_eq!(cfg.workspaces.len(), 1);
+        });
+    }
+
+    #[test]
+    fn add_second_workspace_does_not_change_current() {
+        let home = TempDir::new().unwrap();
+        let v1 = TempDir::new().unwrap();
+        let v2 = TempDir::new().unwrap();
+        with_lw_home(home.path(), || {
+            add("personal", v1.path(), false).unwrap();
+            add("work", v2.path(), false).unwrap();
+            let cfg = Config::load_from(&config_path().unwrap()).unwrap();
+            assert_eq!(cfg.workspace.current.as_deref(), Some("personal"));
+            assert_eq!(cfg.workspaces.len(), 2);
+        });
+    }
+
+    #[test]
+    fn add_duplicate_name_errors() {
+        let home = TempDir::new().unwrap();
+        let v = TempDir::new().unwrap();
+        with_lw_home(home.path(), || {
+            add("foo", v.path(), false).unwrap();
+            assert!(add("foo", v.path(), false).is_err());
+        });
+    }
+
+    #[test]
+    fn add_with_init_creates_wiki_in_empty_dir() {
+        let home = TempDir::new().unwrap();
+        let vault = TempDir::new().unwrap();
+        with_lw_home(home.path(), || {
+            add("foo", vault.path(), true).unwrap();
+            assert!(vault.path().join(".lw/schema.toml").exists());
+        });
+    }
+
+    #[test]
+    fn add_with_init_rejects_nonempty_non_wiki() {
+        let home = TempDir::new().unwrap();
+        let vault = TempDir::new().unwrap();
+        std::fs::write(vault.path().join("stranger.txt"), "hi").unwrap();
+        with_lw_home(home.path(), || {
+            assert!(add("foo", vault.path(), true).is_err());
+        });
+    }
+}
+```
+
+Add `mod workspace;` to `crates/lw-cli/src/main.rs` (alphabetic order).
+
+- [ ] **Step 2: Run tests**
+
+```bash
+cargo test -p lw-cli workspace::tests -- --test-threads=1
+```
+
+Expected: 8 passed. `--test-threads=1` is required because tests mutate `LW_HOME` env var.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/lw-cli/src/workspace.rs crates/lw-cli/src/main.rs
+git commit -m "feat(lw-cli): add workspace::add with name/path validation and --init"
+```
+
+---
+
+## Task 5: Workspace list / current / use\_ / remove
+
+**Files:**
+
+- Modify: `crates/lw-cli/src/workspace.rs`
+
+- [ ] **Step 1: Write failing tests + impls**
+
+Append to `crates/lw-cli/src/workspace.rs`:
+
+```rust
+pub fn list() -> anyhow::Result<()> {
+    let cfg = Config::load_from(&config_path()?)?;
+    if cfg.workspaces.is_empty() {
+        println!("(no workspaces registered — use `lw workspace add` to create one)");
+        return Ok(());
+    }
+    let current = cfg.workspace.current.as_deref();
+    for (name, entry) in &cfg.workspaces {
+        let marker = if Some(name.as_str()) == current { "*" } else { " " };
+        println!("{marker} {name:20} {}", entry.path.display());
+    }
+    Ok(())
+}
+
+pub fn current(verbose: bool) -> anyhow::Result<()> {
+    let cfg = Config::load_from(&config_path()?)?;
+    let cur = cfg.workspace.current.as_deref();
+    match cur {
+        Some(name) => match cfg.workspaces.get(name) {
+            Some(entry) => {
+                println!("{name}\t{}", entry.path.display());
+            }
+            None => {
+                anyhow::bail!(
+                    "current workspace '{name}' is registered but missing from workspaces table — config corrupt"
+                );
+            }
+        },
+        None => println!("(no current workspace)"),
+    }
+    if verbose {
+        println!();
+        println!("Resolution chain (--root > LW_WIKI_ROOT env > current workspace > cwd):");
+        println!(
+            "  --root flag:        {}",
+            "(only available at command time)"
+        );
+        println!(
+            "  LW_WIKI_ROOT env:   {}",
+            std::env::var("LW_WIKI_ROOT").unwrap_or_else(|_| "(unset)".into())
+        );
+        println!(
+            "  current workspace:  {}",
+            cur.map(|n| {
+                cfg.workspaces
+                    .get(n)
+                    .map(|e| e.path.display().to_string())
+                    .unwrap_or_else(|| "(missing entry)".into())
+            })
+            .unwrap_or_else(|| "(unset)".into())
+        );
+        println!(
+            "  cwd auto-discover:  {}",
+            std::env::current_dir()
+                .ok()
+                .and_then(|p| lw_core::fs::discover_wiki_root(&p))
+                .map(|p| p.display().to_string())
+                .unwrap_or_else(|| "(no wiki ancestor)".into())
+        );
+    }
+    Ok(())
+}
+
+pub fn use_(name: &str) -> anyhow::Result<()> {
+    let cfg_path = config_path()?;
+    let mut cfg = Config::load_from(&cfg_path)?;
+    if !cfg.workspaces.contains_key(name) {
+        anyhow::bail!(
+            "workspace '{name}' not found (use `lw workspace list` to see registered)"
+        );
+    }
+    cfg.workspace.current = Some(name.into());
+    cfg.save_to(&cfg_path)?;
+    println!("Current workspace set to '{name}'");
+    println!(
+        "Note: any running `lw serve` MCP processes still point at the previous vault. Restart your agent tool to pick up."
+    );
+    Ok(())
+}
+
+pub fn remove(name: &str) -> anyhow::Result<()> {
+    let cfg_path = config_path()?;
+    let mut cfg = Config::load_from(&cfg_path)?;
+    if cfg.workspaces.remove(name).is_none() {
+        anyhow::bail!("workspace '{name}' not found");
+    }
+    if cfg.workspace.current.as_deref() == Some(name) {
+        cfg.workspace.current = None;
+    }
+    cfg.save_to(&cfg_path)?;
+    println!("Removed workspace '{name}' from registry (vault directory untouched)");
+    Ok(())
+}
+
+#[cfg(test)]
+mod crud_tests {
+    use super::*;
+    use super::tests::with_lw_home;
+    use tempfile::TempDir;
+
+    #[test]
+    fn use_unknown_errors() {
+        let home = TempDir::new().unwrap();
+        with_lw_home(home.path(), || {
+            assert!(use_("ghost").is_err());
+        });
+    }
+
+    #[test]
+    fn use_sets_current() {
+        let home = TempDir::new().unwrap();
+        let v = TempDir::new().unwrap();
+        with_lw_home(home.path(), || {
+            add("a", v.path(), false).unwrap();
+            add("b", v.path(), false).unwrap();
+            use_("b").unwrap();
+            let cfg = Config::load_from(&config_path().unwrap()).unwrap();
+            assert_eq!(cfg.workspace.current.as_deref(), Some("b"));
+        });
+    }
+
+    #[test]
+    fn remove_clears_current_if_was_current() {
+        let home = TempDir::new().unwrap();
+        let v = TempDir::new().unwrap();
+        with_lw_home(home.path(), || {
+            add("a", v.path(), false).unwrap();
+            remove("a").unwrap();
+            let cfg = Config::load_from(&config_path().unwrap()).unwrap();
+            assert!(cfg.workspace.current.is_none());
+            assert!(cfg.workspaces.is_empty());
+        });
+    }
+
+    #[test]
+    fn remove_unknown_errors() {
+        let home = TempDir::new().unwrap();
+        with_lw_home(home.path(), || {
+            assert!(remove("ghost").is_err());
+        });
+    }
+}
+```
+
+In `crates/lw-cli/src/workspace.rs`, change `mod tests` to `pub(super) mod tests` so `crud_tests` can reuse `with_lw_home`. Then change `fn with_lw_home` to `pub(super) fn with_lw_home` inside that module.
+
+- [ ] **Step 2: Run tests**
+
+```bash
+cargo test -p lw-cli workspace -- --test-threads=1
+```
+
+Expected: 12 passed (8 from Task 4 + 4 new).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/lw-cli/src/workspace.rs
+git commit -m "feat(lw-cli): add workspace list/current/use/remove subcommands"
+```
+
+---
+
+## Task 6: Upgrade `resolve_root` to 4-layer priority
+
+**Files:**
+
+- Modify: `crates/lw-cli/src/main.rs`
+
+- [ ] **Step 1: Replace `resolve_root` body**
+
+In `crates/lw-cli/src/main.rs`, find the existing `fn resolve_root(...)` and replace with:
+
+```rust
+fn resolve_root(cli_root: Option<PathBuf>) -> Result<PathBuf, String> {
+    // Priority: --root flag > LW_WIKI_ROOT env (already merged into cli_root by clap) > current workspace > cwd
+    if let Some(root) = cli_root {
+        return Ok(root);
+    }
+    // Try current workspace from ~/.llm-wiki/config.toml
+    if let Ok(cfg_path) = config::config_path()
+        && let Ok(cfg) = config::Config::load_from(&cfg_path)
+        && let Some(name) = &cfg.workspace.current
+        && let Some(entry) = cfg.workspaces.get(name)
+        && entry.path.exists()
+    {
+        return Ok(entry.path.clone());
+    }
+    // Final fallback: cwd auto-discover
+    let cwd = std::env::current_dir().map_err(|e| format!("Cannot get cwd: {e}"))?;
+    lw_core::fs::discover_wiki_root(&cwd).ok_or_else(|| {
+        format!(
+            "Not a wiki directory (or any parent): {}\n  Run: lw init --root <path>\n  Or: lw workspace add <name> <path> --init\n  Or set LW_WIKI_ROOT environment variable",
+            cwd.display()
+        )
+    })
+}
+```
+
+Note: clap's `#[arg(env = "LW_WIKI_ROOT")]` on the `--root` flag already folds the env var into `cli_root`, so we don't need a separate env check.
+
+- [ ] **Step 2: Verify existing tests still pass**
+
+```bash
+cargo test -p lw-cli
+```
+
+Expected: all existing tests pass; `resolve_root` is exercised by integration tests for query/lint/etc., which all use explicit `--root` so they're unaffected.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/lw-cli/src/main.rs
+git commit -m "feat(lw-cli): resolve_root falls back to current workspace before cwd"
+```
+
+---
+
+## Task 7: Wire Workspace subcommand into CLI
+
+**Files:**
+
+- Modify: `crates/lw-cli/src/main.rs`
+
+- [ ] **Step 1: Add subcommand variant**
+
+In `crates/lw-cli/src/main.rs`, inside `enum Commands`, add (preserve existing variants):
+
+```rust
+    /// Manage registered wiki workspaces (Obsidian-style vaults)
+    #[command(after_help = "Examples:\n  lw workspace add personal ~/Documents/MyWiki --init\n  lw workspace list\n  lw workspace use work\n  lw workspace current -v\n  lw workspace remove old-vault")]
+    Workspace {
+        #[command(subcommand)]
+        action: WorkspaceCmd,
+    },
+```
+
+After `enum Commands { ... }`, add:
+
+```rust
+#[derive(clap::Subcommand)]
+enum WorkspaceCmd {
+    /// Register a new workspace
+    Add {
+        /// Workspace name (lowercase alphanumeric + dashes)
+        name: String,
+        /// Path to the vault directory
+        path: PathBuf,
+        /// Initialize an empty wiki at the path if it does not exist
+        #[arg(long)]
+        init: bool,
+    },
+    /// List all registered workspaces
+    List,
+    /// Print the current workspace name and path
+    Current {
+        /// Show the full root resolution chain for debugging
+        #[arg(short, long)]
+        verbose: bool,
+    },
+    /// Set the current workspace
+    #[command(name = "use")]
+    UseCmd {
+        /// Name of the workspace to switch to
+        name: String,
+    },
+    /// Remove a workspace from the registry (does not touch the directory)
+    Remove {
+        /// Name of the workspace to unregister
+        name: String,
+    },
+}
+```
+
+In `fn main()`, inside the `match cli.command { ... }`, add (before the closing brace):
+
+```rust
+        Commands::Workspace { action } => match action {
+            WorkspaceCmd::Add { name, path, init } => workspace::add(&name, &path, init),
+            WorkspaceCmd::List => workspace::list(),
+            WorkspaceCmd::Current { verbose } => workspace::current(verbose),
+            WorkspaceCmd::UseCmd { name } => workspace::use_(&name),
+            WorkspaceCmd::Remove { name } => workspace::remove(&name),
+        },
+```
+
+- [ ] **Step 2: Build and run --help to confirm wiring**
+
+```bash
+cargo build -p lw-cli
+./target/debug/lw workspace --help
+```
+
+Expected output includes:
+
+```
+Manage registered wiki workspaces (Obsidian-style vaults)
+
+Usage: lw workspace <COMMAND>
+
+Commands:
+  add      Register a new workspace
+  list     List all registered workspaces
+  current  Print the current workspace name and path
+  use      Set the current workspace
+  remove   Remove a workspace from the registry (does not touch the directory)
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/lw-cli/src/main.rs
+git commit -m "feat(lw-cli): wire workspace subcommand into CLI"
+```
+
+---
+
+## Task 8: End-to-end integration test
+
+**Files:**
+
+- Create: `crates/lw-cli/tests/workspace_cli.rs`
+
+- [ ] **Step 1: Write failing test**
+
+Create `crates/lw-cli/tests/workspace_cli.rs`:
+
+```rust
+use assert_cmd::Command;
+use predicates::prelude::*;
+use tempfile::TempDir;
+
+fn lw(home: &std::path::Path) -> Command {
+    let mut cmd = Command::cargo_bin("lw").unwrap();
+    cmd.env("LW_HOME", home);
+    // Clear LW_WIKI_ROOT to keep tests deterministic
+    cmd.env_remove("LW_WIKI_ROOT");
+    cmd
+}
+
+#[test]
+fn full_workspace_lifecycle() {
+    let home = TempDir::new().unwrap();
+    let vault_a = TempDir::new().unwrap();
+    let vault_b = TempDir::new().unwrap();
+
+    // Add first workspace, init the wiki structure
+    lw(home.path())
+        .args(["workspace", "add", "alpha", vault_a.path().to_str().unwrap(), "--init"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Added workspace 'alpha'"))
+        .stdout(predicate::str::contains("set as current"));
+
+    assert!(vault_a.path().join(".lw/schema.toml").exists());
+
+    // Add second
+    lw(home.path())
+        .args(["workspace", "add", "beta", vault_b.path().to_str().unwrap(), "--init"])
+        .assert()
+        .success();
+
+    // List shows both, alpha marked current
+    lw(home.path())
+        .args(["workspace", "list"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("* alpha"))
+        .stdout(predicate::str::contains("  beta"));
+
+    // Current prints alpha
+    lw(home.path())
+        .args(["workspace", "current"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("alpha"));
+
+    // Switch to beta
+    lw(home.path())
+        .args(["workspace", "use", "beta"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Current workspace set to 'beta'"))
+        .stdout(predicate::str::contains("Restart your agent"));
+
+    // Verbose current shows resolution chain
+    lw(home.path())
+        .args(["workspace", "current", "-v"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Resolution chain"))
+        .stdout(predicate::str::contains("LW_WIKI_ROOT env"))
+        .stdout(predicate::str::contains("current workspace"));
+
+    // Remove beta clears current
+    lw(home.path())
+        .args(["workspace", "remove", "beta"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Removed workspace 'beta'"));
+
+    lw(home.path())
+        .args(["workspace", "current"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("(no current workspace)"));
+
+    // Vault directories must remain on disk
+    assert!(vault_a.path().exists());
+    assert!(vault_b.path().exists());
+}
+
+#[test]
+fn duplicate_add_fails() {
+    let home = TempDir::new().unwrap();
+    let vault = TempDir::new().unwrap();
+    lw(home.path())
+        .args(["workspace", "add", "x", vault.path().to_str().unwrap()])
+        .assert()
+        .success();
+    lw(home.path())
+        .args(["workspace", "add", "x", vault.path().to_str().unwrap()])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("already exists"));
+}
+
+#[test]
+fn invalid_name_fails() {
+    let home = TempDir::new().unwrap();
+    let vault = TempDir::new().unwrap();
+    lw(home.path())
+        .args(["workspace", "add", "BadName", vault.path().to_str().unwrap()])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("lowercase"));
+}
+
+#[test]
+fn list_empty_message() {
+    let home = TempDir::new().unwrap();
+    lw(home.path())
+        .args(["workspace", "list"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("no workspaces registered"));
+}
+```
+
+- [ ] **Step 2: Run integration tests**
+
+```bash
+cargo test -p lw-cli --test workspace_cli -- --test-threads=1
+```
+
+Expected: 4 passed.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/lw-cli/tests/workspace_cli.rs
+git commit -m "test(lw-cli): end-to-end integration tests for workspace commands"
+```
+
+---
+
+## Task 9: Final verification
+
+**Files:** None (verification only)
+
+- [ ] **Step 1: Full test suite**
+
+```bash
+cargo test --workspace -- --test-threads=1
+```
+
+Expected: all green.
+
+- [ ] **Step 2: Clippy**
+
+```bash
+cargo clippy --workspace --all-targets -- -D warnings
+```
+
+Expected: clean.
+
+- [ ] **Step 3: Format check**
+
+```bash
+cargo fmt --all -- --check
+```
+
+Expected: clean.
+
+- [ ] **Step 4: Manual smoke test**
+
+```bash
+LW_HOME=/tmp/lw-test ./target/debug/lw workspace add demo /tmp/demo-vault --init
+LW_HOME=/tmp/lw-test ./target/debug/lw workspace list
+LW_HOME=/tmp/lw-test ./target/debug/lw workspace current -v
+rm -rf /tmp/lw-test /tmp/demo-vault
+```
+
+Expected: all commands succeed; `current -v` prints resolution chain with `current workspace: /tmp/demo-vault`.
+
+- [ ] **Step 5: Commit verification artifacts (if any)**
+
+If clippy or fmt made changes during the session, commit them:
+
+```bash
+git status
+# If clean, no commit needed.
+```
+
+---
+
+## Done criteria
+
+- `lw workspace {add,list,current,use,remove}` all functional
+- `~/.llm-wiki/config.toml` (or `$LW_HOME/config.toml`) reads/writes atomically
+- `resolve_root` falls back to current workspace before cwd
+- `lw workspace current -v` shows full resolution chain
+- All tests green, clippy clean, fmt clean
+- Single-vault users with no registration see no behavior change (cwd auto-discover still works)

--- a/docs/plans/2026-04-20-wrapper-plan-b-skills-integrations.md
+++ b/docs/plans/2026-04-20-wrapper-plan-b-skills-integrations.md
@@ -1,0 +1,1868 @@
+# Plan B — Skills, Templates, Integrations Engine Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship the canonical `llm-wiki:import` skill, three starter vault templates (`general` / `research-papers` / `engineering-notes`), the TOML-driven integration adapter engine, and `lw integrate` command. Wire Claude Code as the first integration target with safe MCP config merging (atomic write + backup + version marker + diff-prompt on user-edited entries).
+
+**Architecture:** Templates and skills are static asset trees in the repo, embedded into release tarballs by Plan C. The integrations engine is a small Rust subsystem in `lw-cli` that loads `*.toml` descriptors at runtime, knows how to read/merge per-tool config files (JSON or TOML), and manages skills as symlinks (copy-mode fallback for filesystems without symlink support). One adapter trait + descriptor loader covers the 90% case; per-tool logic only when truly needed.
+
+**Tech Stack:** Rust 2024, `serde_json` (already in deps) for JSON merge, `toml` for descriptors, `dirs` for path resolution. Skills are markdown + YAML frontmatter.
+
+**Working dir:** `tool/llm-wiki/`. Depends on Plan A (workspace registry must exist).
+
+**Spec reference:** `docs/superpowers/specs/2026-04-19-llm-wiki-product-wrapper-design.md` §6, §9, §10, §10.5.
+
+---
+
+## File structure
+
+| File                                                                                                 | Status | Responsibility                  |
+| ---------------------------------------------------------------------------------------------------- | ------ | ------------------------------- |
+| `templates/general/{.lw/schema.toml,SCOPE.md,wiki/_uncategorized/welcome.md,raw/.gitkeep}`           | create | Generic starter vault           |
+| `templates/research-papers/{.lw/schema.toml,SCOPE.md,wiki/_uncategorized/welcome.md,raw/.gitkeep}`   | create | Paper-curation starter          |
+| `templates/engineering-notes/{.lw/schema.toml,SCOPE.md,wiki/_uncategorized/welcome.md,raw/.gitkeep}` | create | Eng-notes starter               |
+| `skills/llm-wiki-import/SKILL.md`                                                                    | create | Canonical import skill prompt   |
+| `integrations/claude-code.toml`                                                                      | create | Claude Code adapter descriptor  |
+| `crates/lw-cli/src/templates.rs`                                                                     | create | Locate templates dir, copy tree |
+| `crates/lw-cli/src/workspace.rs`                                                                     | modify | Add `--template` to `add`       |
+| `crates/lw-cli/src/integrations/mod.rs`                                                              | create | Module aggregator               |
+| `crates/lw-cli/src/integrations/descriptor.rs`                                                       | create | `Descriptor` types + loader     |
+| `crates/lw-cli/src/integrations/mcp.rs`                                                              | create | JSON config atomic merge        |
+| `crates/lw-cli/src/integrations/skills.rs`                                                           | create | Symlink / copy management       |
+| `crates/lw-cli/src/integrate.rs`                                                                     | create | `lw integrate` command body     |
+| `crates/lw-cli/src/main.rs`                                                                          | modify | Wire `Integrate` + `--template` |
+| `crates/lw-cli/tests/integrate_cli.rs`                                                               | create | E2E with fake config dirs       |
+
+Asset directories (`templates/`, `skills/`, `integrations/`) live at the **repo root**, not inside `crates/`. They are copied into release tarballs by Plan C.
+
+---
+
+## Task 1: Create three starter template trees
+
+**Files:**
+
+- Create: `templates/general/.lw/schema.toml`
+- Create: `templates/general/SCOPE.md`
+- Create: `templates/general/wiki/_uncategorized/welcome.md`
+- Create: `templates/general/raw/.gitkeep`
+- Create: `templates/research-papers/.lw/schema.toml`
+- Create: `templates/research-papers/SCOPE.md`
+- Create: `templates/research-papers/wiki/_uncategorized/welcome.md`
+- Create: `templates/research-papers/raw/.gitkeep`
+- Create: `templates/engineering-notes/.lw/schema.toml`
+- Create: `templates/engineering-notes/SCOPE.md`
+- Create: `templates/engineering-notes/wiki/_uncategorized/welcome.md`
+- Create: `templates/engineering-notes/raw/.gitkeep`
+
+- [ ] **Step 1: Create general template**
+
+`templates/general/.lw/schema.toml`:
+
+```toml
+[tags]
+categories = ["notes", "links", "people", "_uncategorized"]
+```
+
+`templates/general/SCOPE.md`:
+
+```markdown
+# Scope
+
+## Purpose
+
+A general-purpose knowledge base. Capture interesting links, articles, notes, and references that you want to come back to later.
+
+## Includes
+
+- Articles and blog posts you found valuable
+- Notes from books, talks, podcasts
+- Links worth saving with context for why
+- People and organizations worth tracking
+
+## Excludes
+
+- Private credentials, API keys, secrets
+- Daily journal entries (use a separate journal tool)
+- Code snippets that belong in a real codebase
+```
+
+`templates/general/wiki/_uncategorized/welcome.md`:
+
+```markdown
+---
+title: Welcome
+tags: [meta]
+---
+
+# Welcome to your wiki
+
+This is a starter page. Edit or delete it.
+
+To add content, ask your agent: _"add this link to my wiki"_ with a URL or paste the text directly. The `llm-wiki:import` skill will handle fetching, scope-checking, and filing.
+
+To customize what gets accepted, edit `SCOPE.md` at the vault root.
+```
+
+`templates/general/raw/.gitkeep`: empty file.
+
+- [ ] **Step 2: Create research-papers template**
+
+`templates/research-papers/.lw/schema.toml`:
+
+```toml
+[tags]
+categories = ["architecture", "training", "evaluation", "applications", "_uncategorized"]
+```
+
+`templates/research-papers/SCOPE.md`:
+
+```markdown
+# Scope
+
+## Purpose
+
+A curated collection of machine learning research papers, with summaries, key takeaways, and cross-references.
+
+## Includes
+
+- arXiv papers and their summaries
+- Conference / workshop publications
+- Survey papers and benchmark studies
+- Reference works on ML architecture, training methods, evaluation
+
+## Excludes
+
+- News articles about papers (link in the paper page if relevant)
+- Marketing posts and product announcements
+- Twitter threads (capture the underlying paper instead)
+```
+
+`templates/research-papers/wiki/_uncategorized/welcome.md`:
+
+```markdown
+---
+title: Welcome
+tags: [meta]
+---
+
+# Research Papers
+
+Drop arXiv URLs into your agent and ask it to import. The `llm-wiki:import` skill will fetch, summarize, and file under the right category (architecture / training / evaluation / applications).
+
+Categories are configured in `.lw/schema.toml`. Edit them to match your research focus.
+```
+
+`templates/research-papers/raw/.gitkeep`: empty.
+
+- [ ] **Step 3: Create engineering-notes template**
+
+`templates/engineering-notes/.lw/schema.toml`:
+
+```toml
+[tags]
+categories = ["systems", "tools", "patterns", "incidents", "_uncategorized"]
+```
+
+`templates/engineering-notes/SCOPE.md`:
+
+```markdown
+# Scope
+
+## Purpose
+
+A working engineer's reference: tools you use, systems you've debugged, patterns you've found useful, incidents you've learned from.
+
+## Includes
+
+- Tool docs and gotchas (CLIs, libraries, infra)
+- Architecture write-ups for systems you maintain or depend on
+- Reusable patterns: code, config, debugging methodology
+- Incident postmortems (yours or notable public ones)
+
+## Excludes
+
+- Production credentials or sensitive infra details
+- Code that should be in a repo with version control
+- Personal task lists (use an issue tracker)
+```
+
+`templates/engineering-notes/wiki/_uncategorized/welcome.md`:
+
+```markdown
+---
+title: Welcome
+tags: [meta]
+---
+
+# Engineering Notes
+
+Working engineer's reference. Categories: systems, tools, patterns, incidents.
+
+Customize categories in `.lw/schema.toml`. Adjust `SCOPE.md` to reflect what you actually want to capture.
+```
+
+`templates/engineering-notes/raw/.gitkeep`: empty.
+
+- [ ] **Step 4: Verify tree**
+
+```bash
+find templates -type f | sort
+```
+
+Expected:
+
+```
+templates/engineering-notes/.lw/schema.toml
+templates/engineering-notes/SCOPE.md
+templates/engineering-notes/raw/.gitkeep
+templates/engineering-notes/wiki/_uncategorized/welcome.md
+templates/general/.lw/schema.toml
+templates/general/SCOPE.md
+templates/general/raw/.gitkeep
+templates/general/wiki/_uncategorized/welcome.md
+templates/research-papers/.lw/schema.toml
+templates/research-papers/SCOPE.md
+templates/research-papers/raw/.gitkeep
+templates/research-papers/wiki/_uncategorized/welcome.md
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add templates/
+git commit -m "feat(templates): add general/research-papers/engineering-notes starter vaults"
+```
+
+---
+
+## Task 2: Templates discovery + copy + `--template` flag on `workspace add`
+
+**Files:**
+
+- Create: `crates/lw-cli/src/templates.rs`
+- Modify: `crates/lw-cli/src/workspace.rs`
+- Modify: `crates/lw-cli/src/main.rs`
+
+- [ ] **Step 1: Write tests**
+
+Create `crates/lw-cli/src/templates.rs`:
+
+```rust
+use std::path::{Path, PathBuf};
+
+/// Resolution order for the templates root:
+/// 1. $LW_TEMPLATES_DIR (explicit override, mostly for tests)
+/// 2. $LW_HOME/templates/ (set by installer)
+/// 3. ~/.llm-wiki/templates/ (default install location)
+/// 4. <exe_dir>/../share/llm-wiki/templates/ (cargo-installed layout)
+/// 5. <repo>/templates/ (development checkout — exe at target/debug/lw)
+pub fn templates_root() -> anyhow::Result<PathBuf> {
+    if let Ok(p) = std::env::var("LW_TEMPLATES_DIR") {
+        return Ok(PathBuf::from(p));
+    }
+    if let Ok(home) = std::env::var("LW_HOME") {
+        return Ok(PathBuf::from(home).join("templates"));
+    }
+    if let Some(home) = dirs::home_dir() {
+        let p = home.join(".llm-wiki").join("templates");
+        if p.exists() {
+            return Ok(p);
+        }
+    }
+    let exe = std::env::current_exe()?;
+    if let Some(exe_dir) = exe.parent() {
+        let share = exe_dir.join("../share/llm-wiki/templates");
+        if share.exists() {
+            return Ok(share);
+        }
+        // Dev fallback: walk up looking for templates/
+        let mut cur = exe_dir.to_path_buf();
+        for _ in 0..6 {
+            let candidate = cur.join("templates");
+            if candidate.exists() {
+                return Ok(candidate);
+            }
+            if !cur.pop() {
+                break;
+            }
+        }
+    }
+    anyhow::bail!("Cannot locate templates directory")
+}
+
+pub fn list_available() -> anyhow::Result<Vec<String>> {
+    let root = templates_root()?;
+    let mut out = Vec::new();
+    for entry in std::fs::read_dir(&root)? {
+        let entry = entry?;
+        if entry.file_type()?.is_dir() {
+            if let Some(name) = entry.file_name().to_str() {
+                out.push(name.to_string());
+            }
+        }
+    }
+    out.sort();
+    Ok(out)
+}
+
+/// Copy a template tree into `dest`. Dest must be empty or non-existent.
+/// Skips `.gitkeep` placeholder files (they only exist to ship empty dirs).
+pub fn copy_template(template_name: &str, dest: &Path) -> anyhow::Result<()> {
+    let root = templates_root()?;
+    let src = root.join(template_name);
+    if !src.exists() {
+        let avail = list_available().unwrap_or_default().join(", ");
+        anyhow::bail!(
+            "template '{template_name}' not found in {} (available: {avail})",
+            root.display()
+        );
+    }
+    if dest.exists() && std::fs::read_dir(dest)?.next().is_some() {
+        anyhow::bail!("destination {} is not empty", dest.display());
+    }
+    std::fs::create_dir_all(dest)?;
+    copy_recursive(&src, dest)
+}
+
+fn copy_recursive(src: &Path, dst: &Path) -> anyhow::Result<()> {
+    for entry in std::fs::read_dir(src)? {
+        let entry = entry?;
+        let from = entry.path();
+        let name = entry.file_name();
+        if name == ".gitkeep" {
+            // Materialize the parent directory but don't copy the placeholder
+            std::fs::create_dir_all(dst)?;
+            continue;
+        }
+        let to = dst.join(&name);
+        if entry.file_type()?.is_dir() {
+            std::fs::create_dir_all(&to)?;
+            copy_recursive(&from, &to)?;
+        } else {
+            std::fs::copy(&from, &to)?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn make_fake_templates(dir: &Path) {
+        let t = dir.join("templates").join("demo");
+        std::fs::create_dir_all(t.join(".lw")).unwrap();
+        std::fs::create_dir_all(t.join("wiki/_uncategorized")).unwrap();
+        std::fs::write(t.join(".lw/schema.toml"), "[tags]\ncategories = [\"_uncategorized\"]\n").unwrap();
+        std::fs::write(t.join("SCOPE.md"), "# Scope\n").unwrap();
+        std::fs::write(t.join("wiki/_uncategorized/welcome.md"), "# Hi\n").unwrap();
+        std::fs::write(t.join(".gitkeep"), "").unwrap();
+        std::fs::create_dir_all(t.join("raw")).unwrap();
+        std::fs::write(t.join("raw/.gitkeep"), "").unwrap();
+    }
+
+    #[test]
+    fn list_available_finds_dirs() {
+        let dir = TempDir::new().unwrap();
+        make_fake_templates(dir.path());
+        // SAFETY: tests serialized via --test-threads=1
+        unsafe { std::env::set_var("LW_TEMPLATES_DIR", dir.path().join("templates")) };
+        let avail = list_available().unwrap();
+        assert_eq!(avail, vec!["demo".to_string()]);
+        unsafe { std::env::remove_var("LW_TEMPLATES_DIR") };
+    }
+
+    #[test]
+    fn copy_template_writes_tree() {
+        let templates_dir = TempDir::new().unwrap();
+        make_fake_templates(templates_dir.path());
+        let dest = TempDir::new().unwrap();
+        unsafe { std::env::set_var("LW_TEMPLATES_DIR", templates_dir.path().join("templates")) };
+        copy_template("demo", &dest.path().join("vault")).unwrap();
+        unsafe { std::env::remove_var("LW_TEMPLATES_DIR") };
+
+        assert!(dest.path().join("vault/.lw/schema.toml").exists());
+        assert!(dest.path().join("vault/SCOPE.md").exists());
+        assert!(dest.path().join("vault/wiki/_uncategorized/welcome.md").exists());
+        assert!(dest.path().join("vault/raw").exists());
+        // .gitkeep must NOT be copied
+        assert!(!dest.path().join("vault/raw/.gitkeep").exists());
+        assert!(!dest.path().join("vault/.gitkeep").exists());
+    }
+
+    #[test]
+    fn copy_template_unknown_errors() {
+        let templates_dir = TempDir::new().unwrap();
+        make_fake_templates(templates_dir.path());
+        let dest = TempDir::new().unwrap();
+        unsafe { std::env::set_var("LW_TEMPLATES_DIR", templates_dir.path().join("templates")) };
+        let result = copy_template("ghost", &dest.path().join("vault"));
+        unsafe { std::env::remove_var("LW_TEMPLATES_DIR") };
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn copy_template_rejects_nonempty_dest() {
+        let templates_dir = TempDir::new().unwrap();
+        make_fake_templates(templates_dir.path());
+        let dest = TempDir::new().unwrap();
+        let vault = dest.path().join("vault");
+        std::fs::create_dir(&vault).unwrap();
+        std::fs::write(vault.join("stranger.txt"), "hi").unwrap();
+        unsafe { std::env::set_var("LW_TEMPLATES_DIR", templates_dir.path().join("templates")) };
+        let result = copy_template("demo", &vault);
+        unsafe { std::env::remove_var("LW_TEMPLATES_DIR") };
+        assert!(result.is_err());
+    }
+}
+```
+
+Add `mod templates;` to `crates/lw-cli/src/main.rs`.
+
+- [ ] **Step 2: Update workspace::add to support --template**
+
+In `crates/lw-cli/src/workspace.rs`, change the signature and body of `add`:
+
+```rust
+pub fn add(name: &str, path: &Path, init: bool, template: Option<&str>) -> anyhow::Result<()> {
+    validate_name(name)?;
+    let abs = resolve_path(path)?;
+
+    let cfg_path = config_path()?;
+    let mut cfg = Config::load_from(&cfg_path)?;
+
+    if cfg.workspaces.contains_key(name) {
+        anyhow::bail!("workspace '{name}' already exists");
+    }
+
+    if init && template.is_some() {
+        anyhow::bail!("--init and --template are mutually exclusive");
+    }
+
+    if let Some(tpl) = template {
+        if abs.exists() && std::fs::read_dir(&abs)?.next().is_some() {
+            anyhow::bail!("--template requires an empty or non-existent directory");
+        }
+        crate::templates::copy_template(tpl, &abs)?;
+    } else if init {
+        if !abs.exists() {
+            std::fs::create_dir_all(&abs)?;
+        }
+        let is_empty = std::fs::read_dir(&abs)?.next().is_none();
+        if !is_empty && !abs.join(".lw/schema.toml").exists() {
+            anyhow::bail!(
+                "--init requires an empty directory or an existing wiki (got non-empty non-wiki at {})",
+                abs.display()
+            );
+        }
+        if !abs.join(".lw/schema.toml").exists() {
+            let schema = lw_core::schema::WikiSchema::default();
+            lw_core::fs::init_wiki(&abs, &schema)?;
+        }
+    }
+
+    let first_workspace = cfg.workspaces.is_empty();
+    cfg.workspaces.insert(name.into(), WorkspaceEntry { path: abs.clone() });
+    if first_workspace {
+        cfg.workspace.current = Some(name.into());
+    }
+    cfg.save_to(&cfg_path)?;
+
+    println!("Added workspace '{name}' at {}", abs.display());
+    if let Some(tpl) = template {
+        println!("  initialized from template '{tpl}'");
+    }
+    if first_workspace {
+        println!("  set as current (first workspace)");
+    }
+    Ok(())
+}
+```
+
+In the existing `tests` mod inside `workspace.rs`, update each call to `add(...)` from 3 args to 4 (pass `None` for template):
+
+```rust
+add("personal", vault.path(), false, None).unwrap();
+// ... and so on for all existing test sites
+```
+
+Add a new test at the bottom of the `tests` module:
+
+```rust
+    #[test]
+    fn add_with_template_copies_tree() {
+        use std::path::Path;
+        let home = TempDir::new().unwrap();
+        let templates_dir = TempDir::new().unwrap();
+        // Stub templates
+        let demo = templates_dir.path().join("templates").join("demo");
+        std::fs::create_dir_all(demo.join(".lw")).unwrap();
+        std::fs::create_dir_all(demo.join("wiki/_uncategorized")).unwrap();
+        std::fs::write(demo.join(".lw/schema.toml"), "[tags]\ncategories = [\"_uncategorized\"]\n").unwrap();
+        std::fs::write(demo.join("SCOPE.md"), "# Scope\n").unwrap();
+        std::fs::write(demo.join("wiki/_uncategorized/welcome.md"), "# Hi\n").unwrap();
+
+        let vault = TempDir::new().unwrap();
+        let target: &Path = &vault.path().join("v");
+        with_lw_home(home.path(), || {
+            unsafe { std::env::set_var("LW_TEMPLATES_DIR", templates_dir.path().join("templates")) };
+            add("foo", target, false, Some("demo")).unwrap();
+            unsafe { std::env::remove_var("LW_TEMPLATES_DIR") };
+            assert!(target.join("SCOPE.md").exists());
+            assert!(target.join(".lw/schema.toml").exists());
+        });
+    }
+```
+
+In `crud_tests` and `workspace_cli.rs` integration tests from Plan A, update to 4-arg `add` calls. (Plan A's integration tests use the CLI, not direct calls, so they only need updating if CLI changes — see Step 3.)
+
+- [ ] **Step 3: Wire `--template` into the CLI**
+
+In `crates/lw-cli/src/main.rs`, change the `WorkspaceCmd::Add` variant:
+
+```rust
+    /// Register a new workspace
+    Add {
+        /// Workspace name (lowercase alphanumeric + dashes)
+        name: String,
+        /// Path to the vault directory
+        path: PathBuf,
+        /// Initialize an empty wiki at the path if it does not exist
+        #[arg(long)]
+        init: bool,
+        /// Initialize from a starter template (general | research-papers | engineering-notes)
+        #[arg(long)]
+        template: Option<String>,
+    },
+```
+
+Update the dispatch:
+
+```rust
+            WorkspaceCmd::Add { name, path, init, template } => {
+                workspace::add(&name, &path, init, template.as_deref())
+            }
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+cargo test -p lw-cli -- --test-threads=1
+```
+
+Expected: all green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/lw-cli/src/templates.rs crates/lw-cli/src/workspace.rs crates/lw-cli/src/main.rs
+git commit -m "feat(lw-cli): add templates module and --template flag on workspace add"
+```
+
+---
+
+## Task 3: Canonical `llm-wiki:import` skill
+
+**Files:**
+
+- Create: `skills/llm-wiki-import/SKILL.md`
+
+- [ ] **Step 1: Write the skill**
+
+Create `skills/llm-wiki-import/SKILL.md`:
+
+```markdown
+---
+name: llm-wiki:import
+description: Use when the user wants to add a URL, pasted text, or local file to their llm-wiki. Fetches content if needed, checks against the vault's SCOPE.md, and ingests via `wiki_ingest`.
+when-to-use: User shares a link, paste, or path with intent to save. Trigger phrases include "add this to my wiki", "save this", "remember this article", "ingest this paper", or any case where the user supplies content with archival intent.
+---
+
+You are helping the user maintain an llm-wiki vault. The user has shared content (a URL, pasted text, or a file path) and wants it added to the wiki.
+
+## Step 1 — Identify the input type
+
+- **URL**: a web link → fetch it (use `wiki_ingest` with the URL directly; the tool handles fetching and parsing).
+- **Pasted text**: raw markdown or prose → use `wiki_write` for full pages, or `wiki_ingest` from stdin.
+- **Local file path**: a file the user already has → pass the path to `wiki_ingest`.
+
+## Step 2 — Check scope
+
+Read `SCOPE.md` from the vault root using `wiki_read SCOPE.md`. If `SCOPE.md` does not exist, **skip the scope check entirely** — proceed permissively.
+
+If `SCOPE.md` exists, judge whether the new content fits the documented Purpose / Includes / Excludes. The judgment is yours as the agent — `SCOPE.md` is guidance, not a strict rule list.
+
+## Step 3 — Route the content
+
+- **Clearly in scope**: ingest immediately.
+  - For URLs and files: `wiki_ingest` with `--raw-type articles` (or `papers` for arXiv-style links, `assets` for binary files).
+  - For pasted markdown that looks like a finished article: `wiki_ingest --stdin`.
+  - Suggest a category from the wiki's known categories (read `.lw/schema.toml` if needed).
+- **Clearly out of scope**: do not silently drop. Tell the user:
+  > "This looks out of scope for your wiki (Purpose: <quote>). Want me to add it anyway, or skip?"
+  > Wait for an answer.
+- **Ambiguous**: ask before ingesting.
+  > "I'm not sure this fits the scope. The vault is for <Purpose>; this looks like <observation>. Add it?"
+
+## Step 4 — Confirm
+
+After ingestion, print a one-line confirmation: file path written, category, freshness (raw vs full page).
+
+## Hard rules
+
+- Never silent-fail. If you cannot complete the import, tell the user why.
+- Never overwrite an existing wiki page without confirmation; use `wiki_read` first to check.
+- For URLs that fail to fetch (404, paywall, login wall), report the failure and ask whether to file the URL with a note rather than the content.
+- Do not invent metadata (publication date, author) that you cannot verify from the source.
+
+## MCP tools available
+
+- `wiki_query` — search existing pages
+- `wiki_read` — read a page
+- `wiki_browse` — browse categories / tags
+- `wiki_ingest` — file new raw content (URL, file, or stdin)
+- `wiki_write` — write or update a wiki page
+- `wiki_lint` — health check
+- `wiki_tags` — list tags
+```
+
+- [ ] **Step 2: Verify file exists**
+
+```bash
+ls -la skills/llm-wiki-import/SKILL.md
+```
+
+Expected: file present, non-empty.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add skills/
+git commit -m "feat(skills): add canonical llm-wiki:import skill"
+```
+
+---
+
+## Task 4: IntegrationDescriptor types + loader + `claude-code.toml`
+
+**Files:**
+
+- Create: `crates/lw-cli/src/integrations/mod.rs`
+- Create: `crates/lw-cli/src/integrations/descriptor.rs`
+- Create: `integrations/claude-code.toml`
+
+- [ ] **Step 1: Create descriptor types**
+
+Create `crates/lw-cli/src/integrations/descriptor.rs`:
+
+```rust
+use serde::{Deserialize, Serialize};
+use std::path::PathBuf;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Descriptor {
+    pub name: String,
+    pub detect: Detect,
+    pub mcp: Option<McpConfig>,
+    pub skills: Option<SkillsConfig>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct Detect {
+    pub config_dir: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct McpConfig {
+    pub config_path: String,
+    pub format: McpFormat,
+    pub key_path: String,
+    pub command: String,
+    #[serde(default)]
+    pub args: Vec<String>,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum McpFormat {
+    Json,
+    Toml,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct SkillsConfig {
+    pub target_dir: String,
+    pub mode: SkillsMode,
+}
+
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum SkillsMode {
+    Symlink,
+    Copy,
+}
+
+/// Tilde-expand a path string. `~` and `~/` resolve to $HOME.
+pub fn expand_tilde(s: &str) -> PathBuf {
+    if let Some(stripped) = s.strip_prefix("~/") {
+        if let Some(home) = dirs::home_dir() {
+            return home.join(stripped);
+        }
+    } else if s == "~" {
+        if let Some(home) = dirs::home_dir() {
+            return home;
+        }
+    }
+    PathBuf::from(s)
+}
+
+impl Descriptor {
+    pub fn detect_present(&self) -> bool {
+        expand_tilde(&self.detect.config_dir).exists()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_claude_code_descriptor() {
+        let toml_str = r#"
+name = "Claude Code"
+
+[detect]
+config_dir = "~/.claude"
+
+[mcp]
+config_path = "~/.claude/settings.json"
+format = "json"
+key_path = "mcpServers.llm-wiki"
+command = "lw"
+args = ["serve"]
+
+[skills]
+target_dir = "~/.claude/skills/llm-wiki/"
+mode = "symlink"
+"#;
+        let d: Descriptor = toml::from_str(toml_str).unwrap();
+        assert_eq!(d.name, "Claude Code");
+        assert_eq!(d.mcp.as_ref().unwrap().format, McpFormat::Json);
+        assert_eq!(d.skills.as_ref().unwrap().mode, SkillsMode::Symlink);
+    }
+
+    #[test]
+    fn skills_only_descriptor_no_mcp() {
+        let toml_str = r#"
+name = "Skill-only Tool"
+
+[detect]
+config_dir = "~/.someothertool"
+
+[skills]
+target_dir = "~/.someothertool/skills/llm-wiki/"
+mode = "copy"
+"#;
+        let d: Descriptor = toml::from_str(toml_str).unwrap();
+        assert!(d.mcp.is_none());
+        assert_eq!(d.skills.as_ref().unwrap().mode, SkillsMode::Copy);
+    }
+
+    #[test]
+    fn tilde_expansion() {
+        let home = dirs::home_dir().unwrap();
+        assert_eq!(expand_tilde("~/foo"), home.join("foo"));
+        assert_eq!(expand_tilde("~"), home);
+        assert_eq!(expand_tilde("/abs"), PathBuf::from("/abs"));
+        assert_eq!(expand_tilde("rel"), PathBuf::from("rel"));
+    }
+}
+```
+
+- [ ] **Step 2: Create module aggregator + loader**
+
+Create `crates/lw-cli/src/integrations/mod.rs`:
+
+```rust
+pub mod descriptor;
+pub mod mcp;
+pub mod skills;
+
+use descriptor::Descriptor;
+use std::path::PathBuf;
+
+/// Resolution order for the integrations descriptor dir:
+/// 1. $LW_INTEGRATIONS_DIR
+/// 2. $LW_HOME/integrations
+/// 3. ~/.llm-wiki/integrations
+/// 4. <exe_dir>/../share/llm-wiki/integrations
+/// 5. <repo>/integrations  (dev fallback)
+pub fn integrations_root() -> anyhow::Result<PathBuf> {
+    if let Ok(p) = std::env::var("LW_INTEGRATIONS_DIR") {
+        return Ok(PathBuf::from(p));
+    }
+    if let Ok(home) = std::env::var("LW_HOME") {
+        return Ok(PathBuf::from(home).join("integrations"));
+    }
+    if let Some(home) = dirs::home_dir() {
+        let p = home.join(".llm-wiki").join("integrations");
+        if p.exists() {
+            return Ok(p);
+        }
+    }
+    let exe = std::env::current_exe()?;
+    if let Some(exe_dir) = exe.parent() {
+        let share = exe_dir.join("../share/llm-wiki/integrations");
+        if share.exists() {
+            return Ok(share);
+        }
+        let mut cur = exe_dir.to_path_buf();
+        for _ in 0..6 {
+            let candidate = cur.join("integrations");
+            if candidate.exists() {
+                return Ok(candidate);
+            }
+            if !cur.pop() {
+                break;
+            }
+        }
+    }
+    anyhow::bail!("Cannot locate integrations directory")
+}
+
+pub fn load_all() -> anyhow::Result<Vec<(String, Descriptor)>> {
+    let root = integrations_root()?;
+    let mut out = Vec::new();
+    for entry in std::fs::read_dir(&root)? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.extension().and_then(|s| s.to_str()) == Some("toml") {
+            let id = path
+                .file_stem()
+                .and_then(|s| s.to_str())
+                .ok_or_else(|| anyhow::anyhow!("invalid descriptor filename"))?
+                .to_string();
+            let body = std::fs::read_to_string(&path)?;
+            let desc: Descriptor = toml::from_str(&body)
+                .map_err(|e| anyhow::anyhow!("parse {}: {e}", path.display()))?;
+            out.push((id, desc));
+        }
+    }
+    out.sort_by(|a, b| a.0.cmp(&b.0));
+    Ok(out)
+}
+
+/// Stubs — populated by Tasks 5-7
+pub struct IntegrateOpts {
+    pub yes: bool,
+    pub interactive: bool,
+}
+```
+
+Create stub files so the module compiles:
+
+`crates/lw-cli/src/integrations/mcp.rs`:
+
+```rust
+// Populated by Task 5
+```
+
+`crates/lw-cli/src/integrations/skills.rs`:
+
+```rust
+// Populated by Task 6
+```
+
+Add `mod integrations;` to `crates/lw-cli/src/main.rs`.
+
+- [ ] **Step 3: Create the Claude Code descriptor**
+
+Create `integrations/claude-code.toml`:
+
+```toml
+name = "Claude Code"
+
+[detect]
+config_dir = "~/.claude"
+
+[mcp]
+config_path = "~/.claude/settings.json"
+format = "json"
+key_path = "mcpServers.llm-wiki"
+command = "lw"
+args = ["serve"]
+
+[skills]
+target_dir = "~/.claude/skills/llm-wiki/"
+mode = "symlink"
+```
+
+- [ ] **Step 4: Run tests**
+
+```bash
+cargo test -p lw-cli integrations -- --test-threads=1
+```
+
+Expected: 3 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/lw-cli/src/integrations/ crates/lw-cli/src/main.rs integrations/
+git commit -m "feat(lw-cli): add integration descriptor types and Claude Code adapter"
+```
+
+---
+
+## Task 5: MCP config atomic merge with version markers + backup
+
+**Files:**
+
+- Modify: `crates/lw-cli/src/integrations/mcp.rs`
+
+- [ ] **Step 1: Implement merge logic with tests**
+
+Replace `crates/lw-cli/src/integrations/mcp.rs`:
+
+```rust
+use serde_json::{Map, Value};
+use std::path::Path;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+pub const VERSION_MARKER: &str = "_lw_version";
+
+/// Result of a merge attempt.
+#[derive(Debug, PartialEq)]
+pub enum MergeOutcome {
+    /// Entry inserted (was absent).
+    Inserted,
+    /// Entry updated; previous version matched expected (clean upgrade).
+    Updated,
+    /// Entry exists but appears user-edited; not modified.
+    Conflict { existing: Value },
+    /// Entry already matches desired; no-op.
+    NoOp,
+}
+
+/// Merge a managed entry into a JSON config.
+///
+/// `key_path` is dot-separated (e.g., "mcpServers.llm-wiki").
+/// `entry` MUST contain a `_lw_version` field; it will be added if missing.
+/// `expected_prev_version` is the version we last shipped; if the existing entry's
+/// `_lw_version` matches, we treat it as an unmodified upgrade and replace silently.
+/// If it does not match (or `_lw_version` is absent), we treat it as user-edited
+/// and return `Conflict` without modifying.
+pub fn merge_entry(
+    config: &mut Value,
+    key_path: &str,
+    mut entry: Value,
+    expected_prev_version: Option<&str>,
+) -> anyhow::Result<MergeOutcome> {
+    // Ensure entry has a version marker
+    if !entry
+        .as_object()
+        .map(|o| o.contains_key(VERSION_MARKER))
+        .unwrap_or(false)
+    {
+        anyhow::bail!("entry must include '{VERSION_MARKER}' field");
+    }
+
+    let parts: Vec<&str> = key_path.split('.').collect();
+    let (last, parents) = parts.split_last().unwrap();
+
+    // Walk / create parents
+    let mut cursor = config;
+    for p in parents {
+        if !cursor.is_object() {
+            *cursor = Value::Object(Map::new());
+        }
+        let obj = cursor.as_object_mut().unwrap();
+        cursor = obj.entry((*p).to_string()).or_insert(Value::Object(Map::new()));
+    }
+    if !cursor.is_object() {
+        *cursor = Value::Object(Map::new());
+    }
+    let obj = cursor.as_object_mut().unwrap();
+
+    match obj.get(*last) {
+        None => {
+            obj.insert((*last).to_string(), entry);
+            Ok(MergeOutcome::Inserted)
+        }
+        Some(existing) if existing == &entry => Ok(MergeOutcome::NoOp),
+        Some(existing) => {
+            let existing_ver = existing
+                .get(VERSION_MARKER)
+                .and_then(|v| v.as_str());
+            match (existing_ver, expected_prev_version) {
+                (Some(ev), Some(pv)) if ev == pv => {
+                    // Clean upgrade
+                    if let Some(obj_entry) = entry.as_object_mut() {
+                        obj_entry.insert(
+                            VERSION_MARKER.into(),
+                            entry
+                                .get(VERSION_MARKER)
+                                .cloned()
+                                .unwrap_or_else(|| Value::String("unknown".into())),
+                        );
+                    }
+                    obj.insert((*last).to_string(), entry);
+                    Ok(MergeOutcome::Updated)
+                }
+                _ => Ok(MergeOutcome::Conflict { existing: existing.clone() }),
+            }
+        }
+    }
+}
+
+/// Atomically write a JSON file: backup → temp → fsync → rename.
+/// Returns the backup path so callers can report it.
+pub fn atomic_write_with_backup(
+    path: &Path,
+    body: &str,
+) -> anyhow::Result<Option<std::path::PathBuf>> {
+    let backup_path = if path.exists() {
+        let ts = SystemTime::now()
+            .duration_since(UNIX_EPOCH)?
+            .as_secs();
+        let bak = path.with_extension(format!(
+            "{}.bak.{ts}",
+            path.extension()
+                .and_then(|s| s.to_str())
+                .unwrap_or("")
+        ));
+        std::fs::copy(path, &bak)?;
+        Some(bak)
+    } else {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        None
+    };
+    let tmp = path.with_extension(format!(
+        "{}.tmp",
+        path.extension().and_then(|s| s.to_str()).unwrap_or("")
+    ));
+    std::fs::write(&tmp, body)?;
+    let f = std::fs::File::open(&tmp)?;
+    f.sync_all()?;
+    std::fs::rename(&tmp, path)?;
+    Ok(backup_path)
+}
+
+/// Remove an entry from JSON config by key_path. Returns true if removed.
+pub fn remove_entry(config: &mut Value, key_path: &str) -> bool {
+    let parts: Vec<&str> = key_path.split('.').collect();
+    let (last, parents) = parts.split_last().unwrap();
+    let mut cursor = config;
+    for p in parents {
+        match cursor.get_mut(*p) {
+            Some(child) => cursor = child,
+            None => return false,
+        }
+    }
+    cursor
+        .as_object_mut()
+        .map(|o| o.remove(*last).is_some())
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use tempfile::TempDir;
+
+    fn entry(version: &str) -> Value {
+        json!({
+            "command": "lw",
+            "args": ["serve"],
+            VERSION_MARKER: version
+        })
+    }
+
+    #[test]
+    fn merge_inserts_when_absent() {
+        let mut cfg = json!({});
+        let outcome = merge_entry(&mut cfg, "mcpServers.llm-wiki", entry("0.2.0"), None).unwrap();
+        assert_eq!(outcome, MergeOutcome::Inserted);
+        assert_eq!(
+            cfg["mcpServers"]["llm-wiki"][VERSION_MARKER],
+            json!("0.2.0")
+        );
+    }
+
+    #[test]
+    fn merge_noop_when_identical() {
+        let mut cfg = json!({"mcpServers": {"llm-wiki": entry("0.2.0")}});
+        let outcome = merge_entry(&mut cfg, "mcpServers.llm-wiki", entry("0.2.0"), Some("0.2.0")).unwrap();
+        assert_eq!(outcome, MergeOutcome::NoOp);
+    }
+
+    #[test]
+    fn merge_updates_when_prev_version_matches() {
+        let mut cfg = json!({"mcpServers": {"llm-wiki": entry("0.1.0")}});
+        let outcome = merge_entry(&mut cfg, "mcpServers.llm-wiki", entry("0.2.0"), Some("0.1.0")).unwrap();
+        assert_eq!(outcome, MergeOutcome::Updated);
+        assert_eq!(
+            cfg["mcpServers"]["llm-wiki"][VERSION_MARKER],
+            json!("0.2.0")
+        );
+    }
+
+    #[test]
+    fn merge_conflict_when_user_edited() {
+        let mut user_edited = entry("0.1.0");
+        user_edited["args"] = json!(["serve", "--root", "/custom"]);
+        let mut cfg = json!({"mcpServers": {"llm-wiki": user_edited.clone()}});
+        let outcome = merge_entry(&mut cfg, "mcpServers.llm-wiki", entry("0.2.0"), Some("0.0.1")).unwrap();
+        match outcome {
+            MergeOutcome::Conflict { existing } => assert_eq!(existing, user_edited),
+            _ => panic!("expected Conflict"),
+        }
+        // Config must be unchanged
+        assert_eq!(cfg["mcpServers"]["llm-wiki"], user_edited);
+    }
+
+    #[test]
+    fn merge_preserves_sibling_entries() {
+        let mut cfg = json!({
+            "mcpServers": {
+                "other-tool": {"command": "other"},
+                "llm-wiki": entry("0.1.0"),
+            },
+            "permissions": {"allow": ["foo"]},
+        });
+        merge_entry(&mut cfg, "mcpServers.llm-wiki", entry("0.2.0"), Some("0.1.0")).unwrap();
+        assert_eq!(cfg["mcpServers"]["other-tool"], json!({"command": "other"}));
+        assert_eq!(cfg["permissions"]["allow"], json!(["foo"]));
+    }
+
+    #[test]
+    fn merge_rejects_entry_without_version_marker() {
+        let mut cfg = json!({});
+        let bad = json!({"command": "lw", "args": ["serve"]});
+        let result = merge_entry(&mut cfg, "mcpServers.llm-wiki", bad, None);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn atomic_write_creates_backup() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("settings.json");
+        std::fs::write(&path, "{\"old\": true}").unwrap();
+        let backup = atomic_write_with_backup(&path, "{\"new\": true}").unwrap();
+        assert!(backup.is_some());
+        let bak = backup.unwrap();
+        assert!(bak.exists());
+        assert_eq!(std::fs::read_to_string(&bak).unwrap(), "{\"old\": true}");
+        assert_eq!(std::fs::read_to_string(&path).unwrap(), "{\"new\": true}");
+    }
+
+    #[test]
+    fn atomic_write_no_backup_when_file_absent() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("settings.json");
+        let backup = atomic_write_with_backup(&path, "{}").unwrap();
+        assert!(backup.is_none());
+        assert!(path.exists());
+    }
+
+    #[test]
+    fn remove_entry_returns_true_when_present() {
+        let mut cfg = json!({"mcpServers": {"llm-wiki": entry("0.2.0"), "other": {}}});
+        assert!(remove_entry(&mut cfg, "mcpServers.llm-wiki"));
+        assert!(cfg["mcpServers"]["llm-wiki"].is_null());
+        assert_eq!(cfg["mcpServers"]["other"], json!({}));
+    }
+
+    #[test]
+    fn remove_entry_returns_false_when_absent() {
+        let mut cfg = json!({});
+        assert!(!remove_entry(&mut cfg, "mcpServers.llm-wiki"));
+    }
+}
+```
+
+- [ ] **Step 2: Run tests**
+
+```bash
+cargo test -p lw-cli mcp:: -- --test-threads=1
+```
+
+Expected: 9 passed.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/lw-cli/src/integrations/mcp.rs
+git commit -m "feat(integrations): atomic JSON config merge with version markers and backup"
+```
+
+---
+
+## Task 6: Skills symlink / copy installer
+
+**Files:**
+
+- Modify: `crates/lw-cli/src/integrations/skills.rs`
+
+- [ ] **Step 1: Implement skills installer**
+
+Replace `crates/lw-cli/src/integrations/skills.rs`:
+
+```rust
+use crate::integrations::descriptor::{SkillsConfig, SkillsMode, expand_tilde};
+use std::path::{Path, PathBuf};
+
+pub fn skills_root() -> anyhow::Result<PathBuf> {
+    if let Ok(p) = std::env::var("LW_SKILLS_DIR") {
+        return Ok(PathBuf::from(p));
+    }
+    if let Ok(home) = std::env::var("LW_HOME") {
+        return Ok(PathBuf::from(home).join("skills"));
+    }
+    if let Some(home) = dirs::home_dir() {
+        let p = home.join(".llm-wiki").join("skills");
+        if p.exists() {
+            return Ok(p);
+        }
+    }
+    let exe = std::env::current_exe()?;
+    if let Some(exe_dir) = exe.parent() {
+        let share = exe_dir.join("../share/llm-wiki/skills");
+        if share.exists() {
+            return Ok(share);
+        }
+        let mut cur = exe_dir.to_path_buf();
+        for _ in 0..6 {
+            let candidate = cur.join("skills");
+            if candidate.exists() {
+                return Ok(candidate);
+            }
+            if !cur.pop() {
+                break;
+            }
+        }
+    }
+    anyhow::bail!("Cannot locate skills directory")
+}
+
+pub fn install(cfg: &SkillsConfig) -> anyhow::Result<PathBuf> {
+    let target = expand_tilde(&cfg.target_dir);
+    if let Some(parent) = target.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let source = skills_root()?;
+    if !source.exists() {
+        anyhow::bail!(
+            "skills source not found at {} — install layout broken",
+            source.display()
+        );
+    }
+    // If target already exists, replace it.
+    if target.exists() || target.symlink_metadata().is_ok() {
+        if target.is_symlink() || target.is_file() {
+            std::fs::remove_file(&target)?;
+        } else if target.is_dir() {
+            std::fs::remove_dir_all(&target)?;
+        }
+    }
+    match cfg.mode {
+        SkillsMode::Symlink => link_dir(&source, &target)?,
+        SkillsMode::Copy => copy_recursive(&source, &target)?,
+    }
+    Ok(target)
+}
+
+pub fn uninstall(cfg: &SkillsConfig) -> anyhow::Result<bool> {
+    let target = expand_tilde(&cfg.target_dir);
+    if !target.exists() && target.symlink_metadata().is_err() {
+        return Ok(false);
+    }
+    if target.is_symlink() || target.is_file() {
+        std::fs::remove_file(&target)?;
+    } else if target.is_dir() {
+        std::fs::remove_dir_all(&target)?;
+    }
+    Ok(true)
+}
+
+#[cfg(unix)]
+fn link_dir(src: &Path, dst: &Path) -> anyhow::Result<()> {
+    std::os::unix::fs::symlink(src, dst)?;
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn link_dir(_src: &Path, _dst: &Path) -> anyhow::Result<()> {
+    anyhow::bail!("symlink mode requires Unix; use mode = \"copy\" on this platform")
+}
+
+fn copy_recursive(src: &Path, dst: &Path) -> anyhow::Result<()> {
+    std::fs::create_dir_all(dst)?;
+    for entry in std::fs::read_dir(src)? {
+        let entry = entry?;
+        let from = entry.path();
+        let to = dst.join(entry.file_name());
+        if entry.file_type()?.is_dir() {
+            copy_recursive(&from, &to)?;
+        } else {
+            std::fs::copy(&from, &to)?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn make_skills_root(dir: &Path) {
+        let s = dir.join("skills").join("llm-wiki-import");
+        std::fs::create_dir_all(&s).unwrap();
+        std::fs::write(s.join("SKILL.md"), "---\nname: test\n---\nbody").unwrap();
+    }
+
+    #[test]
+    fn install_symlink_creates_link() {
+        let src_dir = TempDir::new().unwrap();
+        make_skills_root(src_dir.path());
+        let target_dir = TempDir::new().unwrap();
+        let cfg = SkillsConfig {
+            target_dir: target_dir.path().join("llm-wiki").display().to_string(),
+            mode: SkillsMode::Symlink,
+        };
+        unsafe { std::env::set_var("LW_SKILLS_DIR", src_dir.path().join("skills")) };
+        let target = install(&cfg).unwrap();
+        unsafe { std::env::remove_var("LW_SKILLS_DIR") };
+        assert!(target.exists());
+        assert!(target.is_symlink() || target.read_link().is_ok());
+        assert!(target.join("llm-wiki-import/SKILL.md").exists());
+    }
+
+    #[test]
+    fn install_copy_writes_files() {
+        let src_dir = TempDir::new().unwrap();
+        make_skills_root(src_dir.path());
+        let target_dir = TempDir::new().unwrap();
+        let cfg = SkillsConfig {
+            target_dir: target_dir.path().join("llm-wiki").display().to_string(),
+            mode: SkillsMode::Copy,
+        };
+        unsafe { std::env::set_var("LW_SKILLS_DIR", src_dir.path().join("skills")) };
+        let target = install(&cfg).unwrap();
+        unsafe { std::env::remove_var("LW_SKILLS_DIR") };
+        assert!(target.join("llm-wiki-import/SKILL.md").exists());
+        assert!(!target.is_symlink());
+    }
+
+    #[test]
+    fn uninstall_removes_symlink() {
+        let src_dir = TempDir::new().unwrap();
+        make_skills_root(src_dir.path());
+        let target_dir = TempDir::new().unwrap();
+        let cfg = SkillsConfig {
+            target_dir: target_dir.path().join("llm-wiki").display().to_string(),
+            mode: SkillsMode::Symlink,
+        };
+        unsafe { std::env::set_var("LW_SKILLS_DIR", src_dir.path().join("skills")) };
+        install(&cfg).unwrap();
+        let removed = uninstall(&cfg).unwrap();
+        unsafe { std::env::remove_var("LW_SKILLS_DIR") };
+        assert!(removed);
+        assert!(!target_dir.path().join("llm-wiki").exists());
+    }
+
+    #[test]
+    fn install_replaces_existing_symlink() {
+        let src_dir = TempDir::new().unwrap();
+        make_skills_root(src_dir.path());
+        let target_dir = TempDir::new().unwrap();
+        let cfg = SkillsConfig {
+            target_dir: target_dir.path().join("llm-wiki").display().to_string(),
+            mode: SkillsMode::Symlink,
+        };
+        unsafe { std::env::set_var("LW_SKILLS_DIR", src_dir.path().join("skills")) };
+        install(&cfg).unwrap();
+        // Re-install must succeed (replaces existing)
+        install(&cfg).unwrap();
+        unsafe { std::env::remove_var("LW_SKILLS_DIR") };
+    }
+}
+```
+
+- [ ] **Step 2: Run tests**
+
+```bash
+cargo test -p lw-cli skills:: -- --test-threads=1
+```
+
+Expected: 4 passed.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/lw-cli/src/integrations/skills.rs
+git commit -m "feat(integrations): add skills symlink/copy installer with replace semantics"
+```
+
+---
+
+## Task 7: `lw integrate` command (install + auto + uninstall)
+
+**Files:**
+
+- Create: `crates/lw-cli/src/integrate.rs`
+- Modify: `crates/lw-cli/src/integrations/mod.rs` (export helper, drop stub)
+- Modify: `crates/lw-cli/src/main.rs` (wire subcommand)
+
+- [ ] **Step 1: Write integrate command**
+
+Create `crates/lw-cli/src/integrate.rs`:
+
+```rust
+use crate::integrations::{
+    descriptor::{Descriptor, McpFormat, expand_tilde},
+    integrations_root, load_all, mcp, skills,
+};
+use serde_json::{Value, json};
+use std::io::IsTerminal;
+
+pub struct IntegrateOpts {
+    pub yes: bool,
+    pub uninstall: bool,
+}
+
+const VERSION: &str = env!("CARGO_PKG_VERSION");
+
+pub fn run(target: Option<&str>, opts: IntegrateOpts) -> anyhow::Result<()> {
+    let descriptors = load_all()?;
+    let to_process: Vec<(String, Descriptor)> = match target {
+        Some(name) => descriptors
+            .into_iter()
+            .filter(|(id, _)| id == name)
+            .collect(),
+        None => {
+            // --auto: only those whose detect.config_dir exists
+            descriptors
+                .into_iter()
+                .filter(|(_, d)| d.detect_present())
+                .collect()
+        }
+    };
+
+    if to_process.is_empty() {
+        match target {
+            Some(t) => anyhow::bail!(
+                "no integration descriptor named '{t}' (check {})",
+                integrations_root()?.display()
+            ),
+            None => {
+                println!("No supported agent tools detected. Install Claude Code, Codex, or OpenClaw first.");
+                return Ok(());
+            }
+        }
+    }
+
+    for (id, desc) in to_process {
+        if opts.uninstall {
+            uninstall_one(&id, &desc)?;
+        } else {
+            let proceed = if opts.yes || target.is_some() {
+                true
+            } else if std::io::stdout().is_terminal() {
+                prompt_yes_no(&format!("Integrate llm-wiki with {} ({}?)", desc.name, id))?
+            } else {
+                println!("Detected {} ({id}). Run `lw integrate {id}` or `lw integrate --auto --yes` to install.", desc.name);
+                false
+            };
+            if proceed {
+                install_one(&id, &desc)?;
+            }
+        }
+    }
+    Ok(())
+}
+
+fn install_one(id: &str, desc: &Descriptor) -> anyhow::Result<()> {
+    println!("Installing integration: {} ({id})", desc.name);
+
+    if let Some(mcp_cfg) = &desc.mcp {
+        if mcp_cfg.format != McpFormat::Json {
+            anyhow::bail!("only JSON MCP format is supported in this version");
+        }
+        let path = expand_tilde(&mcp_cfg.config_path);
+        let mut config: Value = if path.exists() {
+            serde_json::from_str(&std::fs::read_to_string(&path)?)
+                .map_err(|e| anyhow::anyhow!("parse {}: {e}", path.display()))?
+        } else {
+            json!({})
+        };
+        let entry = json!({
+            "command": mcp_cfg.command,
+            "args": mcp_cfg.args,
+            mcp::VERSION_MARKER: VERSION,
+        });
+        let outcome = mcp::merge_entry(&mut config, &mcp_cfg.key_path, entry, Some(VERSION))?;
+        match outcome {
+            mcp::MergeOutcome::Inserted => println!("  MCP entry inserted at {}", path.display()),
+            mcp::MergeOutcome::NoOp => println!("  MCP entry already current at {}", path.display()),
+            mcp::MergeOutcome::Updated => println!("  MCP entry updated at {}", path.display()),
+            mcp::MergeOutcome::Conflict { existing } => {
+                eprintln!(
+                    "  MCP entry at {} appears user-edited; not overwriting.",
+                    path.display()
+                );
+                eprintln!("  Existing: {}", serde_json::to_string_pretty(&existing)?);
+                eprintln!(
+                    "  To force, remove the entry manually or run with `--force` (not yet supported)."
+                );
+                return Ok(());
+            }
+        }
+        let body = serde_json::to_string_pretty(&config)? + "\n";
+        let backup = mcp::atomic_write_with_backup(&path, &body)?;
+        if let Some(b) = backup {
+            println!("  backup: {}", b.display());
+        }
+    }
+
+    if let Some(skills_cfg) = &desc.skills {
+        let target = skills::install(skills_cfg)?;
+        println!("  skills installed at {}", target.display());
+    }
+
+    Ok(())
+}
+
+fn uninstall_one(id: &str, desc: &Descriptor) -> anyhow::Result<()> {
+    println!("Uninstalling integration: {} ({id})", desc.name);
+
+    if let Some(mcp_cfg) = &desc.mcp {
+        let path = expand_tilde(&mcp_cfg.config_path);
+        if path.exists() {
+            let mut config: Value = serde_json::from_str(&std::fs::read_to_string(&path)?)
+                .map_err(|e| anyhow::anyhow!("parse {}: {e}", path.display()))?;
+            let removed = mcp::remove_entry(&mut config, &mcp_cfg.key_path);
+            if removed {
+                let body = serde_json::to_string_pretty(&config)? + "\n";
+                let backup = mcp::atomic_write_with_backup(&path, &body)?;
+                println!("  MCP entry removed from {}", path.display());
+                if let Some(b) = backup {
+                    println!("  backup: {}", b.display());
+                }
+            } else {
+                println!("  MCP entry not present at {}", path.display());
+            }
+        }
+    }
+
+    if let Some(skills_cfg) = &desc.skills {
+        let removed = skills::uninstall(skills_cfg)?;
+        if removed {
+            println!("  skills removed from {}", expand_tilde(&skills_cfg.target_dir).display());
+        }
+    }
+
+    Ok(())
+}
+
+fn prompt_yes_no(question: &str) -> anyhow::Result<bool> {
+    use std::io::Write;
+    print!("{question} [y/N] ");
+    std::io::stdout().flush()?;
+    let mut buf = String::new();
+    std::io::stdin().read_line(&mut buf)?;
+    Ok(matches!(buf.trim().to_ascii_lowercase().as_str(), "y" | "yes"))
+}
+```
+
+- [ ] **Step 2: Wire CLI subcommand**
+
+In `crates/lw-cli/src/main.rs`, add to `enum Commands`:
+
+```rust
+    /// Wire llm-wiki into your agent tool(s)
+    #[command(after_help = "Examples:\n  lw integrate --auto\n  lw integrate claude-code\n  lw integrate claude-code --uninstall\n  lw integrate --auto --yes  # non-interactive")]
+    Integrate {
+        /// Specific integration id (omit for --auto detection)
+        tool: Option<String>,
+        /// Detect installed tools and prompt per tool
+        #[arg(long, conflicts_with = "tool")]
+        auto: bool,
+        /// Skip prompts (assume yes)
+        #[arg(short, long)]
+        yes: bool,
+        /// Reverse the integration
+        #[arg(long)]
+        uninstall: bool,
+    },
+```
+
+Add `mod integrate;` near top of `main.rs`.
+
+In the `match cli.command { ... }` block, add:
+
+```rust
+        Commands::Integrate { tool, auto, yes, uninstall } => {
+            let target = if auto { None } else { tool.as_deref() };
+            integrate::run(target, integrate::IntegrateOpts { yes, uninstall })
+        }
+```
+
+- [ ] **Step 3: Build and smoke-test**
+
+```bash
+cargo build -p lw-cli
+./target/debug/lw integrate --help
+```
+
+Expected: help text shows all flags.
+
+```bash
+LW_INTEGRATIONS_DIR=$PWD/integrations LW_SKILLS_DIR=$PWD/skills ./target/debug/lw integrate --auto
+```
+
+Expected on a system without `~/.claude/`: prints "No supported agent tools detected." and exits 0.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/lw-cli/src/integrate.rs crates/lw-cli/src/main.rs
+git commit -m "feat(lw-cli): add lw integrate command (auto/single/uninstall)"
+```
+
+---
+
+## Task 8: End-to-end integration test
+
+**Files:**
+
+- Create: `crates/lw-cli/tests/integrate_cli.rs`
+
+- [ ] **Step 1: Write tests**
+
+Create `crates/lw-cli/tests/integrate_cli.rs`:
+
+```rust
+use assert_cmd::Command;
+use predicates::prelude::*;
+use serde_json::Value;
+use tempfile::TempDir;
+
+fn lw(env_home: &std::path::Path, integrations: &std::path::Path, skills: &std::path::Path) -> Command {
+    let mut cmd = Command::cargo_bin("lw").unwrap();
+    cmd.env("LW_HOME", env_home);
+    cmd.env("LW_INTEGRATIONS_DIR", integrations);
+    cmd.env("LW_SKILLS_DIR", skills);
+    cmd.env_remove("LW_WIKI_ROOT");
+    cmd
+}
+
+fn make_descriptor(integrations: &std::path::Path, fake_home: &std::path::Path) {
+    std::fs::create_dir_all(integrations).unwrap();
+    let claude_dir = fake_home.join(".claude");
+    std::fs::create_dir_all(&claude_dir).unwrap();
+    let settings_path = claude_dir.join("settings.json");
+    let skills_target = claude_dir.join("skills/llm-wiki/");
+
+    let toml = format!(
+        r#"
+name = "Claude Code"
+
+[detect]
+config_dir = "{}"
+
+[mcp]
+config_path = "{}"
+format = "json"
+key_path = "mcpServers.llm-wiki"
+command = "lw"
+args = ["serve"]
+
+[skills]
+target_dir = "{}"
+mode = "symlink"
+"#,
+        claude_dir.display(),
+        settings_path.display(),
+        skills_target.display()
+    );
+    std::fs::write(integrations.join("claude-code.toml"), toml).unwrap();
+}
+
+fn make_skills(skills_dir: &std::path::Path) {
+    let s = skills_dir.join("llm-wiki-import");
+    std::fs::create_dir_all(&s).unwrap();
+    std::fs::write(s.join("SKILL.md"), "---\nname: llm-wiki:import\n---\nbody").unwrap();
+}
+
+#[test]
+fn integrate_install_writes_settings_and_links_skills() {
+    let env_home = TempDir::new().unwrap();
+    let integrations = TempDir::new().unwrap();
+    let skills = TempDir::new().unwrap();
+    let fake_home = TempDir::new().unwrap();
+    make_descriptor(integrations.path(), fake_home.path());
+    make_skills(skills.path());
+
+    lw(env_home.path(), integrations.path(), skills.path())
+        .args(["integrate", "claude-code"])
+        .assert()
+        .success();
+
+    let settings_path = fake_home.path().join(".claude/settings.json");
+    let settings: Value =
+        serde_json::from_str(&std::fs::read_to_string(&settings_path).unwrap()).unwrap();
+    assert_eq!(settings["mcpServers"]["llm-wiki"]["command"], "lw");
+    assert_eq!(settings["mcpServers"]["llm-wiki"]["args"], serde_json::json!(["serve"]));
+    assert!(settings["mcpServers"]["llm-wiki"]["_lw_version"].is_string());
+
+    let skills_link = fake_home.path().join(".claude/skills/llm-wiki/");
+    assert!(skills_link.join("llm-wiki-import/SKILL.md").exists());
+}
+
+#[test]
+fn integrate_uninstall_removes_entry_and_skills() {
+    let env_home = TempDir::new().unwrap();
+    let integrations = TempDir::new().unwrap();
+    let skills = TempDir::new().unwrap();
+    let fake_home = TempDir::new().unwrap();
+    make_descriptor(integrations.path(), fake_home.path());
+    make_skills(skills.path());
+
+    // Install first
+    lw(env_home.path(), integrations.path(), skills.path())
+        .args(["integrate", "claude-code"])
+        .assert()
+        .success();
+    // Then uninstall
+    lw(env_home.path(), integrations.path(), skills.path())
+        .args(["integrate", "claude-code", "--uninstall"])
+        .assert()
+        .success();
+
+    let settings_path = fake_home.path().join(".claude/settings.json");
+    let settings: Value =
+        serde_json::from_str(&std::fs::read_to_string(&settings_path).unwrap()).unwrap();
+    assert!(settings["mcpServers"].get("llm-wiki").is_none());
+    assert!(!fake_home.path().join(".claude/skills/llm-wiki/").exists());
+}
+
+#[test]
+fn integrate_preserves_other_mcp_entries() {
+    let env_home = TempDir::new().unwrap();
+    let integrations = TempDir::new().unwrap();
+    let skills = TempDir::new().unwrap();
+    let fake_home = TempDir::new().unwrap();
+    make_descriptor(integrations.path(), fake_home.path());
+    make_skills(skills.path());
+
+    let settings_path = fake_home.path().join(".claude/settings.json");
+    std::fs::write(
+        &settings_path,
+        r#"{"mcpServers":{"other":{"command":"other"}},"permissions":{"allow":["foo"]}}"#,
+    )
+    .unwrap();
+
+    lw(env_home.path(), integrations.path(), skills.path())
+        .args(["integrate", "claude-code"])
+        .assert()
+        .success();
+
+    let settings: Value =
+        serde_json::from_str(&std::fs::read_to_string(&settings_path).unwrap()).unwrap();
+    assert_eq!(settings["mcpServers"]["other"]["command"], "other");
+    assert_eq!(settings["permissions"]["allow"], serde_json::json!(["foo"]));
+    assert_eq!(settings["mcpServers"]["llm-wiki"]["command"], "lw");
+
+    // Backup must exist
+    let entries: Vec<_> = std::fs::read_dir(fake_home.path().join(".claude"))
+        .unwrap()
+        .map(|e| e.unwrap().file_name().to_string_lossy().to_string())
+        .filter(|n| n.contains(".bak."))
+        .collect();
+    assert!(!entries.is_empty(), "expected at least one backup file");
+}
+
+#[test]
+fn integrate_auto_with_no_tools_succeeds() {
+    let env_home = TempDir::new().unwrap();
+    let integrations = TempDir::new().unwrap();
+    let skills = TempDir::new().unwrap();
+    let fake_home = TempDir::new().unwrap();
+    // Descriptor present but its detect.config_dir does NOT exist
+    let phantom = fake_home.path().join("never-installed");
+    std::fs::create_dir_all(integrations.path()).unwrap();
+    let toml = format!(
+        r#"
+name = "Phantom"
+
+[detect]
+config_dir = "{}"
+
+[mcp]
+config_path = "{}"
+format = "json"
+key_path = "mcpServers.llm-wiki"
+command = "lw"
+args = ["serve"]
+
+[skills]
+target_dir = "{}"
+mode = "symlink"
+"#,
+        phantom.display(),
+        phantom.join("settings.json").display(),
+        phantom.join("skills/").display()
+    );
+    std::fs::write(integrations.path().join("phantom.toml"), toml).unwrap();
+    make_skills(skills.path());
+
+    lw(env_home.path(), integrations.path(), skills.path())
+        .args(["integrate", "--auto", "--yes"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("No supported agent tools detected"));
+}
+```
+
+- [ ] **Step 2: Run tests**
+
+```bash
+cargo test -p lw-cli --test integrate_cli -- --test-threads=1
+```
+
+Expected: 4 passed.
+
+- [ ] **Step 3: Final verification**
+
+```bash
+cargo test --workspace -- --test-threads=1
+cargo clippy --workspace --all-targets -- -D warnings
+cargo fmt --all -- --check
+```
+
+Expected: all green.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/lw-cli/tests/integrate_cli.rs
+git commit -m "test(lw-cli): end-to-end integrate install/uninstall against fake config"
+```
+
+---
+
+## Done criteria
+
+- 3 templates copyable via `lw workspace add --template <name>`
+- `llm-wiki:import` skill present in canonical `skills/`
+- `lw integrate claude-code` writes a valid mcpServers entry, links skills, backs up prior config
+- `lw integrate claude-code --uninstall` reverses cleanly, leaves sibling entries intact
+- `lw integrate --auto` skips when no tools detected, prompts (or `--yes`) when present
+- User-edited entries trigger Conflict and are NOT overwritten
+- All tests green, clippy clean, fmt clean

--- a/docs/plans/2026-04-20-wrapper-plan-c-installer.md
+++ b/docs/plans/2026-04-20-wrapper-plan-c-installer.md
@@ -1,0 +1,1158 @@
+# Plan C — Installer, Upgrade, Uninstall, CI Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship a one-line `curl | sh` installer (versioned, sha256-verified), `lw upgrade` and `lw uninstall` subcommands, the `~/.llm-wiki/version` metadata file, and a CI release pipeline that bundles binary + skills + templates + integrations + installer scripts into a single per-platform tarball plus a separately-signed `install.sh` asset.
+
+**Architecture:** Shell scripts (`install.sh`, `uninstall.sh`) own all platform-bridging logic — OS/arch detection, tarball fetch and verify, PATH manipulation in shell rc, self-delete safety. Rust subcommands (`lw upgrade`, `lw uninstall`) are thin wrappers that exec the shipped scripts in `~/.llm-wiki/installer/`. The release tarball is one bundle per platform; `install.sh` itself ships as a separate release asset so it can be `curl`-fetched without first downloading the binary.
+
+**Tech Stack:** POSIX `sh` for installers (portable across macOS / Linux), Rust for CLI subcommands, `ureq` (already in deps) for GitHub releases API, GitHub Actions for release pipeline.
+
+**Working dir:** `tool/llm-wiki/`. Depends on Plan A (workspace registry) and Plan B (skills/templates/integrations assets exist in repo).
+
+**Spec reference:** `docs/superpowers/specs/2026-04-19-llm-wiki-product-wrapper-design.md` §7, §11, §11.5, §14.
+
+---
+
+## File structure
+
+| File                                      | Status | Responsibility                                                     |
+| ----------------------------------------- | ------ | ------------------------------------------------------------------ |
+| `crates/lw-cli/src/version_file.rs`       | create | TOML `~/.llm-wiki/version` reader/writer                           |
+| `crates/lw-cli/src/upgrade.rs`            | create | `lw upgrade` (--check via GitHub API; --apply execs install.sh)    |
+| `crates/lw-cli/src/uninstall.rs`          | create | `lw uninstall` (execs `~/.llm-wiki/installer/uninstall.sh`)        |
+| `crates/lw-cli/src/main.rs`               | modify | Wire `Upgrade` + `Uninstall` subcommands                           |
+| `installer/install.sh`                    | create | Curl-installable script (also embedded for re-use)                 |
+| `installer/uninstall.sh`                  | create | Reverse flow per spec §11.5                                        |
+| `installer/test-install.sh`               | create | Containerized smoke test driver                                    |
+| `installer/Dockerfile.test-linux`         | create | Clean Linux env for smoke test                                     |
+| `.github/workflows/release.yml`           | modify | Bundle assets + publish install.sh as a separate asset with sha256 |
+| `crates/lw-cli/tests/version_file_cli.rs` | create | Integration test                                                   |
+
+---
+
+## Task 1: Version file format + Rust reader/writer
+
+**Files:**
+
+- Create: `crates/lw-cli/src/version_file.rs`
+- Modify: `crates/lw-cli/src/main.rs` (add `mod version_file;`)
+
+- [ ] **Step 1: Write tests + impl**
+
+Create `crates/lw-cli/src/version_file.rs`:
+
+```rust
+use serde::{Deserialize, Serialize};
+use std::path::{Path, PathBuf};
+
+/// Per spec §11: the binary and the assets (skills/templates) ship with matched
+/// versions and `lw doctor` enforces compatibility. We record both in
+/// `~/.llm-wiki/version` so an upgrade-skew (e.g., user manually replaced the
+/// binary) is detectable.
+#[derive(Debug, Default, Serialize, Deserialize, PartialEq)]
+pub struct VersionFile {
+    #[serde(default)]
+    pub binary: String,
+    #[serde(default)]
+    pub assets: String,
+    /// ISO-8601 timestamp set at install/upgrade time.
+    #[serde(default)]
+    pub installed_at: String,
+}
+
+pub fn version_file_path() -> anyhow::Result<PathBuf> {
+    if let Ok(home) = std::env::var("LW_HOME") {
+        return Ok(PathBuf::from(home).join("version"));
+    }
+    let home = dirs::home_dir()
+        .ok_or_else(|| anyhow::anyhow!("Cannot resolve home directory"))?;
+    Ok(home.join(".llm-wiki").join("version"))
+}
+
+impl VersionFile {
+    pub fn load_from(path: &Path) -> anyhow::Result<Self> {
+        match std::fs::read_to_string(path) {
+            Ok(s) => Ok(toml::from_str(&s)?),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(Self::default()),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    pub fn save_to(&self, path: &Path) -> anyhow::Result<()> {
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let body = toml::to_string_pretty(self)?;
+        std::fs::write(path, body)?;
+        Ok(())
+    }
+
+    pub fn is_compatible(&self) -> bool {
+        !self.binary.is_empty() && self.binary == self.assets
+    }
+}
+
+pub const CURRENT_BINARY_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn load_returns_default_when_missing() {
+        let dir = TempDir::new().unwrap();
+        let v = VersionFile::load_from(&dir.path().join("nope")).unwrap();
+        assert_eq!(v, VersionFile::default());
+    }
+
+    #[test]
+    fn save_then_load_roundtrips() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("version");
+        let v = VersionFile {
+            binary: "0.2.0".into(),
+            assets: "0.2.0".into(),
+            installed_at: "2026-04-20T12:00:00Z".into(),
+        };
+        v.save_to(&path).unwrap();
+        let back = VersionFile::load_from(&path).unwrap();
+        assert_eq!(back, v);
+    }
+
+    #[test]
+    fn is_compatible_when_versions_match() {
+        let v = VersionFile {
+            binary: "0.2.0".into(),
+            assets: "0.2.0".into(),
+            installed_at: "x".into(),
+        };
+        assert!(v.is_compatible());
+    }
+
+    #[test]
+    fn is_incompatible_when_skewed() {
+        let v = VersionFile {
+            binary: "0.2.0".into(),
+            assets: "0.1.9".into(),
+            installed_at: "x".into(),
+        };
+        assert!(!v.is_compatible());
+    }
+
+    #[test]
+    fn is_incompatible_when_empty() {
+        let v = VersionFile::default();
+        assert!(!v.is_compatible());
+    }
+}
+```
+
+Add `mod version_file;` to `crates/lw-cli/src/main.rs`.
+
+- [ ] **Step 2: Run tests**
+
+```bash
+cargo test -p lw-cli version_file::
+```
+
+Expected: 5 passed.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add crates/lw-cli/src/version_file.rs crates/lw-cli/src/main.rs
+git commit -m "feat(lw-cli): add ~/.llm-wiki/version metadata file"
+```
+
+---
+
+## Task 2: `install.sh` — full installer script
+
+**Files:**
+
+- Create: `installer/install.sh`
+
+- [ ] **Step 1: Write the script**
+
+Create `installer/install.sh`:
+
+```sh
+#!/bin/sh
+# llm-wiki installer — curl-installable, idempotent, non-interactive by default.
+# Spec: docs/superpowers/specs/2026-04-19-llm-wiki-product-wrapper-design.md §7
+
+set -eu
+
+# --- Defaults & flags --------------------------------------------------------
+
+LW_INSTALL_PREFIX="${LW_INSTALL_PREFIX:-$HOME/.llm-wiki}"
+LW_VERSION="${LW_VERSION:-latest}"
+LW_REPO="${LW_REPO:-Pawpaw-Technology/llm-wiki}"
+LW_YES=0
+LW_NO_INTEGRATE=0
+
+usage() {
+  cat <<EOF
+Usage: install.sh [options]
+
+Options:
+  --yes, -y           Auto-integrate detected agent tools (no prompts)
+  --no-integrate      Install only; never prompt or write to agent configs
+  --prefix <dir>      Install to <dir> instead of \$HOME/.llm-wiki
+  --version <tag>     Install a specific release tag (default: latest)
+  --help, -h          Show this help
+
+Environment:
+  LW_INSTALL_PREFIX   Same as --prefix
+  LW_VERSION          Same as --version
+  LW_REPO             GitHub repo slug (default: Pawpaw-Technology/llm-wiki)
+EOF
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -y|--yes) LW_YES=1; shift ;;
+    --no-integrate) LW_NO_INTEGRATE=1; shift ;;
+    --prefix) LW_INSTALL_PREFIX="$2"; shift 2 ;;
+    --version) LW_VERSION="$2"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown flag: $1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+# --- TTY detection -----------------------------------------------------------
+
+if [ -t 1 ]; then
+  IS_TTY=1
+else
+  IS_TTY=0
+fi
+
+# --- OS / arch detection -----------------------------------------------------
+
+UNAME_S=$(uname -s)
+UNAME_M=$(uname -m)
+
+case "$UNAME_S" in
+  Darwin) OS=darwin ;;
+  Linux)  OS=linux ;;
+  *) echo "Unsupported OS: $UNAME_S (only macOS and Linux are supported in this version)" >&2; exit 1 ;;
+esac
+
+case "$UNAME_M" in
+  x86_64|amd64) ARCH=x86_64 ;;
+  arm64|aarch64) ARCH=aarch64 ;;
+  *) echo "Unsupported arch: $UNAME_M" >&2; exit 1 ;;
+esac
+
+ASSET="lw-${ARCH}-${OS}.tar.gz"
+
+# --- GitHub release URL resolution -------------------------------------------
+
+if [ "$LW_VERSION" = "latest" ]; then
+  BASE_URL="https://github.com/${LW_REPO}/releases/latest/download"
+else
+  BASE_URL="https://github.com/${LW_REPO}/releases/download/${LW_VERSION}"
+fi
+
+DIST_URL="${BASE_URL}/${ASSET}"
+SHA_URL="${BASE_URL}/${ASSET}.sha256"
+
+# --- Helper: fetch w/ curl preferred, wget fallback --------------------------
+
+fetch() {
+  url="$1"; out="$2"
+  if command -v curl >/dev/null 2>&1; then
+    curl -fsSL "$url" -o "$out"
+  elif command -v wget >/dev/null 2>&1; then
+    wget -qO "$out" "$url"
+  else
+    echo "Need curl or wget" >&2; exit 1
+  fi
+}
+
+# --- Helper: sha256 verify ---------------------------------------------------
+
+verify_sha256() {
+  file="$1"; expected_sha_file="$2"
+  if command -v shasum >/dev/null 2>&1; then
+    actual=$(shasum -a 256 "$file" | awk '{print $1}')
+  elif command -v sha256sum >/dev/null 2>&1; then
+    actual=$(sha256sum "$file" | awk '{print $1}')
+  else
+    echo "Need shasum or sha256sum" >&2; exit 1
+  fi
+  expected=$(awk '{print $1}' "$expected_sha_file")
+  if [ "$actual" != "$expected" ]; then
+    echo "sha256 mismatch! expected $expected, got $actual" >&2
+    exit 1
+  fi
+}
+
+# --- Download + verify -------------------------------------------------------
+
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT INT TERM
+
+echo "Fetching ${ASSET} from ${BASE_URL}..."
+fetch "$DIST_URL" "$TMPDIR/$ASSET"
+fetch "$SHA_URL" "$TMPDIR/$ASSET.sha256"
+verify_sha256 "$TMPDIR/$ASSET" "$TMPDIR/$ASSET.sha256"
+echo "  sha256 ok"
+
+# --- Extract -----------------------------------------------------------------
+
+mkdir -p "$LW_INSTALL_PREFIX"
+tar -C "$TMPDIR" -xzf "$TMPDIR/$ASSET"
+
+# Tarball layout (built by release.yml):
+#   lw                       binary
+#   skills/                  skills tree
+#   templates/               templates tree
+#   integrations/            descriptors
+#   installer/install.sh     this script (bundled for upgrade)
+#   installer/uninstall.sh
+#   VERSION                  e.g. "0.2.0"
+
+mkdir -p "$LW_INSTALL_PREFIX/bin"
+install -m 755 "$TMPDIR/lw" "$LW_INSTALL_PREFIX/bin/lw"
+
+# Replace asset trees atomically per directory
+for d in skills templates integrations installer; do
+  if [ -d "$TMPDIR/$d" ]; then
+    rm -rf "$LW_INSTALL_PREFIX/$d.new"
+    cp -R "$TMPDIR/$d" "$LW_INSTALL_PREFIX/$d.new"
+    rm -rf "$LW_INSTALL_PREFIX/$d"
+    mv "$LW_INSTALL_PREFIX/$d.new" "$LW_INSTALL_PREFIX/$d"
+  fi
+done
+
+# Make installer scripts executable
+[ -f "$LW_INSTALL_PREFIX/installer/install.sh" ] && chmod +x "$LW_INSTALL_PREFIX/installer/install.sh"
+[ -f "$LW_INSTALL_PREFIX/installer/uninstall.sh" ] && chmod +x "$LW_INSTALL_PREFIX/installer/uninstall.sh"
+
+# Write VERSION file
+RELEASE_VERSION=$(cat "$TMPDIR/VERSION" 2>/dev/null || echo "unknown")
+NOW_ISO=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+cat > "$LW_INSTALL_PREFIX/version" <<EOF
+binary = "${RELEASE_VERSION}"
+assets = "${RELEASE_VERSION}"
+installed_at = "${NOW_ISO}"
+EOF
+
+echo "Installed lw ${RELEASE_VERSION} to ${LW_INSTALL_PREFIX}"
+
+# --- PATH injection ----------------------------------------------------------
+
+inject_path() {
+  rc="$1"
+  marker_start="# >>> llm-wiki >>>"
+  marker_end="# <<< llm-wiki <<<"
+  block="${marker_start}
+export PATH=\"${LW_INSTALL_PREFIX}/bin:\$PATH\"
+${marker_end}"
+
+  [ ! -f "$rc" ] && return 0
+  if grep -q "$marker_start" "$rc" 2>/dev/null; then
+    return 0  # already present
+  fi
+  printf '\n%s\n' "$block" >> "$rc"
+  echo "  PATH appended to $rc"
+}
+
+case "${SHELL:-}" in
+  *zsh*)  inject_path "$HOME/.zshrc" ;;
+  *bash*) inject_path "$HOME/.bashrc"; inject_path "$HOME/.bash_profile" ;;
+  *fish*) inject_path "$HOME/.config/fish/config.fish" ;;
+  *) inject_path "$HOME/.profile" ;;
+esac
+
+# Ensure PATH is good for THIS shell session
+export PATH="${LW_INSTALL_PREFIX}/bin:$PATH"
+
+# --- Optional integration ---------------------------------------------------
+
+if [ "$LW_NO_INTEGRATE" -eq 1 ]; then
+  :
+elif [ "$LW_YES" -eq 1 ]; then
+  "$LW_INSTALL_PREFIX/bin/lw" integrate --auto --yes || true
+elif [ "$IS_TTY" -eq 1 ]; then
+  # Detect available tools, suggest commands
+  AVAIL=""
+  for d in "$HOME/.claude" "$HOME/.codex" "$HOME/.openclaw"; do
+    [ -d "$d" ] && AVAIL="${AVAIL} $(basename "$d" | sed 's/^.//')"
+  done
+  AVAIL=$(echo "$AVAIL" | sed 's/^ //')
+  if [ -n "$AVAIL" ]; then
+    echo ""
+    echo "Detected agent tools:${AVAIL}"
+    echo "Wire them up with: lw integrate --auto"
+    echo "(Pass --yes during install to do this automatically.)"
+  fi
+fi
+
+# --- Next steps --------------------------------------------------------------
+
+if [ "$IS_TTY" -eq 1 ]; then
+  cat <<EOF
+
+Next steps:
+  1. Restart your shell (or: source ${rc:-~/.profile})
+  2. lw workspace add my-vault ~/path/to/wiki --template general
+  3. lw integrate --auto    # if you skipped during install
+  4. Open your agent tool in the vault and try the llm-wiki:import skill
+
+Docs: https://github.com/${LW_REPO}#readme
+EOF
+fi
+```
+
+- [ ] **Step 2: Lint with shellcheck**
+
+```bash
+shellcheck installer/install.sh
+```
+
+Expected: no warnings. If shellcheck not installed: `brew install shellcheck` or skip and rely on CI.
+
+- [ ] **Step 3: Manual sanity check (parse only, do not run against real GitHub)**
+
+```bash
+sh -n installer/install.sh && echo "OK"
+```
+
+Expected: `OK` (syntax valid).
+
+```bash
+LW_REPO=fake/fake LW_VERSION=v0 sh installer/install.sh --help
+```
+
+Expected: usage block, exit 0.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add installer/install.sh
+git commit -m "feat(installer): add curl-installable install.sh"
+```
+
+---
+
+## Task 3: `uninstall.sh` — full reverse flow
+
+**Files:**
+
+- Create: `installer/uninstall.sh`
+
+- [ ] **Step 1: Write the script**
+
+Create `installer/uninstall.sh`:
+
+```sh
+#!/bin/sh
+# llm-wiki uninstaller — reverses install.sh per spec §11.5.
+
+set -eu
+
+LW_INSTALL_PREFIX="${LW_INSTALL_PREFIX:-$HOME/.llm-wiki}"
+LW_YES=0
+LW_KEEP_CONFIG=0
+LW_PURGE=0
+
+usage() {
+  cat <<EOF
+Usage: uninstall.sh [options]
+
+Options:
+  --yes, -y          Skip confirmation prompt
+  --keep-config      Preserve ~/.llm-wiki/config.toml in place
+  --purge            Also delete .bak files left by integration writes
+  --prefix <dir>     Override install prefix
+  --help, -h         Show this help
+EOF
+}
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -y|--yes) LW_YES=1; shift ;;
+    --keep-config) LW_KEEP_CONFIG=1; shift ;;
+    --purge) LW_PURGE=1; shift ;;
+    --prefix) LW_INSTALL_PREFIX="$2"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "Unknown flag: $1" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+if [ ! -d "$LW_INSTALL_PREFIX" ]; then
+  echo "Nothing to uninstall — $LW_INSTALL_PREFIX not present."
+  exit 0
+fi
+
+# --- Confirm ----------------------------------------------------------------
+
+if [ "$LW_YES" -ne 1 ] && [ -t 0 ]; then
+  printf "Uninstall llm-wiki from %s? [y/N] " "$LW_INSTALL_PREFIX"
+  read ans
+  case "$ans" in
+    y|Y|yes|YES) ;;
+    *) echo "Aborted."; exit 1 ;;
+  esac
+fi
+
+# --- Step 1: reverse integrations ------------------------------------------
+
+if [ -x "$LW_INSTALL_PREFIX/bin/lw" ] && [ -d "$LW_INSTALL_PREFIX/integrations" ]; then
+  echo "Reversing integrations..."
+  for tool_toml in "$LW_INSTALL_PREFIX/integrations/"*.toml; do
+    [ -f "$tool_toml" ] || continue
+    tool_id=$(basename "$tool_toml" .toml)
+    LW_INTEGRATIONS_DIR="$LW_INSTALL_PREFIX/integrations" \
+      LW_SKILLS_DIR="$LW_INSTALL_PREFIX/skills" \
+      LW_HOME="$LW_INSTALL_PREFIX" \
+      "$LW_INSTALL_PREFIX/bin/lw" integrate "$tool_id" --uninstall 2>/dev/null || \
+      echo "  (skipped $tool_id — not currently installed)"
+  done
+fi
+
+# --- Step 2: remove PATH marker block --------------------------------------
+
+strip_path_marker() {
+  rc="$1"
+  [ ! -f "$rc" ] && return 0
+  if ! grep -q "# >>> llm-wiki >>>" "$rc" 2>/dev/null; then
+    return 0
+  fi
+  tmp=$(mktemp)
+  awk '
+    /^# >>> llm-wiki >>>$/ { in_block=1; next }
+    /^# <<< llm-wiki <<<$/ { in_block=0; next }
+    !in_block { print }
+  ' "$rc" > "$tmp"
+  mv "$tmp" "$rc"
+  echo "  PATH marker removed from $rc"
+}
+
+for rc in "$HOME/.zshrc" "$HOME/.bashrc" "$HOME/.bash_profile" "$HOME/.profile" "$HOME/.config/fish/config.fish"; do
+  strip_path_marker "$rc"
+done
+
+# --- Step 3: preserve config, then remove ----------------------------------
+
+CONFIG="$LW_INSTALL_PREFIX/config.toml"
+if [ -f "$CONFIG" ] && [ "$LW_KEEP_CONFIG" -ne 1 ]; then
+  TS=$(date +%s)
+  BAK="$HOME/.llm-wiki.config.toml.bak.${TS}"
+  cp "$CONFIG" "$BAK"
+  echo "  config saved to $BAK"
+fi
+
+# --- Step 4: optional purge of integration backup files --------------------
+
+if [ "$LW_PURGE" -eq 1 ]; then
+  echo "Purging integration backup files..."
+  for d in "$HOME/.claude" "$HOME/.codex" "$HOME/.openclaw"; do
+    [ -d "$d" ] || continue
+    find "$d" -maxdepth 1 -name '*.bak.*' -print -delete 2>/dev/null || true
+  done
+fi
+
+# --- Step 5: remove install prefix -----------------------------------------
+
+if [ "$LW_KEEP_CONFIG" -eq 1 ] && [ -f "$CONFIG" ]; then
+  # Move config back into place after wipe? Simplest: skip wipe.
+  rm -rf "$LW_INSTALL_PREFIX/bin" "$LW_INSTALL_PREFIX/skills" \
+         "$LW_INSTALL_PREFIX/templates" "$LW_INSTALL_PREFIX/integrations" \
+         "$LW_INSTALL_PREFIX/installer" "$LW_INSTALL_PREFIX/version"
+  echo "  removed binary, skills, templates, integrations (config preserved)"
+else
+  rm -rf "$LW_INSTALL_PREFIX"
+  echo "  removed $LW_INSTALL_PREFIX"
+fi
+
+echo ""
+echo "Uninstall complete."
+echo "Vault directories were NOT touched. Check ~/.llm-wiki.config.toml.bak.* if you want to re-register."
+```
+
+- [ ] **Step 2: Lint + syntax check**
+
+```bash
+sh -n installer/uninstall.sh && echo "OK"
+shellcheck installer/uninstall.sh || true
+```
+
+Expected: `OK`. shellcheck warnings about `read ans` (POSIX `read` is fine) can be tolerated.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add installer/uninstall.sh
+git commit -m "feat(installer): add uninstall.sh per spec §11.5"
+```
+
+---
+
+## Task 4: `lw upgrade` Rust subcommand
+
+**Files:**
+
+- Create: `crates/lw-cli/src/upgrade.rs`
+- Modify: `crates/lw-cli/src/main.rs`
+
+- [ ] **Step 1: Write the upgrade module**
+
+Create `crates/lw-cli/src/upgrade.rs`:
+
+```rust
+use crate::version_file::{CURRENT_BINARY_VERSION, VersionFile, version_file_path};
+use serde::Deserialize;
+use std::process::Command;
+
+#[derive(Deserialize)]
+struct GhRelease {
+    tag_name: String,
+}
+
+const RELEASES_API: &str = "https://api.github.com/repos/Pawpaw-Technology/llm-wiki/releases/latest";
+
+pub fn check() -> anyhow::Result<()> {
+    let installed = VersionFile::load_from(&version_file_path()?)?;
+    let installed_str = if installed.binary.is_empty() {
+        CURRENT_BINARY_VERSION.to_string()
+    } else {
+        installed.binary.clone()
+    };
+    let latest = fetch_latest_tag()?;
+    let latest_clean = latest.trim_start_matches('v');
+    if latest_clean == installed_str {
+        println!("lw {installed_str} is up to date.");
+        Ok(())
+    } else {
+        println!("Newer release available: {latest} (installed: {installed_str})");
+        println!("Run `lw upgrade` to install.");
+        std::process::exit(1)
+    }
+}
+
+pub fn apply(yes: bool) -> anyhow::Result<()> {
+    let prefix = std::env::var("LW_INSTALL_PREFIX")
+        .unwrap_or_else(|_| {
+            dirs::home_dir()
+                .map(|h| h.join(".llm-wiki").display().to_string())
+                .unwrap_or_else(|| "$HOME/.llm-wiki".into())
+        });
+
+    let installer = std::path::PathBuf::from(&prefix)
+        .join("installer")
+        .join("install.sh");
+    if !installer.exists() {
+        anyhow::bail!(
+            "installer not found at {} — re-run the curl install command from the README",
+            installer.display()
+        );
+    }
+
+    let mut cmd = Command::new("sh");
+    cmd.arg(&installer);
+    if yes {
+        cmd.arg("--yes");
+    }
+    cmd.env("LW_INSTALL_PREFIX", &prefix);
+
+    let status = cmd.status()?;
+    if !status.success() {
+        anyhow::bail!("installer exited with {status}");
+    }
+    Ok(())
+}
+
+fn fetch_latest_tag() -> anyhow::Result<String> {
+    let resp = ureq::get(RELEASES_API)
+        .header("User-Agent", concat!("lw/", env!("CARGO_PKG_VERSION")))
+        .call()?;
+    let release: GhRelease = resp.into_body().read_json()?;
+    Ok(release.tag_name)
+}
+```
+
+- [ ] **Step 2: Wire into CLI**
+
+In `crates/lw-cli/src/main.rs`, add to `enum Commands`:
+
+```rust
+    /// Check for or apply a newer llm-wiki release
+    #[command(after_help = "Examples:\n  lw upgrade --check\n  lw upgrade\n  lw upgrade --yes")]
+    Upgrade {
+        /// Only check; do not download/replace
+        #[arg(long)]
+        check: bool,
+        /// Pass --yes to the installer (auto-integrate)
+        #[arg(short, long)]
+        yes: bool,
+    },
+```
+
+Add `mod upgrade;` near the top.
+
+In the `match cli.command`:
+
+```rust
+        Commands::Upgrade { check, yes } => {
+            if check {
+                upgrade::check()
+            } else {
+                upgrade::apply(yes)
+            }
+        }
+```
+
+- [ ] **Step 3: Build + smoke test**
+
+```bash
+cargo build -p lw-cli
+./target/debug/lw upgrade --help
+```
+
+Expected: help text. Do NOT run `lw upgrade --check` here without network; CI / smoke tests cover it.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/lw-cli/src/upgrade.rs crates/lw-cli/src/main.rs
+git commit -m "feat(lw-cli): add lw upgrade --check / apply"
+```
+
+---
+
+## Task 5: `lw uninstall` subcommand
+
+**Files:**
+
+- Create: `crates/lw-cli/src/uninstall.rs`
+- Modify: `crates/lw-cli/src/main.rs`
+
+- [ ] **Step 1: Write the uninstall wrapper**
+
+Create `crates/lw-cli/src/uninstall.rs`:
+
+```rust
+use std::process::Command;
+
+pub struct UninstallOpts {
+    pub yes: bool,
+    pub keep_config: bool,
+    pub purge: bool,
+}
+
+pub fn run(opts: UninstallOpts) -> anyhow::Result<()> {
+    let prefix = std::env::var("LW_INSTALL_PREFIX")
+        .unwrap_or_else(|_| {
+            dirs::home_dir()
+                .map(|h| h.join(".llm-wiki").display().to_string())
+                .unwrap_or_else(|| "$HOME/.llm-wiki".into())
+        });
+
+    let script = std::path::PathBuf::from(&prefix)
+        .join("installer")
+        .join("uninstall.sh");
+    if !script.exists() {
+        anyhow::bail!(
+            "uninstall script not found at {} — manual cleanup required (rm -rf ~/.llm-wiki and strip PATH marker)",
+            script.display()
+        );
+    }
+
+    let mut cmd = Command::new("sh");
+    cmd.arg(&script);
+    if opts.yes {
+        cmd.arg("--yes");
+    }
+    if opts.keep_config {
+        cmd.arg("--keep-config");
+    }
+    if opts.purge {
+        cmd.arg("--purge");
+    }
+    cmd.env("LW_INSTALL_PREFIX", &prefix);
+
+    let status = cmd.status()?;
+    if !status.success() {
+        anyhow::bail!("uninstall script exited with {status}");
+    }
+    Ok(())
+}
+```
+
+- [ ] **Step 2: Wire into CLI**
+
+In `crates/lw-cli/src/main.rs`, add to `enum Commands`:
+
+```rust
+    /// Remove llm-wiki from this machine (vault data preserved)
+    #[command(after_help = "Examples:\n  lw uninstall\n  lw uninstall --yes\n  lw uninstall --keep-config\n  lw uninstall --yes --purge")]
+    Uninstall {
+        /// Skip confirmation prompt
+        #[arg(short, long)]
+        yes: bool,
+        /// Keep ~/.llm-wiki/config.toml in place
+        #[arg(long)]
+        keep_config: bool,
+        /// Also delete .bak files left by past integration writes
+        #[arg(long)]
+        purge: bool,
+    },
+```
+
+Add `mod uninstall;` near the top.
+
+In the `match cli.command`:
+
+```rust
+        Commands::Uninstall { yes, keep_config, purge } => {
+            uninstall::run(uninstall::UninstallOpts { yes, keep_config, purge })
+        }
+```
+
+- [ ] **Step 3: Build + smoke test**
+
+```bash
+cargo build -p lw-cli
+./target/debug/lw uninstall --help
+```
+
+Expected: help text shows all flags.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/lw-cli/src/uninstall.rs crates/lw-cli/src/main.rs
+git commit -m "feat(lw-cli): add lw uninstall (wraps installer/uninstall.sh)"
+```
+
+---
+
+## Task 6: `release.yml` — bundle assets + publish install.sh as separate asset
+
+**Files:**
+
+- Modify: `.github/workflows/release.yml`
+
+- [ ] **Step 1: Replace release.yml**
+
+Replace `.github/workflows/release.yml` with:
+
+```yaml
+name: Release
+
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: write
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    name: Build (${{ matrix.target }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+            asset: lw-x86_64-linux.tar.gz
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+            asset: lw-aarch64-linux.tar.gz
+          - target: x86_64-apple-darwin
+            os: macos-latest
+            asset: lw-x86_64-darwin.tar.gz
+          - target: aarch64-apple-darwin
+            os: macos-latest
+            asset: lw-aarch64-darwin.tar.gz
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Install cross-compilation tools
+        if: matrix.target == 'aarch64-unknown-linux-gnu'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-aarch64-linux-gnu
+          echo "CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=aarch64-linux-gnu-gcc" >> "$GITHUB_ENV"
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.target }}
+
+      - name: Build release binary
+        run: cargo build --release --target ${{ matrix.target }} -p lw-cli
+
+      - name: Stage tarball contents
+        run: |
+          STAGE=stage
+          mkdir -p "$STAGE"
+          cp target/${{ matrix.target }}/release/lw "$STAGE/lw"
+          cp -R skills "$STAGE/skills"
+          cp -R templates "$STAGE/templates"
+          cp -R integrations "$STAGE/integrations"
+          mkdir -p "$STAGE/installer"
+          cp installer/install.sh "$STAGE/installer/"
+          cp installer/uninstall.sh "$STAGE/installer/"
+          chmod +x "$STAGE/installer/install.sh" "$STAGE/installer/uninstall.sh"
+          # VERSION = tag without leading 'v'
+          echo "${GITHUB_REF_NAME#v}" > "$STAGE/VERSION"
+
+      - name: Package tarball
+        run: |
+          mkdir -p dist
+          tar -C stage -czf dist/${{ matrix.asset }} .
+          shasum -a 256 dist/${{ matrix.asset }} | awk '{print $1"  "$2}' > dist/${{ matrix.asset }}.sha256
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.asset }}
+          path: dist/${{ matrix.asset }}*
+
+  publish-installer:
+    name: Publish install.sh as separate asset
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Stage installer + sha256
+        run: |
+          mkdir -p dist
+          cp installer/install.sh dist/install.sh
+          cp installer/uninstall.sh dist/uninstall.sh
+          shasum -a 256 dist/install.sh | awk '{print $1"  "$2}' > dist/install.sh.sha256
+          shasum -a 256 dist/uninstall.sh | awk '{print $1"  "$2}' > dist/uninstall.sh.sha256
+      - uses: actions/upload-artifact@v4
+        with:
+          name: installer-scripts
+          path: dist/*
+
+  release:
+    name: Create Release
+    needs: [build, publish-installer]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          merge-multiple: true
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: artifacts/*
+```
+
+- [ ] **Step 2: Validate workflow YAML**
+
+```bash
+# Use yamllint if available, otherwise just confirm parseability with python
+python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))" && echo "YAML OK"
+```
+
+Expected: `YAML OK`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/release.yml
+git commit -m "ci(release): bundle skills/templates/integrations + publish install.sh asset"
+```
+
+---
+
+## Task 7: Containerized smoke test
+
+**Files:**
+
+- Create: `installer/Dockerfile.test-linux`
+- Create: `installer/test-install.sh`
+
+- [ ] **Step 1: Create Dockerfile**
+
+Create `installer/Dockerfile.test-linux`:
+
+```dockerfile
+# Clean Linux env to smoke-test the installer end-to-end.
+# Build: docker build -f installer/Dockerfile.test-linux -t lw-installer-test .
+# Run:   docker run --rm -e LW_VERSION=v0.2.0 lw-installer-test
+
+FROM ubuntu:24.04
+
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+        curl ca-certificates tar gzip coreutils && \
+    rm -rf /var/lib/apt/lists/*
+
+RUN useradd -m tester
+USER tester
+WORKDIR /home/tester
+
+COPY --chown=tester:tester installer/test-install.sh /home/tester/test-install.sh
+RUN chmod +x /home/tester/test-install.sh
+
+ENTRYPOINT ["/home/tester/test-install.sh"]
+```
+
+- [ ] **Step 2: Create test driver**
+
+Create `installer/test-install.sh`:
+
+```sh
+#!/bin/sh
+# Fresh-machine smoke test for install.sh / uninstall.sh.
+# Usage inside container:
+#   LW_VERSION=v0.2.0 ./test-install.sh
+
+set -eu
+
+LW_VERSION="${LW_VERSION:-latest}"
+LW_REPO="${LW_REPO:-Pawpaw-Technology/llm-wiki}"
+
+echo "=== Test 1: install + verify binary present ==="
+curl -fsSL "https://github.com/${LW_REPO}/releases/${LW_VERSION#v}/download/install.sh" \
+  > /tmp/install.sh 2>/dev/null \
+  || curl -fsSL "https://github.com/${LW_REPO}/releases/latest/download/install.sh" > /tmp/install.sh
+sh /tmp/install.sh --no-integrate
+
+[ -x "$HOME/.llm-wiki/bin/lw" ] || { echo "FAIL: binary not installed"; exit 1; }
+[ -d "$HOME/.llm-wiki/skills" ] || { echo "FAIL: skills not extracted"; exit 1; }
+[ -d "$HOME/.llm-wiki/templates" ] || { echo "FAIL: templates not extracted"; exit 1; }
+[ -d "$HOME/.llm-wiki/integrations" ] || { echo "FAIL: integrations not extracted"; exit 1; }
+[ -f "$HOME/.llm-wiki/version" ] || { echo "FAIL: version file missing"; exit 1; }
+[ -x "$HOME/.llm-wiki/installer/uninstall.sh" ] || { echo "FAIL: uninstaller not bundled"; exit 1; }
+echo "  OK"
+
+echo "=== Test 2: PATH marker injected (.bashrc) ==="
+grep -q "# >>> llm-wiki >>>" "$HOME/.bashrc" || { echo "FAIL: PATH marker missing"; exit 1; }
+grep -q "# <<< llm-wiki <<<" "$HOME/.bashrc" || { echo "FAIL: PATH marker end missing"; exit 1; }
+echo "  OK"
+
+echo "=== Test 3: lw runs and prints version ==="
+export PATH="$HOME/.llm-wiki/bin:$PATH"
+lw --version >/dev/null 2>&1 || lw --help >/dev/null 2>&1 || { echo "FAIL: lw not runnable"; exit 1; }
+echo "  OK"
+
+echo "=== Test 4: workspace add --template general works ==="
+lw workspace add demo "$HOME/demo-vault" --template general
+[ -f "$HOME/demo-vault/SCOPE.md" ] || { echo "FAIL: template not copied"; exit 1; }
+[ -f "$HOME/demo-vault/.lw/schema.toml" ] || { echo "FAIL: schema not present"; exit 1; }
+echo "  OK"
+
+echo "=== Test 5: re-install is idempotent ==="
+sh /tmp/install.sh --no-integrate
+grep -c "# >>> llm-wiki >>>" "$HOME/.bashrc" | grep -q '^1$' \
+  || { echo "FAIL: PATH marker duplicated"; exit 1; }
+echo "  OK"
+
+echo "=== Test 6: uninstall --yes ==="
+sh "$HOME/.llm-wiki/installer/uninstall.sh" --yes
+[ ! -d "$HOME/.llm-wiki" ] || { echo "FAIL: install prefix not removed"; exit 1; }
+grep -q "# >>> llm-wiki >>>" "$HOME/.bashrc" 2>/dev/null \
+  && { echo "FAIL: PATH marker not stripped"; exit 1; }
+[ -d "$HOME/demo-vault" ] || { echo "FAIL: vault data was destroyed"; exit 1; }
+[ -f "$HOME/.llm-wiki.config.toml.bak."* ] 2>/dev/null \
+  || ls "$HOME"/.llm-wiki.config.toml.bak.* >/dev/null 2>&1 \
+  || echo "  (note: no config.toml.bak — expected if no workspaces had been registered)"
+echo "  OK"
+
+echo ""
+echo "=== ALL SMOKE TESTS PASSED ==="
+```
+
+- [ ] **Step 3: Local sanity check**
+
+```bash
+chmod +x installer/test-install.sh
+sh -n installer/test-install.sh && echo "OK"
+```
+
+Expected: `OK`. Do NOT actually run the test until a release exists; this is for the smoke-test phase in Plan D.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add installer/Dockerfile.test-linux installer/test-install.sh
+git commit -m "test(installer): add containerized smoke test driver"
+```
+
+---
+
+## Task 8: Final verification
+
+**Files:** None (verification only)
+
+- [ ] **Step 1: Workspace test pass**
+
+```bash
+cargo test --workspace -- --test-threads=1
+cargo clippy --workspace --all-targets -- -D warnings
+cargo fmt --all -- --check
+```
+
+Expected: all green.
+
+- [ ] **Step 2: Help command coverage**
+
+```bash
+cargo build -p lw-cli
+for c in workspace integrate upgrade uninstall; do
+  ./target/debug/lw $c --help >/dev/null && echo "  $c help OK"
+done
+```
+
+Expected: all four commands' help renders without error.
+
+- [ ] **Step 3: Manual end-to-end installer dry-run (no GitHub)**
+
+```bash
+# Stage a fake release locally
+mkdir -p /tmp/lw-fake-release
+mkdir -p /tmp/lw-fake-stage/installer
+cp target/debug/lw /tmp/lw-fake-stage/lw
+cp -R skills templates integrations /tmp/lw-fake-stage/
+cp installer/install.sh installer/uninstall.sh /tmp/lw-fake-stage/installer/
+echo "0.0.0-local" > /tmp/lw-fake-stage/VERSION
+tar -C /tmp/lw-fake-stage -czf /tmp/lw-fake-release/lw-$(uname -m | sed 's/arm64/aarch64/')-$(uname -s | tr '[:upper:]' '[:lower:]').tar.gz .
+shasum -a 256 /tmp/lw-fake-release/lw-*.tar.gz | awk '{print $1}' > /tmp/lw-fake-release/lw-$(uname -m | sed 's/arm64/aarch64/')-$(uname -s | tr '[:upper:]' '[:lower:]').tar.gz.sha256
+
+# Skip the real install.sh (it expects GitHub URL); manually verify tarball layout
+tar -tzf /tmp/lw-fake-release/lw-*.tar.gz | head -20
+```
+
+Expected: tarball lists `lw`, `skills/`, `templates/`, `integrations/`, `installer/`, `VERSION`.
+
+- [ ] **Step 4: Commit any final fixes**
+
+```bash
+git status
+# If clean, no commit needed.
+```
+
+---
+
+## Done criteria
+
+- `installer/install.sh` is a valid, shellcheck-clean POSIX script with `--yes` / `--no-integrate` / `--prefix` / `--version` flags
+- `installer/uninstall.sh` is a valid POSIX script implementing spec §11.5 reverse flow
+- `lw upgrade --check` queries GitHub releases API and exits 0/1 based on version comparison
+- `lw upgrade` execs the bundled `install.sh` for clean reinstall
+- `lw uninstall` execs the bundled `uninstall.sh` with passthrough flags
+- `release.yml` produces 4 platform tarballs containing binary + skills + templates + integrations + installer + VERSION; also publishes `install.sh` and `uninstall.sh` as separate assets with sha256
+- Containerized smoke test driver script exists for use in Plan D
+- All Rust tests green, clippy clean, fmt clean

--- a/docs/plans/2026-04-20-wrapper-plan-d-doctor-1.0-gate.md
+++ b/docs/plans/2026-04-20-wrapper-plan-d-doctor-1.0-gate.md
@@ -1,0 +1,1195 @@
+# Plan D — Multi-tool, Doctor, 1.0 Gate Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add Codex and OpenClaw integration descriptors, implement `lw doctor` with the full check matrix from spec §12, rewrite the user-facing README per §13, redirect the mono repo's install surface to the new curl line, and execute the three-part 1.0 gate (install / behavior / uninstall smoke tests on macOS + Linux across all three agent tools) — with transcripts committed under `docs/smoke-tests/v1.0.0/`.
+
+**Architecture:** `lw doctor` is a sequence of small check functions, each producing a `CheckResult { status, label, detail, remediation }`. The runner prints a checklist and exits non-zero if any check fails. Codex and OpenClaw descriptors reuse the same TOML schema as Claude Code (Plan B); OpenClaw's descriptor has no `[mcp]` section (skill-only path per spec §9). The 1.0 gate is a composite: automated install/uninstall via the container test driver from Plan C, plus manually-driven `llm-wiki:import` walkthroughs against each agent tool with the transcripts checked into the repo.
+
+**Tech Stack:** Rust 2024, existing deps. Smoke tests use Docker (Plan C's Dockerfile) for Linux, fresh macOS user accounts (or VMs) for darwin coverage.
+
+**Working dir:** `tool/llm-wiki/`. Depends on Plans A, B, C. The mono repo README edit happens in `llm-wiki-mono` (the parent repo); the agents README edit happens in `llm-wiki-agents`.
+
+**Spec reference:** `docs/superpowers/specs/2026-04-19-llm-wiki-product-wrapper-design.md` §9, §12, §13, §14.
+
+---
+
+## File structure
+
+| File                                              | Status  | Responsibility                                  |
+| ------------------------------------------------- | ------- | ----------------------------------------------- |
+| `integrations/codex.toml`                         | create  | Codex MCP + skills adapter                      |
+| `integrations/openclaw.toml`                      | create  | OpenClaw skill-only adapter                     |
+| `crates/lw-cli/src/doctor.rs`                     | create  | `lw doctor` checks + reporter                   |
+| `crates/lw-cli/src/main.rs`                       | modify  | Wire `Doctor` subcommand                        |
+| `crates/lw-cli/tests/doctor_cli.rs`               | create  | E2E doctor with controlled env                  |
+| `README.md` (llm-wiki repo)                       | rewrite | Per spec §13 user journey                       |
+| `docs/smoke-tests/v1.0.0/install-linux.log`       | create  | Captured during gate                            |
+| `docs/smoke-tests/v1.0.0/install-darwin.log`      | create  | Captured during gate                            |
+| `docs/smoke-tests/v1.0.0/behavior-claude-code.md` | create  | Transcript                                      |
+| `docs/smoke-tests/v1.0.0/behavior-codex.md`       | create  | Transcript                                      |
+| `docs/smoke-tests/v1.0.0/behavior-openclaw.md`    | create  | Transcript                                      |
+| `docs/smoke-tests/v1.0.0/uninstall.log`           | create  | Captured during gate                            |
+| (mono repo) `README.md`                           | modify  | Replace install instructions with curl redirect |
+| (agents repo) `README.md`                         | modify  | Point at new install method                     |
+
+---
+
+## Task 1: Codex + OpenClaw integration descriptors
+
+**Files:**
+
+- Create: `integrations/codex.toml`
+- Create: `integrations/openclaw.toml`
+
+- [ ] **Step 1: Create Codex descriptor**
+
+Codex stores config in `~/.codex/config.toml` and skills under `~/.codex/skills/`. (Per spec §9 table.)
+
+Create `integrations/codex.toml`:
+
+```toml
+name = "Codex"
+
+[detect]
+config_dir = "~/.codex"
+
+# Codex's MCP config is TOML, not JSON. The current MCP merge engine
+# (lw-cli/src/integrations/mcp.rs) only handles JSON. For 1.0 we ship the
+# descriptor with only the [skills] section so `lw integrate codex` performs
+# the skill-link half. The MCP wiring lands in 1.1 once the merge engine grows
+# TOML support; until then, README documents the manual MCP step for Codex.
+
+[skills]
+target_dir = "~/.codex/skills/llm-wiki/"
+mode = "symlink"
+```
+
+- [ ] **Step 2: Create OpenClaw descriptor**
+
+Per spec §9 table, OpenClaw is skill-only in 1.0 (user judgment: skill install is the bulk of value; MCP wiring lands in 1.1 if non-trivial).
+
+Create `integrations/openclaw.toml`:
+
+```toml
+name = "OpenClaw"
+
+[detect]
+config_dir = "~/.openclaw"
+
+[skills]
+target_dir = "~/.openclaw/skills/llm-wiki/"
+mode = "symlink"
+```
+
+- [ ] **Step 3: Verify descriptors parse**
+
+```bash
+cargo test -p lw-cli integrations::descriptor::tests::skills_only_descriptor_no_mcp -- --test-threads=1
+```
+
+Expected: passed (the test from Plan B Task 4 covers MCP-less descriptors; just confirm).
+
+```bash
+ls integrations/
+```
+
+Expected: `claude-code.toml`, `codex.toml`, `openclaw.toml`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add integrations/codex.toml integrations/openclaw.toml
+git commit -m "feat(integrations): add Codex and OpenClaw descriptors (skill-only for 1.0)"
+```
+
+---
+
+## Task 2: `lw doctor` — implementation
+
+**Files:**
+
+- Create: `crates/lw-cli/src/doctor.rs`
+- Modify: `crates/lw-cli/src/main.rs`
+
+- [ ] **Step 1: Write check infrastructure + tests**
+
+Create `crates/lw-cli/src/doctor.rs`:
+
+```rust
+use crate::config::{Config, config_path};
+use crate::integrations::{
+    descriptor::{Descriptor, expand_tilde},
+    integrations_root, load_all, mcp,
+};
+use crate::version_file::{CURRENT_BINARY_VERSION, VersionFile, version_file_path};
+use serde_json::Value;
+use std::path::PathBuf;
+use std::time::Duration;
+
+#[derive(Debug, PartialEq)]
+pub enum Status {
+    Ok,
+    Warn,
+    Fail,
+}
+
+#[derive(Debug)]
+pub struct CheckResult {
+    pub label: String,
+    pub status: Status,
+    pub detail: Option<String>,
+    pub remediation: Option<String>,
+}
+
+impl CheckResult {
+    pub fn ok(label: impl Into<String>, detail: impl Into<String>) -> Self {
+        Self {
+            label: label.into(),
+            status: Status::Ok,
+            detail: Some(detail.into()),
+            remediation: None,
+        }
+    }
+
+    pub fn warn(label: impl Into<String>, detail: impl Into<String>, remediation: impl Into<String>) -> Self {
+        Self {
+            label: label.into(),
+            status: Status::Warn,
+            detail: Some(detail.into()),
+            remediation: Some(remediation.into()),
+        }
+    }
+
+    pub fn fail(label: impl Into<String>, detail: impl Into<String>, remediation: impl Into<String>) -> Self {
+        Self {
+            label: label.into(),
+            status: Status::Fail,
+            detail: Some(detail.into()),
+            remediation: Some(remediation.into()),
+        }
+    }
+}
+
+pub fn run() -> anyhow::Result<()> {
+    let mut results = Vec::new();
+    results.push(check_binary());
+    results.push(check_path_env());
+    results.push(check_config_loadable());
+    results.push(check_current_workspace());
+    results.push(check_version_compat());
+    results.extend(check_integrations());
+    results.push(check_serve_smoke());
+
+    print_report(&results);
+
+    if results.iter().any(|r| r.status == Status::Fail) {
+        std::process::exit(1);
+    }
+    Ok(())
+}
+
+fn print_report(results: &[CheckResult]) {
+    println!("lw doctor");
+    println!("=========");
+    for r in results {
+        let mark = match r.status {
+            Status::Ok => "✓",
+            Status::Warn => "⚠",
+            Status::Fail => "✗",
+        };
+        println!("{mark} {}", r.label);
+        if let Some(d) = &r.detail {
+            println!("    {}", d);
+        }
+        if let Some(rem) = &r.remediation {
+            println!("    → {}", rem);
+        }
+    }
+    let fails = results.iter().filter(|r| r.status == Status::Fail).count();
+    let warns = results.iter().filter(|r| r.status == Status::Warn).count();
+    println!("---");
+    println!("{} passed, {} warned, {} failed", results.len() - fails - warns, warns, fails);
+}
+
+// --- Individual checks ---------------------------------------------------
+
+fn check_binary() -> CheckResult {
+    match std::env::current_exe() {
+        Ok(p) => CheckResult::ok(
+            "binary location",
+            format!("{} (v{CURRENT_BINARY_VERSION})", p.display()),
+        ),
+        Err(e) => CheckResult::fail("binary location", e.to_string(), "reinstall via curl install.sh"),
+    }
+}
+
+fn check_path_env() -> CheckResult {
+    let prefix = std::env::var("LW_INSTALL_PREFIX")
+        .ok()
+        .map(PathBuf::from)
+        .or_else(|| dirs::home_dir().map(|h| h.join(".llm-wiki")))
+        .map(|p| p.join("bin"));
+
+    let path_var = std::env::var("PATH").unwrap_or_default();
+    let in_path = match &prefix {
+        Some(p) => path_var.split(':').any(|seg| std::path::Path::new(seg) == p),
+        None => false,
+    };
+
+    match (prefix, in_path) {
+        (Some(p), true) => CheckResult::ok("PATH includes lw bin", p.display().to_string()),
+        (Some(p), false) => CheckResult::warn(
+            "PATH includes lw bin",
+            format!("{} not in PATH", p.display()),
+            "open a new shell, or `source ~/.zshrc` (or your rc file)".into(),
+        ),
+        (None, _) => CheckResult::fail(
+            "PATH includes lw bin",
+            "cannot resolve home dir".into(),
+            "set HOME or LW_INSTALL_PREFIX".into(),
+        ),
+    }
+}
+
+fn check_config_loadable() -> CheckResult {
+    let path = match config_path() {
+        Ok(p) => p,
+        Err(e) => return CheckResult::fail("config.toml", e.to_string(), "set HOME or LW_HOME"),
+    };
+    if !path.exists() {
+        return CheckResult::ok(
+            "config.toml",
+            format!("{} (not present — single-vault mode)", path.display()),
+        );
+    }
+    match Config::load_from(&path) {
+        Ok(_) => CheckResult::ok("config.toml", format!("{} parses", path.display())),
+        Err(e) => CheckResult::fail(
+            "config.toml",
+            format!("{} parse error: {e}", path.display()),
+            "edit by hand or `lw workspace remove` and re-add".into(),
+        ),
+    }
+}
+
+fn check_current_workspace() -> CheckResult {
+    let path = match config_path() {
+        Ok(p) => p,
+        Err(_) => return CheckResult::ok("current workspace", "skipped (no config dir)".into()),
+    };
+    let cfg = match Config::load_from(&path) {
+        Ok(c) => c,
+        Err(_) => return CheckResult::ok("current workspace", "skipped (config unparseable)".into()),
+    };
+    match cfg.workspace.current.as_deref() {
+        None => CheckResult::ok("current workspace", "(none — using cwd auto-discover)".into()),
+        Some(name) => match cfg.workspaces.get(name) {
+            Some(entry) if entry.path.exists() => {
+                CheckResult::ok("current workspace", format!("{name} → {}", entry.path.display()))
+            }
+            Some(entry) => CheckResult::fail(
+                "current workspace",
+                format!("{name} → {} (path does not exist)", entry.path.display()),
+                format!("`lw workspace use <other>` or recreate {}", entry.path.display()),
+            ),
+            None => CheckResult::fail(
+                "current workspace",
+                format!("'{name}' set as current but missing from workspaces table"),
+                "edit ~/.llm-wiki/config.toml or remove and re-add".into(),
+            ),
+        },
+    }
+}
+
+fn check_version_compat() -> CheckResult {
+    let path = match version_file_path() {
+        Ok(p) => p,
+        Err(_) => return CheckResult::warn("version file", "skipped".into(), "set HOME".into()),
+    };
+    let v = match VersionFile::load_from(&path) {
+        Ok(v) => v,
+        Err(e) => return CheckResult::fail("version file", e.to_string(), "reinstall".into()),
+    };
+    if v.binary.is_empty() && v.assets.is_empty() {
+        return CheckResult::warn(
+            "version file",
+            "missing — pre-installer setup or partial install".into(),
+            "run install.sh".into(),
+        );
+    }
+    if !v.is_compatible() {
+        return CheckResult::fail(
+            "binary/assets version",
+            format!("binary={}, assets={} (mismatch)", v.binary, v.assets),
+            "run `lw upgrade` to realign".into(),
+        );
+    }
+    CheckResult::ok(
+        "binary/assets version",
+        format!("both at {}", v.binary),
+    )
+}
+
+fn check_integrations() -> Vec<CheckResult> {
+    let mut out = Vec::new();
+    let descriptors = match load_all() {
+        Ok(d) => d,
+        Err(e) => {
+            out.push(CheckResult::warn(
+                "integrations",
+                e.to_string(),
+                "reinstall to restore integrations dir".into(),
+            ));
+            return out;
+        }
+    };
+    for (id, desc) in descriptors {
+        if !desc.detect_present() {
+            out.push(CheckResult::ok(
+                format!("integration: {id}"),
+                format!("{} not detected — skipped", desc.name),
+            ));
+            continue;
+        }
+        out.extend(check_one_integration(&id, &desc));
+    }
+    out
+}
+
+fn check_one_integration(id: &str, desc: &Descriptor) -> Vec<CheckResult> {
+    let mut out = Vec::new();
+    if let Some(mcp_cfg) = &desc.mcp {
+        let path = expand_tilde(&mcp_cfg.config_path);
+        if !path.exists() {
+            out.push(CheckResult::warn(
+                format!("integration: {id} (MCP)"),
+                format!("{} missing", path.display()),
+                format!("`lw integrate {id}` to install"),
+            ));
+        } else {
+            match std::fs::read_to_string(&path).and_then(|s| {
+                serde_json::from_str::<Value>(&s)
+                    .map_err(|e| std::io::Error::other(e.to_string()))
+            }) {
+                Ok(cfg) => {
+                    let parts: Vec<&str> = mcp_cfg.key_path.split('.').collect();
+                    let mut cursor = &cfg;
+                    let mut found = true;
+                    for p in &parts {
+                        match cursor.get(*p) {
+                            Some(c) => cursor = c,
+                            None => {
+                                found = false;
+                                break;
+                            }
+                        }
+                    }
+                    if !found || cursor.is_null() {
+                        out.push(CheckResult::warn(
+                            format!("integration: {id} (MCP)"),
+                            format!("entry {} not present", mcp_cfg.key_path),
+                            format!("`lw integrate {id}` to install"),
+                        ));
+                    } else {
+                        let entry_version = cursor
+                            .get(mcp::VERSION_MARKER)
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("(missing)");
+                        let cmd = cursor.get("command").and_then(|v| v.as_str()).unwrap_or("");
+                        // Stale binary path check: command is bare "lw" or absolute.
+                        // If absolute and points somewhere unexpected, warn.
+                        let cmd_warn = if cmd != "lw" {
+                            let p = std::path::Path::new(cmd);
+                            if p.is_absolute() && !p.exists() {
+                                Some(format!("MCP command points at non-existent {cmd}"))
+                            } else {
+                                None
+                            }
+                        } else {
+                            None
+                        };
+                        let label = format!("integration: {id} (MCP)");
+                        let detail = format!(
+                            "{} entry version={entry_version}",
+                            mcp_cfg.key_path
+                        );
+                        match cmd_warn {
+                            Some(w) => out.push(CheckResult::warn(label, w, format!("`lw integrate {id}` to refresh"))),
+                            None if entry_version != CURRENT_BINARY_VERSION => out.push(
+                                CheckResult::warn(
+                                    label,
+                                    format!("{detail} (current lw is {CURRENT_BINARY_VERSION})"),
+                                    format!("`lw integrate {id}` to refresh"),
+                                ),
+                            ),
+                            None => out.push(CheckResult::ok(label, detail)),
+                        }
+                    }
+                }
+                Err(e) => out.push(CheckResult::fail(
+                    format!("integration: {id} (MCP)"),
+                    format!("{} unparseable: {e}", path.display()),
+                    "restore from .bak.* file or repair JSON".into(),
+                )),
+            }
+        }
+    }
+    if let Some(skills_cfg) = &desc.skills {
+        let target = expand_tilde(&skills_cfg.target_dir);
+        if !target.exists() && target.symlink_metadata().is_err() {
+            out.push(CheckResult::warn(
+                format!("integration: {id} (skills)"),
+                format!("{} missing", target.display()),
+                format!("`lw integrate {id}` to install"),
+            ));
+        } else {
+            // If symlink, verify target resolves
+            match target.canonicalize() {
+                Ok(_) => out.push(CheckResult::ok(
+                    format!("integration: {id} (skills)"),
+                    target.display().to_string(),
+                )),
+                Err(e) => out.push(CheckResult::fail(
+                    format!("integration: {id} (skills)"),
+                    format!("{} dangling: {e}", target.display()),
+                    format!("`lw integrate {id}` to relink"),
+                )),
+            }
+        }
+    }
+    out
+}
+
+fn check_serve_smoke() -> CheckResult {
+    use std::process::{Command, Stdio};
+
+    let exe = match std::env::current_exe() {
+        Ok(p) => p,
+        Err(e) => return CheckResult::fail("lw serve smoke", e.to_string(), "reinstall".into()),
+    };
+    let tmp = match tempfile::TempDir::new() {
+        Ok(t) => t,
+        Err(e) => return CheckResult::fail("lw serve smoke", e.to_string(), "check disk space".into()),
+    };
+    // Initialize an empty wiki for the smoke test
+    let schema = lw_core::schema::WikiSchema::default();
+    if let Err(e) = lw_core::fs::init_wiki(tmp.path(), &schema) {
+        return CheckResult::fail("lw serve smoke", e.to_string(), "fs error".into());
+    }
+    let mut child = match Command::new(&exe)
+        .args(["serve", "--root"])
+        .arg(tmp.path())
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::null())
+        .spawn()
+    {
+        Ok(c) => c,
+        Err(e) => return CheckResult::fail("lw serve smoke", e.to_string(), "binary unrunnable".into()),
+    };
+
+    // Give it 200ms to come up. If it crashed, try_wait returns Some(status).
+    std::thread::sleep(Duration::from_millis(200));
+    match child.try_wait() {
+        Ok(Some(status)) => {
+            return CheckResult::fail(
+                "lw serve smoke",
+                format!("`lw serve` exited immediately with {status}"),
+                "check `RUST_LOG=debug lw serve` for the underlying error".into(),
+            );
+        }
+        Ok(None) => {}
+        Err(e) => return CheckResult::fail("lw serve smoke", e.to_string(), "process API error".into()),
+    }
+    let _ = child.kill();
+    let _ = child.wait();
+    CheckResult::ok("lw serve smoke", "starts and stays up for 200ms".into())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn with_env<F: FnOnce()>(home: &std::path::Path, f: F) {
+        let prev = std::env::var("LW_HOME").ok();
+        unsafe { std::env::set_var("LW_HOME", home) };
+        f();
+        match prev {
+            Some(p) => unsafe { std::env::set_var("LW_HOME", p) },
+            None => unsafe { std::env::remove_var("LW_HOME") },
+        }
+    }
+
+    #[test]
+    fn check_config_when_absent_is_ok() {
+        let home = TempDir::new().unwrap();
+        with_env(home.path(), || {
+            let r = check_config_loadable();
+            assert_eq!(r.status, Status::Ok);
+        });
+    }
+
+    #[test]
+    fn check_current_workspace_when_path_missing_fails() {
+        let home = TempDir::new().unwrap();
+        let cfg_dir = home.path();
+        let cfg = Config {
+            workspace: crate::config::WorkspaceState { current: Some("ghost".into()) },
+            workspaces: std::collections::BTreeMap::from([
+                (
+                    "ghost".to_string(),
+                    crate::config::WorkspaceEntry { path: PathBuf::from("/does/not/exist/x") },
+                ),
+            ]),
+        };
+        cfg.save_to(&cfg_dir.join("config.toml")).unwrap();
+        with_env(home.path(), || {
+            let r = check_current_workspace();
+            assert_eq!(r.status, Status::Fail);
+        });
+    }
+
+    #[test]
+    fn check_version_compat_warns_when_missing() {
+        let home = TempDir::new().unwrap();
+        with_env(home.path(), || {
+            let r = check_version_compat();
+            assert_eq!(r.status, Status::Warn);
+        });
+    }
+
+    #[test]
+    fn check_version_compat_fails_when_skewed() {
+        let home = TempDir::new().unwrap();
+        let v = VersionFile {
+            binary: "0.2.0".into(),
+            assets: "0.1.0".into(),
+            installed_at: "x".into(),
+        };
+        v.save_to(&home.path().join("version")).unwrap();
+        with_env(home.path(), || {
+            let r = check_version_compat();
+            assert_eq!(r.status, Status::Fail);
+        });
+    }
+
+    #[test]
+    fn check_serve_smoke_passes_with_real_binary() {
+        // This test only runs if the dev build has a `lw` binary at target/debug/lw
+        // Otherwise it would invoke the test harness binary, which would not be `lw`.
+        // We skip by checking current_exe name.
+        let exe = std::env::current_exe().unwrap();
+        let stem = exe.file_stem().and_then(|s| s.to_str()).unwrap_or("");
+        if !stem.starts_with("lw") {
+            // Not running as the lw binary — skip.
+            return;
+        }
+        let r = check_serve_smoke();
+        assert_eq!(r.status, Status::Ok);
+    }
+}
+```
+
+- [ ] **Step 2: Add `mod doctor;` to `crates/lw-cli/src/main.rs`**
+
+Insert near other mod declarations (alphabetic order).
+
+- [ ] **Step 3: Run unit tests**
+
+```bash
+cargo test -p lw-cli doctor:: -- --test-threads=1
+```
+
+Expected: 4 passed, 1 conditionally skipped depending on test binary name.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add crates/lw-cli/src/doctor.rs crates/lw-cli/src/main.rs
+git commit -m "feat(lw-cli): add lw doctor with full check matrix per spec §12"
+```
+
+---
+
+## Task 3: Wire `Doctor` subcommand + integration test
+
+**Files:**
+
+- Modify: `crates/lw-cli/src/main.rs`
+- Create: `crates/lw-cli/tests/doctor_cli.rs`
+
+- [ ] **Step 1: Wire subcommand**
+
+In `crates/lw-cli/src/main.rs`, add to `enum Commands`:
+
+```rust
+    /// Diagnose installation health (config, integrations, MCP, version skew)
+    #[command(after_help = "Examples:\n  lw doctor\n  # Exit 1 if any check fails; suitable for CI.")]
+    Doctor,
+```
+
+In the `match cli.command`:
+
+```rust
+        Commands::Doctor => doctor::run(),
+```
+
+- [ ] **Step 2: Build + smoke**
+
+```bash
+cargo build -p lw-cli
+LW_HOME=/tmp/lw-empty ./target/debug/lw doctor
+```
+
+Expected: prints checklist, mostly OKs and a few warns about absent config / version file. Exit 0 because no Fail.
+
+- [ ] **Step 3: Write integration test**
+
+Create `crates/lw-cli/tests/doctor_cli.rs`:
+
+```rust
+use assert_cmd::Command;
+use predicates::prelude::*;
+use tempfile::TempDir;
+
+fn lw(env_home: &std::path::Path) -> Command {
+    let mut cmd = Command::cargo_bin("lw").unwrap();
+    cmd.env("LW_HOME", env_home);
+    cmd.env_remove("LW_WIKI_ROOT");
+    cmd
+}
+
+#[test]
+fn doctor_clean_install_passes() {
+    let home = TempDir::new().unwrap();
+    // Stage a minimal "installed" layout
+    std::fs::create_dir_all(home.path().join("integrations")).unwrap();
+    std::fs::create_dir_all(home.path().join("skills/llm-wiki-import")).unwrap();
+    std::fs::write(
+        home.path().join("skills/llm-wiki-import/SKILL.md"),
+        "---\nname: llm-wiki:import\n---\n",
+    )
+    .unwrap();
+    std::fs::write(
+        home.path().join("version"),
+        format!(
+            "binary = \"{}\"\nassets = \"{}\"\ninstalled_at = \"now\"\n",
+            env!("CARGO_PKG_VERSION"),
+            env!("CARGO_PKG_VERSION")
+        ),
+    )
+    .unwrap();
+
+    lw(home.path())
+        .args(["doctor"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("lw doctor"))
+        .stdout(predicate::str::contains("✓"));
+}
+
+#[test]
+fn doctor_fails_on_version_skew() {
+    let home = TempDir::new().unwrap();
+    std::fs::create_dir_all(home.path().join("integrations")).unwrap();
+    std::fs::write(
+        home.path().join("version"),
+        "binary = \"0.2.0\"\nassets = \"0.1.0\"\ninstalled_at = \"now\"\n",
+    )
+    .unwrap();
+
+    lw(home.path())
+        .args(["doctor"])
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains("✗"));
+}
+
+#[test]
+fn doctor_fails_on_missing_workspace_path() {
+    let home = TempDir::new().unwrap();
+    std::fs::create_dir_all(home.path().join("integrations")).unwrap();
+    std::fs::write(
+        home.path().join("config.toml"),
+        r#"[workspace]
+current = "ghost"
+
+[workspaces.ghost]
+path = "/does/not/exist/abc123"
+"#,
+    )
+    .unwrap();
+
+    lw(home.path())
+        .args(["doctor"])
+        .assert()
+        .failure()
+        .stdout(predicate::str::contains("path does not exist"));
+}
+```
+
+- [ ] **Step 4: Run integration test**
+
+```bash
+cargo test -p lw-cli --test doctor_cli -- --test-threads=1
+```
+
+Expected: 3 passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add crates/lw-cli/src/main.rs crates/lw-cli/tests/doctor_cli.rs
+git commit -m "feat(lw-cli): wire Doctor subcommand + e2e integration tests"
+```
+
+---
+
+## Task 4: README rewrite (llm-wiki repo)
+
+**Files:**
+
+- Modify: `README.md` (in the llm-wiki repo root)
+
+- [ ] **Step 1: Rewrite README per spec §13**
+
+Replace `README.md` (in the llm-wiki repo, i.e. `tool/llm-wiki/README.md` from mono's perspective) with:
+
+````markdown
+# llm-wiki
+
+A CLI + skill bundle that turns any markdown folder into an agent-driven knowledge base. Bring your own data; bring your own agent tool. Built for Claude Code, Codex, and OpenClaw.
+
+> Why not just `markdown folder + filesystem MCP`? llm-wiki adds scope-gated ingest (`SCOPE.md` controls what gets in), wiki-aware operations (lint, freshness, orphans, broken links via git), and curated skills that turn import + curate into one-shot agent actions instead of N-step manual prompting.
+
+## Install
+
+```bash
+curl -fsSL https://github.com/Pawpaw-Technology/llm-wiki/releases/latest/download/install.sh | sh
+```
+````
+
+The installer fetches the matching prebuilt binary for your platform (macOS / Linux, x86_64 / aarch64), verifies sha256, and stages everything under `~/.llm-wiki/`. Pin a version: `... releases/download/v0.2.0/install.sh`. CI / unattended? Append `--no-integrate` (default for non-TTY) or `--yes` (auto-integrate detected agent tools).
+
+## First vault, with a template
+
+```bash
+lw workspace add my-research ~/wiki/research --template research-papers
+lw integrate --auto
+```
+
+The `--template` flag copies a starter vault (3 templates ship: `general`, `research-papers`, `engineering-notes`), each with a `SCOPE.md` and a category schema you can edit. `lw integrate --auto` detects installed agent tools and wires up the MCP server + canonical skill.
+
+## Daily use
+
+Open your agent tool inside the vault. The `llm-wiki:import` skill triggers on phrases like "add this to my wiki" or "save this article":
+
+```
+You: add this to my wiki — https://arxiv.org/abs/2501.12345
+Agent: [fetches paper, reads SCOPE.md, judges fit]
+       Fits the "research papers" scope. Filing under raw/papers/2501.12345.md.
+       Want me to draft a wiki page summary too?
+```
+
+Out-of-scope content prompts before being silently dropped:
+
+```
+You: add my grocery list to the wiki
+Agent: This looks out of scope (vault Purpose: ML research papers). Add anyway, or skip?
+```
+
+## Multiple vaults (Obsidian-style, optional)
+
+```bash
+lw workspace add personal ~/notes/personal --template general
+lw workspace use personal      # current
+lw workspace use my-research   # switch
+lw workspace list
+```
+
+Switching vaults requires restarting your agent tool — the MCP server binds the current vault at launch (so an in-flight session can't silently flip mid-conversation).
+
+## Update
+
+```bash
+lw upgrade --check    # exit 1 if newer release exists
+lw upgrade            # apply
+```
+
+## Troubleshoot
+
+```bash
+lw doctor             # one-shot health check (config, integrations, MCP, version compat)
+lw workspace current -v   # show full root-resolution chain
+```
+
+Backups from MCP config writes land at `<config>.bak.<timestamp>` next to the original file. The uninstaller (`lw uninstall`) preserves your vault directories and saves `~/.llm-wiki/config.toml` to `~/.llm-wiki.config.toml.bak.<timestamp>` so reinstalls can restore vault registrations.
+
+## Architecture
+
+- `lw-core` — wiki I/O, search (Tantivy), lint
+- `lw-mcp` — MCP server library
+- `lw-cli` — `lw` binary (umbrella for workspace / integrate / upgrade / uninstall / doctor + the original wiki commands)
+- `skills/llm-wiki-import/` — canonical agent skill
+- `templates/` — starter vaults
+- `integrations/` — TOML descriptors per agent tool
+
+Tool is open source; wiki content repos are private (BYO).
+
+## Status
+
+- 1.0: Claude Code (full), Codex (skills + manual MCP), OpenClaw (skill-only)
+- 1.1 roadmap: Codex MCP wiring, OpenClaw MCP wiring, `llm-wiki:curate` skill, more templates
+
+## License
+
+MIT.
+
+````
+
+- [ ] **Step 2: Verify README renders**
+
+```bash
+# Sanity check: must mention install, workspace, integrate, upgrade, doctor, uninstall.
+for k in install workspace integrate upgrade doctor uninstall; do
+  grep -q "lw $k" README.md && echo "  $k mention OK"
+done
+````
+
+Expected: all 6 confirmations.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add README.md
+git commit -m "docs(README): rewrite for product wrapper user journey per spec §13"
+```
+
+---
+
+## Task 5: Mono repo + agents repo README updates (out-of-tree)
+
+These edits happen in **different repos** (not the llm-wiki product repo). Push through the existing PR flow for those repos. Do them in this order so the install path works before mono points users at it:
+
+- [ ] **Step 1: Confirm Plan C release tag exists**
+
+```bash
+gh release list --repo Pawpaw-Technology/llm-wiki | head -1
+```
+
+Expected: at least `v0.2.0` (or whatever Plan C's first release was). If nothing released yet, **stop here and finish Plan C** before continuing.
+
+- [ ] **Step 2: Edit mono README**
+
+In `llm-wiki-mono` repo (path on disk: `/Users/vergil/Devwork/homebrew/llm-wiki-mono` or the mono root):
+
+Replace the top-level "Install" section of `README.md` (and anywhere else install instructions live) with:
+
+```markdown
+## Install (end users)
+
+This repo is the development workspace for the llm-wiki ecosystem. **End users should not clone this repo.** Install from the product:
+
+\`\`\`bash
+curl -fsSL https://github.com/Pawpaw-Technology/llm-wiki/releases/latest/download/install.sh | sh
+\`\`\`
+
+This monorepo continues to exist for **dev-time context engineering** (co-locating tool + agents + codebridge for navigation), not as the install surface.
+```
+
+(Replace the literal `\` with backslash; the markdown above is showing escaped fences inside the plan.)
+
+Commit in the mono repo:
+
+```bash
+git add README.md
+git commit -m "docs: redirect install to llm-wiki curl line; mono is dev workspace only"
+git push
+```
+
+- [ ] **Step 3: Edit agents repo README**
+
+In `llm-wiki-agents` repo (path on disk: `tool/.../agents` from mono, or its own clone):
+
+Add to the top of `README.md`:
+
+```markdown
+## Prerequisites
+
+The `lw` CLI must be installed and on PATH:
+
+\`\`\`bash
+curl -fsSL https://github.com/Pawpaw-Technology/llm-wiki/releases/latest/download/install.sh | sh
+\`\`\`
+
+This package is the **batch / cron orchestration layer** that calls `lw` for bulk operations. End users typically interact via the agent tool (Claude Code / Codex / OpenClaw); this layer is for scheduled jobs (daily ingest, weekly lint, etc.).
+```
+
+Commit + push in agents repo.
+
+- [ ] **Step 4: Verify**
+
+```bash
+# In mono:
+grep -A3 "## Install" /Users/vergil/Devwork/homebrew/llm-wiki-mono/README.md
+# In agents:
+grep "curl -fsSL" tool/llm-wiki-mono/agents/README.md   # adjust path
+```
+
+Expected: each shows the curl line.
+
+---
+
+## Task 6: 1.0 gate execution — install / behavior / uninstall smoke tests
+
+This task is **manual + scripted** and produces transcripts that go in the repo as evidence per spec §14.
+
+**Files (created during execution):**
+
+- `docs/smoke-tests/v1.0.0/install-linux.log`
+- `docs/smoke-tests/v1.0.0/install-darwin.log`
+- `docs/smoke-tests/v1.0.0/behavior-claude-code.md`
+- `docs/smoke-tests/v1.0.0/behavior-codex.md`
+- `docs/smoke-tests/v1.0.0/behavior-openclaw.md`
+- `docs/smoke-tests/v1.0.0/uninstall.log`
+
+- [ ] **Step 1: Cut a candidate release**
+
+Tag `v1.0.0-rc.1` (or next available rc) and push:
+
+```bash
+git tag v1.0.0-rc.1
+git push origin v1.0.0-rc.1
+```
+
+Wait for `release.yml` to finish; verify all 4 platform tarballs + install.sh + sha256 are uploaded:
+
+```bash
+gh release view v1.0.0-rc.1
+```
+
+Expected: 11+ assets (4 tarballs × 2 (file + sha) + install.sh + uninstall.sh + their sha256).
+
+- [ ] **Step 2: Linux install smoke (containerized)**
+
+```bash
+docker build -f installer/Dockerfile.test-linux -t lw-installer-test .
+docker run --rm -e LW_VERSION=v1.0.0-rc.1 lw-installer-test 2>&1 | tee /tmp/install-linux.log
+```
+
+Expected: ends with `=== ALL SMOKE TESTS PASSED ===`. If not: fix the issue, cut `v1.0.0-rc.2`, retry.
+
+Save the log:
+
+```bash
+mkdir -p docs/smoke-tests/v1.0.0
+cp /tmp/install-linux.log docs/smoke-tests/v1.0.0/install-linux.log
+```
+
+- [ ] **Step 3: Darwin install smoke (manual on a clean macOS user account)**
+
+Create a fresh macOS user account (System Settings → Users), log in, open Terminal:
+
+```bash
+LW_VERSION=v1.0.0-rc.1 sh -c "$(curl -fsSL https://github.com/Pawpaw-Technology/llm-wiki/releases/download/v1.0.0-rc.1/install.sh)" 2>&1 | tee /tmp/install-darwin.log
+exec $SHELL
+lw --version
+lw workspace add demo ~/demo-vault --template general
+lw doctor
+```
+
+Capture the log; copy back to dev machine and place at `docs/smoke-tests/v1.0.0/install-darwin.log`.
+
+- [ ] **Step 4: Behavior smoke — Claude Code**
+
+In a fresh Claude Code session inside the demo vault (created in Step 2 or 3):
+
+1. Test in-scope import:
+   - Prompt: `add this to my wiki — https://arxiv.org/abs/2305.10601`
+   - Expected: agent invokes `wiki_ingest`, files under `raw/`, prints confirmation.
+2. Test out-of-scope:
+   - Prompt: `add my shopping list (eggs, milk, bread) to the wiki`
+   - Expected: agent asks for confirmation since it doesn't fit "general"/"research" scope, does NOT silent-import.
+
+Capture the conversation (copy the full transcript from Claude Code's UI) and write to `docs/smoke-tests/v1.0.0/behavior-claude-code.md` with format:
+
+```markdown
+# Claude Code — llm-wiki:import smoke test (v1.0.0-rc.1)
+
+Date: <date>
+Vault: ~/demo-vault (template: general)
+Tool: Claude Code <version>
+
+## Test 1: in-scope URL
+
+> User: add this to my wiki — https://arxiv.org/abs/2305.10601
+
+[paste full transcript of agent response and tool calls]
+
+## Test 2: out-of-scope item
+
+> User: add my shopping list...
+
+[paste full transcript]
+
+## Result
+
+- [ ] Test 1: in-scope import → file written to raw/papers/...
+- [ ] Test 2: out-of-scope → agent asked for confirmation, did not silent-import
+
+PASS / FAIL / DOWNGRADED
+```
+
+Mark the result.
+
+- [ ] **Step 5: Behavior smoke — Codex**
+
+Repeat Step 4 in a fresh Codex session. Note: in 1.0 the Codex MCP entry must be wired manually (per `integrations/codex.toml` comment). Document the manual step in the transcript:
+
+```markdown
+## Setup notes (1.0 limitation)
+
+Codex MCP wiring is manual in 1.0. Prior to this test we ran:
+\`\`\`
+echo '[mcp_servers.llm-wiki]
+command = "lw"
+args = ["serve"]
+' >> ~/.codex/config.toml
+\`\`\`
+```
+
+If the skill cannot be triggered because Codex doesn't expose a skill concept the way Claude Code does, mark `DOWNGRADED` and document what works (e.g., the import flow works manually by quoting the SKILL.md prompt) — per spec §14 step 5 "Tools where the skill prompt cannot be triggered faithfully ... downgrade to documented limitation in 1.0".
+
+- [ ] **Step 6: Behavior smoke — OpenClaw**
+
+Repeat Step 4 in OpenClaw (skill-only path; per Task 1, no MCP wiring in 1.0). The skill is dropped into `~/.openclaw/skills/llm-wiki/`. If OpenClaw exposes the skill content to its agent, run the two tests; if it doesn't (skill-only means user manually invokes the prompt), document that limitation and mark `DOWNGRADED`.
+
+- [ ] **Step 7: Uninstall smoke**
+
+On Linux container:
+
+```bash
+docker run --rm -e LW_VERSION=v1.0.0-rc.1 --entrypoint /bin/sh lw-installer-test -c "
+  /home/tester/test-install.sh && \
+  echo '--- uninstall ---' && \
+  sh \$HOME/.llm-wiki/installer/uninstall.sh --yes && \
+  [ ! -d \$HOME/.llm-wiki ] && echo OK && \
+  [ -d \$HOME/demo-vault ] && echo VAULT_PRESERVED
+" 2>&1 | tee /tmp/uninstall.log
+```
+
+Expected: ends with `OK` then `VAULT_PRESERVED`.
+
+Save: `cp /tmp/uninstall.log docs/smoke-tests/v1.0.0/uninstall.log`.
+
+- [ ] **Step 8: Commit transcripts**
+
+```bash
+git add docs/smoke-tests/v1.0.0/
+git commit -m "test(smoke): v1.0.0-rc.1 install/behavior/uninstall transcripts across 3 tools"
+```
+
+- [ ] **Step 9: 1.0 gate decision**
+
+Open the spec § "1.0 gate (composite)" and tick each:
+
+- (install) `lw doctor` green on macOS + Linux for Claude Code, Codex, OpenClaw
+- (behavior) `llm-wiki:import` end-to-end transcript per tool, with in-scope / out-of-scope cases both behaving correctly (PASS or documented DOWNGRADED with reason)
+- (uninstall) `lw uninstall` reverses, leaves vault data untouched
+
+If all three are green (or documented downgrades), proceed to Task 7. If any **regress** (not just downgrade) — fix and cut the next rc.
+
+---
+
+## Task 7: Tag and ship 1.0.0
+
+**Files:** None (release operation)
+
+- [ ] **Step 1: Update version in workspace Cargo.toml**
+
+If the rc was on a different version field, bump to the final:
+
+```bash
+# Edit Cargo.toml workspace.package.version → "1.0.0"
+sed -i.bak 's/version.workspace = true/version.workspace = true/' crates/*/Cargo.toml  # no-op if already
+# Edit the workspace Cargo.toml manually:
+#   [workspace.package]
+#   version = "1.0.0"
+cargo build --release -p lw-cli   # verify
+```
+
+- [ ] **Step 2: Commit version bump**
+
+```bash
+git add Cargo.toml Cargo.lock
+git commit -m "chore: bump version to 1.0.0"
+```
+
+- [ ] **Step 3: Tag and push**
+
+```bash
+git tag v1.0.0
+git push origin main
+git push origin v1.0.0
+```
+
+- [ ] **Step 4: Verify release**
+
+```bash
+gh release view v1.0.0
+```
+
+Expected: full asset list per Plan C release.yml (4 tarballs + install.sh + uninstall.sh + sha256 each).
+
+Edit release notes to include link to the smoke-test transcripts:
+
+```bash
+gh release edit v1.0.0 --notes "$(cat <<'EOF'
+First general-availability release.
+
+## Quick start
+\`\`\`bash
+curl -fsSL https://github.com/Pawpaw-Technology/llm-wiki/releases/latest/download/install.sh | sh
+\`\`\`
+
+## Cross-tool support (1.0)
+- Claude Code — full (MCP + skills)
+- Codex — skills + manual MCP setup (auto MCP wiring in 1.1)
+- OpenClaw — skills only (MCP wiring evaluated for 1.1)
+
+## Verified by
+Smoke transcripts in [docs/smoke-tests/v1.0.0/](https://github.com/Pawpaw-Technology/llm-wiki/tree/main/docs/smoke-tests/v1.0.0).
+
+## Roadmap
+See spec §15 in repo for deferred items (Homebrew, cargo install, signed releases, curate skill, more templates).
+EOF
+)"
+```
+
+- [ ] **Step 5: Post-release: edit mono README + agents README to reference v1.0.0**
+
+In mono and agents repos, replace `releases/latest` references in the install line with `releases/download/v1.0.0` if you want pinned, or leave as `latest` (recommended for evergreen). Push.
+
+---
+
+## Known 1.0 limitations (deferred to 1.1)
+
+Two spec items intentionally **not** implemented in this plan; document in release notes and revisit:
+
+1. **Running `lw serve` mismatch detection** (spec §4.1, §12). Cross-platform process introspection (parse `ps` for live `lw serve --root <X>` whose `<X>` differs from the current registered workspace) is non-trivial and platform-specific. For 1.0, `lw doctor` documents the behavior in its output ("note: running MCP processes bind their vault at launch — restart your agent if you switched"). 1.1 will add the actual scan.
+2. **Startup upgrade nudge** (spec §11). The 24h-cached "newer release available" hint on `lw` startup is not wired in 1.0 — `lw upgrade --check` is the explicit workaround. 1.1 will add the cached background check, suppressed in non-TTY / `CI=1` / `LW_NO_NUDGE=1` per spec.
+
+---
+
+## Done criteria
+
+- `integrations/codex.toml` and `integrations/openclaw.toml` shipped, both pass parsing and `lw integrate <tool>` runs without error
+- `lw doctor` implements all checks from spec §12, exits non-zero on Fail, prints checklist with remediation
+- README rewritten per spec §13 (install / first-vault / daily-use / multi-vault / upgrade / troubleshoot / architecture / status / license)
+- Mono repo README install-surface removed; replaced with redirect to curl line
+- Agents repo README updated to reference new install
+- 1.0 composite gate executed: install (containerized Linux + manual darwin), behavior (transcripts per tool, downgrades documented), uninstall (containerized) — transcripts committed under `docs/smoke-tests/v1.0.0/`
+- `v1.0.0` tag pushed; release notes link transcripts and document tool-tier matrix
+- All Rust tests green, clippy clean, fmt clean

--- a/docs/specs/2026-04-19-product-wrapper-design.md
+++ b/docs/specs/2026-04-19-product-wrapper-design.md
@@ -1,0 +1,381 @@
+# LLM Wiki — Product Wrapper Design
+
+**Date:** 2026-04-19 (revised 2026-04-20 after multi-reviewer pass)
+**Status:** Approved (brainstorm + review)
+**Scope:** Turn `llm-wiki` from a tool repo into a self-contained, installable open-source product. Repurpose the mono repo from install surface into dev workspace.
+
+---
+
+## 1. Problem
+
+Today the `llm-wiki` ecosystem is assembled by humans: clone mono repo → init submodules → build Rust → wire MCP into Claude Code by hand → maintain a private wiki repo. There is no path for an outside open-source user to one-click install and start using it under their own agent tool (Claude Code, Codex, OpenClaw, …).
+
+The mono repo also conflates two roles: (a) co-locating code for context engineering, (b) being the install surface. (b) is wrong — products should ship from a single self-contained repo, not from a git-submodule meta-layout. (a) is still useful and stays.
+
+## 1.5 Why this, not Obsidian + filesystem-MCP
+
+A markdown folder + filesystem MCP gives an agent generic file ops. `llm-wiki` adds:
+
+- **Scope-gated ingest** — the import flow is opinionated: fetch, parse, scope-check, route to `raw/` vs wiki page; never silent-fails on out-of-scope.
+- **Wiki-aware operations** — `wiki_query`, `wiki_lint`, `wiki_browse`, `wiki_tags` understand the wiki's structure (categories, tags, freshness from git, orphans, broken links). A filesystem MCP doesn't.
+- **Curated skills** — packaged prompts that turn the import / curate workflows into one-shot agent actions instead of N-step manual prompts.
+- **Single curl install** — no Obsidian app, no plugin marketplace, runs anywhere a CLI runs (servers, headless dev boxes).
+
+Obsidian + fs-MCP can read your notes; `llm-wiki` is built to _grow_ and _maintain_ a knowledge base under agent guidance.
+
+## 2. Goals
+
+- One-line `curl | sh` install for any macOS / Linux user.
+- llm-wiki becomes a **product umbrella** (like Claude Code): a single user-facing thing built from layered crates, distributed as one binary + skills.
+- Multi-vault, Obsidian-style: users register multiple wiki workspaces and switch between them. Single-vault users pay nothing for this — workspace registry is opt-in; absent registration falls back to cwd auto-discover.
+- Cross-agent-tool: 1.0 ships with Claude Code, Codex, OpenClaw integrations.
+- BYO data: no bundled wiki content; users point at their own repo / local dir, or start from a template.
+- Updates flow from upstream via `lw upgrade`.
+
+**Primary user (1.0):** engineers and researchers who already drive their day with an agent CLI and want a managed wiki layer with opinionated import + lint, not just a markdown folder.
+
+**Leading indicators (post-launch tracking, no telemetry):**
+
+- GitHub release download counts per version
+- GitHub stars (weak adoption proxy)
+- Manual install survey via README link (opt-in form)
+
+No phone-home metrics. OSS users get to stay anonymous.
+
+## 3. Non-goals
+
+- No built-in agent loop (`lw chat`). The user's existing agent tool drives interaction via MCP.
+- No bundled batch/cron orchestration in the product. The TS `agents/` repo and `codebridge` stay separate, consume `lw` via CLI, and are advanced/team-scope.
+- No new repo for the installer. Everything lives in `llm-wiki`.
+- Windows is out of scope for 1.0 (revisit in 1.x).
+- No telemetry / phone-home in any form.
+
+## 4. Architecture
+
+```
+┌─────────────────────────────────────────────────┐
+│  llm-wiki  (umbrella product repo)              │
+│  - installer (curl install.sh)                   │
+│  - skills/ (canonical, agent-tool agnostic)     │
+│  - templates/ (starter vaults)                  │
+│  - lw binary (workspace, upgrade, integrate +    │
+│    existing query/ingest/lint/serve commands)    │
+│  Install targets:                                │
+│    ~/.llm-wiki/   (binary, skills, templates,   │
+│                     config, version)             │
+│    integrations write into each agent tool's     │
+│    config dir (~/.claude, ~/.codex, ...)         │
+└─────────────────────────────────────────────────┘
+         │  cargo workspace
+         ├── lw-core    (wiki I/O, search, lint)
+         ├── lw-mcp     (MCP server lib)
+         └── lw-cli     (binary `lw` — umbrella)
+
+External, unchanged:
+  llm-wiki-agents (TS, batch/cron) → consumes lw CLI
+  codebridge (LLM dispatch)         → dep of agents
+  llm-wiki-mono                     → kept as dev workspace
+                                      (context engineering),
+                                      no longer install surface
+```
+
+## 4.1 Runtime model (added per Arch review §1)
+
+`lw serve` MCP processes are spawned by an agent tool and live for one session. The vault they operate on is **fixed at process launch**, resolved via:
+
+**`--root` flag > `LW_WIKI_ROOT` env > current workspace from config > cwd auto-discover**
+
+`lw workspace use <name>` mutates `~/.llm-wiki/config.toml` but **does not affect already-running MCP processes**. To pick up a new current vault, the user restarts their agent tool (which respawns `lw serve`).
+
+`lw doctor` flags any running `lw serve` whose `--root` differs from the current registered workspace, with a one-line "restart your agent" hint. This avoids the silent-mid-session-switch footgun.
+
+## 5. Repo evolution
+
+| Repo                      | Today                                 | After                                                                                              |
+| ------------------------- | ------------------------------------- | -------------------------------------------------------------------------------------------------- |
+| `llm-wiki-mono`           | submodule meta-repo + install surface | **kept as dev workspace** (context engineering); README redirects installs to `llm-wiki` curl line |
+| `llm-wiki`                | tool only                             | product umbrella (binary + installer + skills + templates)                                         |
+| `llm-wiki-agents`         | submodule                             | unchanged, independent                                                                             |
+| `codebridge`              | submodule                             | unchanged, independent                                                                             |
+| private wiki content repo | submodule of mono                     | unchanged; mono's pointer stays put. Irrelevant to product.                                        |
+
+## 6. Repo layout (after)
+
+```
+llm-wiki/
+├── Cargo.toml                # workspace
+├── crates/
+│   ├── lw-core/
+│   ├── lw-mcp/
+│   └── lw-cli/
+│       └── src/cmd/
+│           ├── workspace.rs  # add | list | use | current | remove
+│           ├── upgrade.rs
+│           ├── integrate.rs  # loads integrations/*.toml + per-tool logic
+│           └── doctor.rs
+├── installer/
+│   ├── install.sh            # ships as release asset (versioned, sha256)
+│   └── uninstall.sh
+├── skills/                   # canonical, markdown + frontmatter
+│   └── llm-wiki:import/      # 1.0 ships import only
+├── templates/                # starter vaults for `lw workspace add --template`
+│   ├── general/
+│   ├── research-papers/
+│   └── engineering-notes/
+├── integrations/             # declarative descriptors per tool
+│   ├── claude-code.toml
+│   ├── codex.toml
+│   └── openclaw.toml
+├── README.md                 # includes onboarding/user journey
+└── docs/
+```
+
+## 7. Install flow
+
+Versioned, pinned to a release asset (per Sec review §1):
+
+```bash
+curl -fsSL https://github.com/Pawpaw-Technology/llm-wiki/releases/latest/download/install.sh | sh
+```
+
+The install script itself is a release artifact with a published sha256, not a live `main`-branch raw URL. Users wanting reproducible installs can pin a tag:
+
+```bash
+curl -fsSL https://github.com/Pawpaw-Technology/llm-wiki/releases/download/v0.2.0/install.sh | sh
+```
+
+Steps:
+
+1. Detect OS/arch → resolve release tarball name (matches existing release.yml matrix: `lw-{x86_64,aarch64}-{linux,darwin}`). Bail with clear message on unsupported targets (Windows).
+2. Fetch latest GitHub release tarball + sha256, verify, extract `lw` → `~/.llm-wiki/bin/lw`.
+3. Fetch `skills/` and `templates/` for the **same release tag** → `~/.llm-wiki/{skills,templates}/`. Versions are pinned together (per PM review §9).
+4. Write PATH export to detected shell rc (`~/.zshrc`, `~/.bashrc`, `~/.config/fish/config.fish`); idempotent, guarded by markers:
+   ```
+   # >>> llm-wiki >>>
+   export PATH="$HOME/.llm-wiki/bin:$PATH"
+   # <<< llm-wiki <<<
+   ```
+   Uninstall matches these markers exactly.
+5. **Non-interactive default** (per Sec review §2): if stdout is not a TTY (CI, scripted install), the installer **skips integration prompts**. Integration is opt-in via `--yes` (auto-integrate all detected tools) or by running `lw integrate --auto` later. If TTY and tools detected, print one line: "Detected: Claude Code. Run `lw integrate claude-code` to wire it up."
+6. Print next steps (TTY only, otherwise quiet success):
+   ```
+   lw workspace add my-vault ~/path/to/wiki --template general
+   lw integrate --auto
+   ```
+7. Write `~/.llm-wiki/version` (records both binary version and skills/templates version, must match).
+
+Failures: any step that can't recover prints a remediation hint and exits non-zero. No silent partial install.
+
+Flags:
+
+- `--yes` / `-y` — auto-integrate detected tools
+- `--no-integrate` — install only, never prompt
+- `--prefix <dir>` — override `~/.llm-wiki`
+
+## 8. Workspace registry
+
+`~/.llm-wiki/config.toml`:
+
+```toml
+[workspace]
+current = "personal"
+
+[workspaces.personal]
+path = "/Users/me/Documents/MyWiki"
+
+[workspaces.work]
+path = "/Users/me/work/team-wiki"
+```
+
+Commands:
+
+- `lw workspace add <name> <path> [--init] [--template <name>]` — register; `--init` runs `lw init` if dir is empty; `--template` copies starter vault from `~/.llm-wiki/templates/<name>` (includes a `SCOPE.md`).
+- `lw workspace list`
+- `lw workspace use <name>` — set `current`. **Note:** does not affect running `lw serve` processes; restart agent tool to pick up.
+- `lw workspace current` — print current name + path.
+- `lw workspace current -v` — print full resolution chain so user can debug "which layer wins".
+- `lw workspace remove <name>` — unregister (does not touch the directory).
+
+**Single-vault fallback:** if no workspace is ever registered, all commands fall back to `cwd` auto-discover (existing behavior). Multi-vault is pure opt-in.
+
+Resolution priority (when `lw serve` or any command needs a root):
+**`--root` flag > `LW_WIKI_ROOT` env > current registered workspace > cwd auto-discover**
+
+## 9. Integrations (cross agent-tool)
+
+**Declarative TOML descriptors** (per Arch review §3) — one per tool, plus a Rust trait for the rare case needing logic. Adding a new tool = ship a new TOML, no recompile.
+
+`integrations/claude-code.toml`:
+
+```toml
+name = "Claude Code"
+detect.config_dir = "~/.claude"
+
+[mcp]
+config_path = "~/.claude/settings.json"
+format = "json"
+key_path = "mcpServers.llm-wiki"
+command = "lw"
+args = ["serve"]
+
+[skills]
+target_dir = "~/.claude/skills/llm-wiki/"
+mode = "symlink"
+```
+
+1.0 coverage:
+
+| Tool        | MCP registration                       | Skills target                          | Notes                                                                                                                   |
+| ----------- | -------------------------------------- | -------------------------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| Claude Code | `~/.claude/settings.json` (mcpServers) | `~/.claude/skills/llm-wiki/` (symlink) | First-class                                                                                                             |
+| Codex       | `~/.codex/config.toml` (mcp_servers)   | per Codex skill convention             | First-class                                                                                                             |
+| OpenClaw    | (deferred to 1.1 unless trivial)       | OpenClaw skills dir (symlink)          | **Skill-only path for 1.0** — user judgment: skill install is the bulk of value; MCP wiring lands in 1.1 if non-trivial |
+
+Commands:
+
+- `lw integrate --auto` — detect installed tools, prompt per tool (or `--yes` to skip prompts).
+- `lw integrate <tool>` — explicit.
+- `lw integrate <tool> --uninstall` — reverse (matches version marker, leaves user's other config alone).
+
+**MCP config write semantics** (per Arch review §4):
+
+- **Atomic write**: stage to temp file, fsync, rename.
+- **Backup**: write `<config>.bak.<unix-ts>` before mutating.
+- **Merge by key with version field**: each managed entry has a `_lw_version` marker. On upgrade, if the existing entry's version matches the previous shipped version, merge silently; if user-edited (version mismatch or unexpected fields), print a unified diff and prompt before writing.
+- **Never** overwrite the whole config file.
+
+Skills are markdown prompts. Tools with a skill concept (Claude Code) get them symlinked into their skills dir. Tools without a native skill concept (potentially Codex/OpenClaw depending on their conventions) get a one-line prompt-include reference pointing at `~/.llm-wiki/skills/`. The "translation" is mechanical, not semantic — same prompt text, different host.
+
+`lw upgrade` re-resolves links so updates propagate. Copy-mode (filesystems without symlinks) explicitly re-copies on upgrade — see §11.
+
+## 10. Skills (canonical, 1 in 1.0)
+
+Onboarding lives in **README**, not in a skill. Per Arch review minor: defer `llm-wiki:curate` to 1.1, ship import only in 1.0.
+
+- **`llm-wiki:import`** (prefixed per PM review minor — avoids collisions with other plugins) — triggered when user shares a URL / pasted text / file path. The skill prompt instructs the agent to:
+  1. Fetch raw content if needed.
+  2. Check against the workspace's scope (read from `SCOPE.md` in vault root). **If `SCOPE.md` is absent, skip scope check** — permissive default.
+  3. If in scope (or no scope defined) → ingest to `raw/` via `wiki_ingest`.
+  4. If ambiguous or out-of-scope → ask user explicitly. Never silent-fail.
+
+Skill is a markdown file with frontmatter (name, description, when-to-use). Pure prompt text + references to `wiki_*` MCP tools. No tool-specific syntax.
+
+## 10.5 SCOPE.md contract
+
+Loose, conventional structure (per Arch review §6 + PM review §7). Templates ship with this:
+
+```markdown
+# Scope
+
+## Purpose
+
+One paragraph: what this wiki is for.
+
+## Includes
+
+- bullet
+- bullet
+
+## Excludes
+
+- bullet
+- bullet
+```
+
+The import skill reads this as guidance (not strict validation — the LLM judges fit). Default-when-absent is **permissive** (no scope check applied). Templates always ship a starter `SCOPE.md` so most users get scope-checking by default.
+
+## 11. Upgrade
+
+- `lw upgrade --check` — query GitHub releases API, compare `~/.llm-wiki/version`. Exit 0 if current, exit 1 + prints latest if newer available.
+- `lw upgrade` — runs install.sh's reinstall path: fetch latest binary + skills + templates (versions pinned together), replace, refresh integrations (re-merge MCP entries with new version marker, re-symlink or re-copy skills). Workspaces and config preserved.
+- **Skill ↔ binary version** (per PM review §9): both written into `~/.llm-wiki/version`; `lw doctor` enforces compat. Mismatch surfaces as a hard warning.
+- **Copy-mode upgrade** (per Arch review §7): when integration uses `mode = "copy"` (filesystems without symlinks), upgrade explicitly re-copies skills directory atomically. Documented behavior, not silent staleness.
+- **Optional weak nudge**: on `lw` startup, if cached version check (24h TTL) sees newer, print one stderr line. **Suppressed when** `!isatty(stderr)` OR `CI=true` OR `LW_NO_NUDGE=1` (per PM minor).
+
+## 11.5 Uninstall
+
+`uninstall.sh` (shipped alongside `install.sh` as a release asset) and `lw uninstall` (CLI shortcut) do the same thing:
+
+1. **Reverse all integrations** — for each tool with an entry whose `_lw_version` marker is present:
+   - Remove the managed MCP entry from the tool's config (atomic write + `.bak.<unix-ts>` first).
+   - Remove the symlinked / copied skills directory at the integration's target path.
+   - User-edited entries (version marker missing or mismatched) are left in place with a printed warning — never silently discard user changes.
+2. **Remove PATH injection** — strip the marked block (`# >>> llm-wiki >>>` … `# <<< llm-wiki <<<`) from each shell rc; idempotent.
+3. **Remove `~/.llm-wiki/`** — binary, skills, templates, version file, integration descriptors. **Default: prompt for confirmation** (TTY) or require `--yes` (non-TTY).
+4. **Preserve user data** — registered workspace directories are **never** touched. `config.toml` is moved to `~/.llm-wiki.config.toml.bak.<unix-ts>` so a re-install can restore vault registrations.
+5. Print summary: what was removed, what was preserved, where backups live.
+
+Flags:
+
+- `--yes` / `-y` — skip confirmation
+- `--keep-config` — preserve `~/.llm-wiki/config.toml` in place (skip the bak rename)
+- `--purge` — also delete the `.bak` files left by integration writes (off by default — backups are insurance)
+
+`lw doctor --uninstall-check` previews what uninstall would do without touching anything.
+
+## 12. `lw doctor`
+
+One-shot diagnostics:
+
+- `lw` binary path + version
+- PATH actually contains `~/.llm-wiki/bin`
+- `~/.llm-wiki/config.toml` parseable; current workspace exists on disk
+- **Skills version vs binary version compat** (per PM §9)
+- For each known agent tool: detected? MCP entry present and version matches shipped descriptor? Skill symlink target exists and not dangling?
+- **Stale MCP entry** (per Arch minor): MCP entry's `command` resolves to the current `lw` binary (catches old paths after upgrade)
+- **Running `lw serve` mismatch** (per §4.1): any running `lw serve` whose `--root` differs from the current registered workspace
+- `lw serve` smoke test (start, list tools, shut down)
+
+Output: human-readable checklist with ✓/✗ and remediation hint per failing check.
+
+## 13. README user journey
+
+README sections, in order:
+
+1. **What it is** — one paragraph. Includes the §1.5 positioning vs Obsidian+fs-MCP in one sentence.
+2. **Install** — one curl line (versioned).
+3. **First vault, with a template** — the recommended path:
+   ```
+   lw workspace add my-research ~/wiki/research --template research-papers
+   lw integrate --auto
+   ```
+   Template copies a working `SCOPE.md` and a few example pages so the agent has something to query immediately.
+4. **Daily use** — example agent conversation showing the import skill: paste a URL → agent fetches, scope-checks, ingests.
+5. **Update** — `lw upgrade`.
+6. **Troubleshoot** — `lw doctor`, common issues, where backup files live.
+7. **Multi-vault (optional)** — `lw workspace add` more, switch with `lw workspace use`, restart your agent.
+
+## 14. Migration / rollout
+
+Order per Arch review §5 (verify-then-redirect, never strand users):
+
+1. In `llm-wiki` repo: add `installer/`, `skills/`, `templates/`, `integrations/`, new `lw-cli` cmd modules. CI release asset publishes `install.sh` (with sha256) alongside binaries.
+2. **Decide skill packaging before 0.2.0** (per Arch minor): bundled in main release tarball is the default; revisit only if size becomes a problem.
+3. Cut `0.2.0` release with the wrapper commands working but installer experimental. README marked "preview".
+4. **Installation smoke test**: clean macOS + Linux VMs, install via curl, run `lw doctor` against all three agent tools (Claude Code, Codex, OpenClaw skill-only). Must pass clean. This validates _installation correctness_.
+5. **Skill behavior smoke test** (per Arch review §2 — installation green ≠ skill works): for each of the three tools, in a fresh agent session against a `--template general` vault, walk the `llm-wiki:import` skill end-to-end:
+   - Paste a sample URL → agent must invoke the skill, fetch, scope-check, and write to `raw/`.
+   - Paste an out-of-scope item → agent must ask the user, not silent-import.
+   - Tools where the skill prompt cannot be triggered faithfully (no skill concept, no prompt-include path) downgrade to "documented limitation" in 1.0 and the cross-tool claim in §2 is qualified accordingly.
+   - Capture a transcript per tool; commit under `docs/smoke-tests/<version>/`.
+6. **Uninstall smoke test**: run `lw uninstall --yes` on the same VMs; verify integrations cleanly removed, vault dirs untouched, backups present per §11.5.
+7. Update `llm-wiki-agents` README to point at new install method.
+8. Cut `1.0.0` once steps 4–6 are green across all targets.
+9. **After** 1.0 is shipping: in `llm-wiki-mono` README, replace install instructions with a redirect to the curl line. **Do not archive mono** — it remains the dev workspace for context engineering. Removing the install-surface claim is a single README edit, not a repo retirement.
+
+1.0 gate (composite):
+
+- (install) `lw doctor` green on Claude Code + Codex + OpenClaw on clean macOS + Linux VMs
+- (behavior) `llm-wiki:import` end-to-end transcript captured per tool, with the in-scope / out-of-scope cases both behaving correctly
+- (uninstall) `lw uninstall` reverses all integrations cleanly, leaves vault data untouched
+
+## 15. Deferred (post-1.0)
+
+- **Distribution channels** (per Arch review §8): Homebrew tap (macOS table-stakes), `cargo install lw-cli`, signed releases via cosign or minisign.
+- **Windows support**.
+- **`llm-wiki:curate` skill** — wraps lint/classify/orphan with proposal UX. 1.1 target.
+- **More templates** beyond the 3 starters.
+- **OpenClaw MCP integration** if it turns out non-trivial in 1.0 testing.
+- **Fourth+ agent tool integrations** (OpenCode, others) via TOML descriptor — community PR friendly thanks to §9.
+- **Project rename** — "llm-wiki" is generic; SEO crowded. Worth a marketing-led naming pass before broad announcement.
+- **More expressive SCOPE.md** — globs, structured rules, multi-scope per directory.


### PR DESCRIPTION
Mono is being archived (separate PR over there). This PR brings the still-useful artifacts home:

- spec → docs/specs/
- plans → docs/plans/
- docs index at docs/README.md
- CLAUDE.md gains a 'Dev workspace' section explaining how to clone the 4 sibling repos without mono

Smoke transcripts (docs/smoke-tests/) were already in this repo from the rc.1/rc.2 smoke runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)