### PR TITLE
fix(test): align help_shows_all_commands with v0.2.1 grouped help format

### DIFF
--- a/crates/lw-cli/tests/cli_test.rs
+++ b/crates/lw-cli/tests/cli_test.rs
@@ -216,12 +216,22 @@ fn help_shows_all_commands() {
     lw().arg("--help")
         .assert()
         .success()
+        // Wiki ops (original commands)
         .stdout(predicate::str::contains("init"))
         .stdout(predicate::str::contains("query"))
         .stdout(predicate::str::contains("ingest"))
         .stdout(predicate::str::contains("serve"))
         .stdout(predicate::str::contains("status"))
-        .stdout(predicate::str::contains("Examples"));
+        // Wrapper / lifecycle commands (added in v0.2.0+)
+        .stdout(predicate::str::contains("workspace"))
+        .stdout(predicate::str::contains("integrate"))
+        .stdout(predicate::str::contains("upgrade"))
+        .stdout(predicate::str::contains("uninstall"))
+        .stdout(predicate::str::contains("doctor"))
+        // v0.2.1 grouped examples sections
+        .stdout(predicate::str::contains("First-time setup"))
+        .stdout(predicate::str::contains("Day-to-day"))
+        .stdout(predicate::str::contains("Maintenance"));
 }
 
 #[test]


### PR DESCRIPTION
Fix CI regression introduced by PR #45 (help text rewrite).

PR #45 grouped `lw --help`'s after_help into 'First-time setup' / 'Day-to-day' / 'Maintenance' sections, dropping the literal 'Examples' header. The test `help_shows_all_commands` still asserted on 'Examples' and started failing on every push since.

This PR:
- Replaces the 'Examples' assertion with checks for the 3 new section headers
- Adds assertions for the 5 wrapper commands (`workspace`, `integrate`, `upgrade`, `uninstall`, `doctor`) — these have been listed in --help since v0.2.0 but the test never covered them

🤖 Generated with [Claude Code](https://claude.com/claude-code)