### PR TITLE
fix(integrations): claude-code MCP path is ~/.claude.json, not settings.json

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1055,7 +1055,7 @@ dependencies = [
 
 [[package]]
 name = "lw-cli"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1078,7 +1078,7 @@ dependencies = [
 
 [[package]]
 name = "lw-core"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "comrak",
  "gray_matter",
@@ -1097,7 +1097,7 @@ dependencies = [
 
 [[package]]
 name = "lw-mcp"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "lw-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.1"
+version = "0.2.2"
 edition = "2024"
 license = "MIT"
 

--- a/integrations/claude-code.toml
+++ b/integrations/claude-code.toml
@@ -3,8 +3,12 @@ name = "Claude Code"
 [detect]
 config_dir = "~/.claude"
 
+# Claude Code (desktop + CLI) reads user-level MCP servers from ~/.claude.json
+# (a file sibling to the .claude/ directory), NOT from ~/.claude/settings.json.
+# Writing to the wrong file means `/mcp` never surfaces the server and the
+# integration silently does nothing. See smoke discovery 2026-04-21.
 [mcp]
-config_path = "~/.claude/settings.json"
+config_path = "~/.claude.json"
 format = "json"
 key_path = "mcpServers.llm-wiki"
 command = "lw"


### PR DESCRIPTION
## Blocker fix (discovered post-v0.2.1)

Our `claude-code.toml` descriptor writes to `~/.claude/settings.json`, but Claude Code actually reads user-level MCP servers from `~/.claude.json` (top-level JSON file, sibling to the `.claude/` directory).

Confirmed by running `/mcp` in Claude Code — 'User MCPs' source is explicitly `/Users/vergil/.claude.json`. Our v0.2.0/0.2.1 `lw integrate claude-code` has been writing to the wrong file silently. `/mcp` never surfaced the llm-wiki server.

## Fix
- `integrations/claude-code.toml`: `config_path` → `~/.claude.json`
- Bump to v0.2.2 (0.2.x integrations were broken)
- Inline comment warns about this distinction to prevent regression

## User action after v0.2.2 ships
```bash
lw upgrade              # picks up new descriptor
lw integrate claude-code --uninstall   # cleans old wrong-file entry
lw integrate claude-code               # writes to right file now
# Cmd+Q Claude Code, then reopen → /mcp should show llm-wiki
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)