### PR TITLE
fix(serve): skip startup rebuild when index is populated (#55)

### DIFF
--- a/crates/lw-cli/src/query.rs
+++ b/crates/lw-cli/src/query.rs
@@ -1,8 +1,8 @@
 use crate::output::{self, Format};
-use lw_core::fs::load_schema;
-use lw_core::git::{page_freshness, FreshnessLevel};
-use lw_core::search::{SearchHit, SearchQuery, Searcher, TantivySearcher};
 use lw_core::WikiError;
+use lw_core::fs::load_schema;
+use lw_core::git::{FreshnessLevel, page_freshness};
+use lw_core::search::{SearchHit, SearchQuery, Searcher, TantivySearcher};
 use std::path::Path;
 
 /// A search hit enriched with freshness information.

--- a/crates/lw-core/src/search.rs
+++ b/crates/lw-core/src/search.rs
@@ -119,17 +119,12 @@ impl TantivySearcher {
         })
     }
 
-    /// Returns true if the on-disk index contains no documents.
+    /// Returns true if the on-disk index contains no committed documents.
     ///
-    /// Callers (notably `lw serve`) use this to skip a startup rebuild
-    /// when the index is already populated — rebuild opens the writer
-    /// and would block concurrent `lw query` rebuilds for the server's
-    /// lifetime. See GitHub issue #55.
+    /// Callers use this to skip work that would otherwise open the
+    /// writer — e.g. a `lw serve` startup rebuild, which would hold
+    /// the writer lock for the server's lifetime.
     pub fn is_empty(&self) -> bool {
-        // `num_docs` counts committed docs visible to the reader. The
-        // reader is built with `ReloadPolicy::Manual`, so reload first
-        // to catch docs persisted by a previous process.
-        let _ = self.reader.reload();
         self.reader.searcher().num_docs() == 0
     }
 

--- a/crates/lw-core/src/search.rs
+++ b/crates/lw-core/src/search.rs
@@ -5,7 +5,7 @@ use std::sync::Mutex;
 use tantivy::collector::TopDocs;
 use tantivy::query::{BooleanQuery, Occur, QueryParser, TermQuery};
 use tantivy::schema::{
-    Field, IndexRecordOption, Schema, TextFieldIndexing, TextOptions, Value, STORED, STRING,
+    Field, IndexRecordOption, STORED, STRING, Schema, TextFieldIndexing, TextOptions, Value,
 };
 use tantivy::snippet::SnippetGenerator;
 use tantivy::tokenizer::{LowerCaser, TextAnalyzer};
@@ -117,6 +117,20 @@ impl TantivySearcher {
             f_tags,
             f_category,
         })
+    }
+
+    /// Returns true if the on-disk index contains no documents.
+    ///
+    /// Callers (notably `lw serve`) use this to skip a startup rebuild
+    /// when the index is already populated — rebuild opens the writer
+    /// and would block concurrent `lw query` rebuilds for the server's
+    /// lifetime. See GitHub issue #55.
+    pub fn is_empty(&self) -> bool {
+        // `num_docs` counts committed docs visible to the reader. The
+        // reader is built with `ReloadPolicy::Manual`, so reload first
+        // to catch docs persisted by a previous process.
+        let _ = self.reader.reload();
+        self.reader.searcher().num_docs() == 0
     }
 
     fn category_from_path(rel_path: &str) -> String {

--- a/crates/lw-core/tests/search_test.rs
+++ b/crates/lw-core/tests/search_test.rs
@@ -323,3 +323,51 @@ fn rebuild_returns_index_locked_when_writer_held_elsewhere() {
         "expected IndexLocked, got {err:?}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// is_empty — lets `lw serve` skip the startup rebuild when the on-disk index
+// is already populated, so it never opens the writer and concurrent
+// `lw query` rebuilds don't hit IndexLocked. See GitHub issue #55.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn is_empty_true_for_fresh_index() {
+    let tmp = TempDir::new().unwrap();
+    let searcher = TantivySearcher::new(tmp.path()).unwrap();
+    assert!(
+        searcher.is_empty(),
+        "fresh index must report is_empty() == true"
+    );
+}
+
+#[test]
+fn is_empty_false_after_indexing() {
+    let tmp = TempDir::new().unwrap();
+    let searcher = TantivySearcher::new(tmp.path()).unwrap();
+    let (path, page) = make_page("Something", &[], "body");
+    searcher.index_page(&path, &page).unwrap();
+    searcher.commit().unwrap();
+    assert!(
+        !searcher.is_empty(),
+        "populated index must report is_empty() == false"
+    );
+}
+
+#[test]
+fn is_empty_reflects_persisted_index_across_instances() {
+    // The MCP startup check must see docs written by a *previous* process
+    // (e.g. a prior `lw serve` run or a CLI ingest). Dropping the first
+    // searcher fully releases the writer lock.
+    let tmp = TempDir::new().unwrap();
+    {
+        let searcher = TantivySearcher::new(tmp.path()).unwrap();
+        let (path, page) = make_page("Persisted", &[], "persisted body");
+        searcher.index_page(&path, &page).unwrap();
+        searcher.commit().unwrap();
+    }
+    let reopened = TantivySearcher::new(tmp.path()).unwrap();
+    assert!(
+        !reopened.is_empty(),
+        "reopened index must see previously-persisted docs"
+    );
+}

--- a/crates/lw-core/tests/search_test.rs
+++ b/crates/lw-core/tests/search_test.rs
@@ -1,6 +1,6 @@
+use lw_core::WikiError;
 use lw_core::page::Page;
 use lw_core::search::{SearchQuery, Searcher, TantivySearcher};
-use lw_core::WikiError;
 use tempfile::TempDir;
 
 fn make_page(title: &str, tags: &[&str], body: &str) -> (String, Page) {

--- a/crates/lw-core/tests/search_test.rs
+++ b/crates/lw-core/tests/search_test.rs
@@ -325,9 +325,8 @@ fn rebuild_returns_index_locked_when_writer_held_elsewhere() {
 }
 
 // ---------------------------------------------------------------------------
-// is_empty — lets `lw serve` skip the startup rebuild when the on-disk index
-// is already populated, so it never opens the writer and concurrent
-// `lw query` rebuilds don't hit IndexLocked. See GitHub issue #55.
+// is_empty — gates any work that would open the writer lock on a fresh
+// index (e.g. `lw serve` startup rebuild).
 // ---------------------------------------------------------------------------
 
 #[test]

--- a/crates/lw-mcp/src/lib.rs
+++ b/crates/lw-mcp/src/lib.rs
@@ -636,11 +636,10 @@ impl WikiMcpServer {
 
         let searcher = TantivySearcher::new(&index_dir)?;
         let wiki_dir = wiki_root.join("wiki");
-        // Trust-on-first-use: skip the startup rebuild when the index
-        // is already populated. Rebuild opens the writer and would hold
-        // the lock for the server's lifetime, forcing concurrent
-        // `lw query` calls onto the IndexLocked fallback path.
-        // See GitHub issue #55.
+        // Rebuild only when the index is empty. A rebuild opens the
+        // writer and holds the lock for this server's lifetime, which
+        // would force any concurrent `lw query` onto the IndexLocked
+        // fallback path.
         if wiki_dir.exists()
             && searcher.is_empty()
             && let Err(e) = searcher.rebuild(&wiki_dir)

--- a/crates/lw-mcp/src/lib.rs
+++ b/crates/lw-mcp/src/lib.rs
@@ -636,10 +636,16 @@ impl WikiMcpServer {
 
         let searcher = TantivySearcher::new(&index_dir)?;
         let wiki_dir = wiki_root.join("wiki");
+        // Trust-on-first-use: skip the startup rebuild when the index
+        // is already populated. Rebuild opens the writer and would hold
+        // the lock for the server's lifetime, forcing concurrent
+        // `lw query` calls onto the IndexLocked fallback path.
+        // See GitHub issue #55.
         if wiki_dir.exists()
+            && searcher.is_empty()
             && let Err(e) = searcher.rebuild(&wiki_dir)
         {
-            tracing::warn!("Failed to rebuild search index: {}", e);
+            tracing::warn!("Failed to build search index on first run: {}", e);
         }
 
         let searcher = Arc::new(searcher);

--- a/crates/lw-mcp/tests/serve_startup_no_rebuild.rs
+++ b/crates/lw-mcp/tests/serve_startup_no_rebuild.rs
@@ -1,0 +1,100 @@
+//! Regression for GitHub issue #55.
+//!
+//! `lw serve` used to unconditionally rebuild the search index on startup.
+//! Rebuild opens the tantivy writer, which is then kept alive for the
+//! lifetime of the server. Any concurrent `lw query` that tries its own
+//! rebuild hits `IndexLocked` and has to fall back to the stale on-disk
+//! index — the consolation path added in v0.2.5.
+//!
+//! The fix (Option 1, trust-on-first-use): if the index already has docs,
+//! skip the startup rebuild. Subsequent MCP writes still lazy-open the
+//! writer on demand. Until a write happens, concurrent `lw query` can
+//! freely refresh the index.
+
+use lw_core::fs::{init_wiki, validate_wiki_path, write_page};
+use lw_core::page::Page;
+use lw_core::schema::WikiSchema;
+use lw_core::search::{Searcher, TantivySearcher};
+use lw_core::WikiError;
+use lw_mcp::WikiMcpServer;
+use tempfile::TempDir;
+
+fn seed_vault_and_index(root: &std::path::Path) {
+    let schema = WikiSchema::default();
+    init_wiki(root, &schema).unwrap();
+
+    let page_content = "---\ntitle: Seed\ntags: [seed]\n---\n\nseed body\n";
+    let rel = "architecture/seed.md";
+    let abs = validate_wiki_path(&root.join("wiki"), rel).unwrap();
+    let page = Page::parse(page_content).unwrap();
+    write_page(&abs, &page).unwrap();
+
+    // Pre-populate the on-disk tantivy index so WikiMcpServer::new sees a
+    // "current" index. Drop the searcher so the writer lock is fully
+    // released before the server starts.
+    let index_dir = root.join(lw_core::INDEX_DIR);
+    std::fs::create_dir_all(&index_dir).unwrap();
+    {
+        let s = TantivySearcher::new(&index_dir).unwrap();
+        s.index_page(rel, &page).unwrap();
+        s.commit().unwrap();
+    }
+}
+
+#[test]
+fn mcp_new_skips_rebuild_when_index_is_populated() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path().to_path_buf();
+    seed_vault_and_index(&root);
+
+    // Start the MCP server. With the fix, it must NOT open the writer
+    // because the index is already populated.
+    let _server = WikiMcpServer::new(root.clone()).expect("server must start");
+
+    // A separate searcher (simulating `lw query`) must now be able to
+    // rebuild without hitting IndexLocked.
+    let index_dir = root.join(lw_core::INDEX_DIR);
+    let cli_searcher = TantivySearcher::new(&index_dir).unwrap();
+    match cli_searcher.rebuild(&root.join("wiki")) {
+        Ok(_) => {} // expected
+        Err(WikiError::IndexLocked { .. }) => {
+            panic!(
+                "lw serve still holds the writer lock after startup — \
+                 `lw query` rebuild should have succeeded"
+            );
+        }
+        Err(e) => panic!("unexpected error: {e:?}"),
+    }
+}
+
+#[test]
+fn mcp_new_still_rebuilds_when_index_is_empty() {
+    // Fresh install: no prior index. The server must build one so
+    // `wiki_query` returns results on first use.
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path().to_path_buf();
+    let schema = WikiSchema::default();
+    init_wiki(&root, &schema).unwrap();
+
+    let rel = "architecture/fresh.md";
+    let abs = validate_wiki_path(&root.join("wiki"), rel).unwrap();
+    let page = Page::parse("---\ntitle: Fresh\ntags: []\n---\n\nfresh body\n").unwrap();
+    write_page(&abs, &page).unwrap();
+
+    let _server = WikiMcpServer::new(root.clone()).expect("server must start");
+
+    // The index should have been built — searching should find the page.
+    let index_dir = root.join(lw_core::INDEX_DIR);
+    let reader = TantivySearcher::new(&index_dir).unwrap();
+    let q = lw_core::search::SearchQuery {
+        text: Some("fresh".into()),
+        tags: vec![],
+        category: None,
+        limit: 10,
+    };
+    let results = reader.search(&q).unwrap();
+    assert_eq!(
+        results.total, 1,
+        "empty-index startup must rebuild so queries return hits"
+    );
+}

--- a/crates/lw-mcp/tests/serve_startup_no_rebuild.rs
+++ b/crates/lw-mcp/tests/serve_startup_no_rebuild.rs
@@ -11,11 +11,11 @@
 //! writer on demand. Until a write happens, concurrent `lw query` can
 //! freely refresh the index.
 
+use lw_core::WikiError;
 use lw_core::fs::{init_wiki, validate_wiki_path, write_page};
 use lw_core::page::Page;
 use lw_core::schema::WikiSchema;
 use lw_core::search::{Searcher, TantivySearcher};
-use lw_core::WikiError;
 use lw_mcp::WikiMcpServer;
 use tempfile::TempDir;
 

--- a/crates/lw-mcp/tests/serve_startup_no_rebuild.rs
+++ b/crates/lw-mcp/tests/serve_startup_no_rebuild.rs
@@ -1,15 +1,6 @@
-//! Regression for GitHub issue #55.
-//!
-//! `lw serve` used to unconditionally rebuild the search index on startup.
-//! Rebuild opens the tantivy writer, which is then kept alive for the
-//! lifetime of the server. Any concurrent `lw query` that tries its own
-//! rebuild hits `IndexLocked` and has to fall back to the stale on-disk
-//! index — the consolation path added in v0.2.5.
-//!
-//! The fix (Option 1, trust-on-first-use): if the index already has docs,
-//! skip the startup rebuild. Subsequent MCP writes still lazy-open the
-//! writer on demand. Until a write happens, concurrent `lw query` can
-//! freely refresh the index.
+//! `WikiMcpServer::new` must not open the writer lock when the index
+//! is already populated; otherwise concurrent `lw query` rebuilds are
+//! forced onto the IndexLocked fallback for the server's lifetime.
 
 use lw_core::WikiError;
 use lw_core::fs::{init_wiki, validate_wiki_path, write_page};


### PR DESCRIPTION
## Summary

- `WikiMcpServer::new` no longer rebuilds the tantivy index on startup when it already has committed docs, so it never opens the writer lock
- Concurrent `lw query` rebuilds against the same vault now succeed instead of falling back to the v0.2.5 `IndexLocked` stale-read path
- Adds `TantivySearcher::is_empty()` + regression tests covering both the populated-skip and fresh-install-rebuild paths

Closes #55.

Option 1 (trust-on-first-use) from the issue. Trade-off: edits made to the vault markdown out-of-band while `lw serve` is down won't be picked up at the next boot until a write touches the index. Acceptable for the agent use case; mtime/git-hash gating (options 2/3) remain available as follow-ups.

## Test plan
- [x] `cargo test` — 279 passed
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] New regression tests: `is_empty_*` (3) + `mcp_new_skips_rebuild_when_index_is_populated` + `mcp_new_still_rebuilds_when_index_is_empty`
- [ ] Host smoke: `lw query "..."` while `lw serve` is running — rebuild succeeds on the CLI side (no IndexLocked note)

🤖 Generated with [Claude Code](https://claude.com/claude-code)