### PR TITLE
ci: bump actions off Node 20 before Sept 2026 deprecation (#53)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     name: Format
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@nightly
         with:
           components: rustfmt
@@ -25,7 +25,7 @@ jobs:
     name: Clippy
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
@@ -40,7 +40,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: cargo test --workspace
@@ -49,11 +49,11 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
       - run: cargo build --release --workspace
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: lw-linux-x86_64
           path: target/release/lw

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
             os: macos-latest
             asset: lw-aarch64-darwin.tar.gz
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -73,7 +73,7 @@ jobs:
           tar -C stage -czf dist/${{ matrix.asset }} .
           shasum -a 256 dist/${{ matrix.asset }} | awk '{print $1"  "$2}' > dist/${{ matrix.asset }}.sha256
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.asset }}
           path: dist/${{ matrix.asset }}*
@@ -82,7 +82,7 @@ jobs:
     name: Publish install.sh as separate asset
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Stage installer + sha256
         run: |
           mkdir -p dist
@@ -90,7 +90,7 @@ jobs:
           cp installer/uninstall.sh dist/uninstall.sh
           shasum -a 256 dist/install.sh | awk '{print $1"  "$2}' > dist/install.sh.sha256
           shasum -a 256 dist/uninstall.sh | awk '{print $1"  "$2}' > dist/uninstall.sh.sha256
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: installer-scripts
           path: dist/*
@@ -100,9 +100,9 @@ jobs:
     needs: [build, publish-installer]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           path: artifacts
           merge-multiple: true


### PR DESCRIPTION
## Summary

- Bump Node-based GitHub Actions off the deprecated Node 20 runtime
- Scope expanded from issue #53 (which mentioned `release.yml` only) to also include `ci.yml`, since the same actions and the same deprecation apply
- All three target majors run on Node 24 (verified from their `action.yml`)

| Action | Before | After |
|---|---|---|
| actions/checkout | v4 | v6 |
| actions/upload-artifact | v4 | v7 |
| actions/download-artifact | v4 | v8 |

`upload-artifact@v7` and `download-artifact@v8` are the current pair and share the v4+ artifact backend. Default (zipped) uploads remain unchanged.

Closes #53.

## Test plan
- [x] YAML syntax valid (`yaml.safe_load`)
- [ ] CI workflow this PR triggers runs green on all jobs (fmt, clippy, test × 2, build upload)
- [ ] First post-merge tag push produces a green release (12 assets published, no Node 20 deprecation banner in logs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)