### PR TITLE
[codex] fix ingest traversal and rebuild index safety

### DIFF
--- a/crates/lw-core/src/ingest.rs
+++ b/crates/lw-core/src/ingest.rs
@@ -91,6 +91,8 @@ pub async fn ingest_source(
     source: &Path,
     raw_subdir: &str,
 ) -> Result<IngestResult> {
+    ensure_single_component("raw_subdir", raw_subdir)?;
+
     // Copy source to raw/
     let filename = source.file_name().ok_or_else(|| {
         crate::WikiError::Io(std::io::Error::new(

--- a/crates/lw-core/src/search.rs
+++ b/crates/lw-core/src/search.rs
@@ -168,6 +168,23 @@ impl TantivySearcher {
         op(guard.as_mut().expect("writer opened above"))
     }
 
+    fn check_writer_available(&self) -> Result<()> {
+        let guard = self
+            .writer
+            .lock()
+            .map_err(|e| WikiError::Internal(e.to_string()))?;
+        if guard.is_some() {
+            return Ok(());
+        }
+        match self.index.writer::<TantivyDocument>(50_000_000) {
+            Ok(_writer) => Ok(()),
+            Err(tantivy::TantivyError::LockFailure(..)) => Err(WikiError::IndexLocked {
+                path: self.index_dir.clone(),
+            }),
+            Err(e) => Err(e.into()),
+        }
+    }
+
     fn rollback_writer(&self) -> Result<()> {
         let mut guard = self
             .writer
@@ -319,6 +336,8 @@ impl Searcher for TantivySearcher {
 
     #[tracing::instrument(skip(self))]
     fn rebuild(&self, wiki_dir: &Path) -> Result<()> {
+        self.check_writer_available()?;
+
         let mut docs = Vec::new();
         let pages = crate::fs::list_pages(wiki_dir)?;
         for rel_path in &pages {

--- a/crates/lw-core/src/search.rs
+++ b/crates/lw-core/src/search.rs
@@ -132,6 +132,19 @@ impl TantivySearcher {
         crate::fs::category_from_path(std::path::Path::new(rel_path)).unwrap_or_default()
     }
 
+    fn page_document(&self, rel_path: &str, page: &Page) -> TantivyDocument {
+        let category = Self::category_from_path(rel_path);
+        let mut doc = TantivyDocument::new();
+        doc.add_text(self.f_path, rel_path);
+        doc.add_text(self.f_title, &page.title);
+        doc.add_text(self.f_body, &page.body);
+        for tag in &page.tags {
+            doc.add_text(self.f_tags, tag);
+        }
+        doc.add_text(self.f_category, &category);
+        doc
+    }
+
     /// Run `op` with the lazily-opened writer. Translates tantivy's
     /// `LockFailure` into the typed `WikiError::IndexLocked` so callers
     /// (e.g. CLI query) can fall back to read-only mode instead of
@@ -154,35 +167,29 @@ impl TantivySearcher {
         }
         op(guard.as_mut().expect("writer opened above"))
     }
+
+    fn rollback_writer(&self) -> Result<()> {
+        let mut guard = self
+            .writer
+            .lock()
+            .map_err(|e| WikiError::Internal(e.to_string()))?;
+        if let Some(writer) = guard.as_mut() {
+            writer.rollback()?;
+        }
+        Ok(())
+    }
 }
 
 impl Searcher for TantivySearcher {
     #[tracing::instrument(skip(self, page))]
     fn index_page(&self, rel_path: &str, page: &Page) -> Result<()> {
         let f_path = self.f_path;
-        let f_title = self.f_title;
-        let f_body = self.f_body;
-        let f_tags = self.f_tags;
-        let f_category = self.f_category;
-        let category = Self::category_from_path(rel_path);
         let rel_path = rel_path.to_string();
-        let page_title = page.title.clone();
-        let page_body = page.body.clone();
-        let page_tags = page.tags.clone();
+        let doc = self.page_document(&rel_path, page);
 
         self.with_writer(|writer| {
             let path_term = Term::from_field_text(f_path, &rel_path);
             writer.delete_term(path_term);
-
-            let mut doc = TantivyDocument::new();
-            doc.add_text(f_path, &rel_path);
-            doc.add_text(f_title, &page_title);
-            doc.add_text(f_body, &page_body);
-            for tag in &page_tags {
-                doc.add_text(f_tags, tag);
-            }
-            doc.add_text(f_category, &category);
-
             writer.add_document(doc)?;
             Ok(())
         })
@@ -312,24 +319,37 @@ impl Searcher for TantivySearcher {
 
     #[tracing::instrument(skip(self))]
     fn rebuild(&self, wiki_dir: &Path) -> Result<()> {
-        self.with_writer(|writer| {
-            writer.delete_all_documents()?;
-            Ok(())
-        })?;
-        self.commit()?;
-
+        let mut docs = Vec::new();
         let pages = crate::fs::list_pages(wiki_dir)?;
         for rel_path in &pages {
             let abs_path = wiki_dir.join(rel_path);
             match crate::fs::read_page(&abs_path) {
                 Ok(page) => {
-                    let rel_str = rel_path.to_string_lossy();
-                    self.index_page(&rel_str, &page)?;
+                    let rel_path = rel_path.to_string_lossy();
+                    docs.push(self.page_document(&rel_path, &page));
                 }
                 Err(_) => continue, // skip unparseable files
             }
         }
-        self.commit()
+
+        let rebuild_result = self.with_writer(|writer| {
+            writer.delete_all_documents()?;
+            for doc in docs {
+                writer.add_document(doc)?;
+            }
+            Ok(())
+        });
+        if let Err(err) = rebuild_result {
+            let _ = self.rollback_writer();
+            return Err(err);
+        }
+        match self.commit() {
+            Ok(()) => Ok(()),
+            Err(err) => {
+                let _ = self.rollback_writer();
+                Err(err)
+            }
+        }
     }
 }
 

--- a/crates/lw-core/tests/ingest_test.rs
+++ b/crates/lw-core/tests/ingest_test.rs
@@ -101,6 +101,24 @@ async fn ingest_content_rejects_raw_subdir_with_separator() {
 }
 
 #[tokio::test]
+async fn ingest_source_rejects_raw_subdir_with_separator() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    init_wiki(root, &WikiSchema::default()).unwrap();
+
+    let source = tmp.path().join("external/paper.md");
+    std::fs::create_dir_all(source.parent().unwrap()).unwrap();
+    std::fs::write(&source, "# My Paper\n\nContent here.").unwrap();
+
+    let err = ingest_source(root, &source, "../escaped")
+        .await
+        .expect_err("path traversal in raw_subdir should be rejected");
+    let msg = err.to_string();
+    assert!(msg.contains("raw_subdir") || msg.contains("path"));
+    assert!(!root.join("escaped/paper.md").exists());
+}
+
+#[tokio::test]
 async fn ingest_does_not_create_wiki_page() {
     let tmp = TempDir::new().unwrap();
     let root = tmp.path();

--- a/crates/lw-core/tests/ingest_test.rs
+++ b/crates/lw-core/tests/ingest_test.rs
@@ -114,7 +114,10 @@ async fn ingest_source_rejects_raw_subdir_with_separator() {
         .await
         .expect_err("path traversal in raw_subdir should be rejected");
     let msg = err.to_string();
-    assert!(msg.contains("raw_subdir") || msg.contains("path"));
+    assert!(
+        msg.contains("invalid raw_subdir") && msg.contains("single path component"),
+        "expected specific raw_subdir validation error, got: {msg}"
+    );
     assert!(!root.join("escaped/paper.md").exists());
 }
 

--- a/crates/lw-core/tests/search_test.rs
+++ b/crates/lw-core/tests/search_test.rs
@@ -353,6 +353,83 @@ fn failed_rebuild_preserves_last_committed_index() {
     );
 }
 
+#[cfg(unix)]
+#[test]
+fn rebuild_rolls_back_writer_after_commit_failure() {
+    use std::os::unix::fs::PermissionsExt;
+
+    struct PermissionsGuard {
+        path: std::path::PathBuf,
+        mode: u32,
+    }
+
+    impl Drop for PermissionsGuard {
+        fn drop(&mut self) {
+            let _ =
+                std::fs::set_permissions(&self.path, std::fs::Permissions::from_mode(self.mode));
+        }
+    }
+
+    let tmp = TempDir::new().unwrap();
+    let index_dir = tmp.path().join("index");
+    std::fs::create_dir_all(&index_dir).unwrap();
+    let searcher = TantivySearcher::new(&index_dir).unwrap();
+    let (path, page) = make_page("Original", &[], "original durable body");
+    searcher.index_page(&path, &page).unwrap();
+    searcher.commit().unwrap();
+
+    let wiki_dir = tmp.path().join("wiki");
+    std::fs::create_dir_all(wiki_dir.join("architecture")).unwrap();
+    let (_, replacement) = make_page("Replacement", &[], "replacement body");
+    std::fs::write(
+        wiki_dir.join("architecture/replacement.md"),
+        replacement.to_markdown(),
+    )
+    .unwrap();
+
+    let original_query = SearchQuery {
+        text: Some("durable".into()),
+        tags: vec![],
+        category: None,
+        limit: 10,
+    };
+    let replacement_query = SearchQuery {
+        text: Some("replacement".into()),
+        tags: vec![],
+        category: None,
+        limit: 10,
+    };
+    assert_eq!(searcher.search(&original_query).unwrap().total, 1);
+    assert_eq!(searcher.search(&replacement_query).unwrap().total, 0);
+
+    let original_mode = std::fs::metadata(&index_dir).unwrap().permissions().mode();
+    let guard = PermissionsGuard {
+        path: index_dir.clone(),
+        mode: original_mode,
+    };
+    std::fs::set_permissions(&index_dir, std::fs::Permissions::from_mode(0o500)).unwrap();
+
+    searcher
+        .rebuild(&wiki_dir)
+        .expect_err("rebuild commit should fail while index dir is read-only");
+
+    drop(guard);
+
+    searcher
+        .commit()
+        .expect("rollback should leave no failed rebuild operations pending");
+    assert_eq!(
+        searcher.search(&original_query).unwrap().total,
+        1,
+        "the previously committed index should remain searchable"
+    );
+    assert_eq!(
+        searcher.search(&replacement_query).unwrap().total,
+        0,
+        "a later commit must not publish the aborted rebuild"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // is_empty — gates any work that would open the writer lock on a fresh
 // index (e.g. `lw serve` startup rebuild).

--- a/crates/lw-core/tests/search_test.rs
+++ b/crates/lw-core/tests/search_test.rs
@@ -324,6 +324,35 @@ fn rebuild_returns_index_locked_when_writer_held_elsewhere() {
     );
 }
 
+#[test]
+fn failed_rebuild_preserves_last_committed_index() {
+    let tmp = TempDir::new().unwrap();
+    let index_dir = tmp.path().join("index");
+    std::fs::create_dir_all(&index_dir).unwrap();
+    let searcher = TantivySearcher::new(&index_dir).unwrap();
+    let (path, page) = make_page("Survives", &[], "durable body");
+    searcher.index_page(&path, &page).unwrap();
+    searcher.commit().unwrap();
+
+    let query = SearchQuery {
+        text: Some("durable".into()),
+        tags: vec![],
+        category: None,
+        limit: 10,
+    };
+    assert_eq!(searcher.search(&query).unwrap().total, 1);
+
+    searcher
+        .rebuild(&tmp.path().join("missing-wiki"))
+        .expect_err("rebuild should fail when the wiki directory cannot be listed");
+
+    assert_eq!(
+        searcher.search(&query).unwrap().total,
+        1,
+        "failed rebuild must not publish an empty index"
+    );
+}
+
 // ---------------------------------------------------------------------------
 // is_empty — gates any work that would open the writer lock on a fresh
 // index (e.g. `lw serve` startup rebuild).

--- a/crates/lw-core/tests/search_test.rs
+++ b/crates/lw-core/tests/search_test.rs
@@ -325,6 +325,25 @@ fn rebuild_returns_index_locked_when_writer_held_elsewhere() {
 }
 
 #[test]
+fn rebuild_checks_writer_lock_before_scanning_pages() {
+    let tmp = TempDir::new().unwrap();
+
+    let searcher_a = TantivySearcher::new(tmp.path()).unwrap();
+    let (path, page) = make_page("A", &[], "body");
+    searcher_a.index_page(&path, &page).unwrap();
+    searcher_a.commit().unwrap();
+
+    let searcher_b = TantivySearcher::new(tmp.path()).unwrap();
+    let err = searcher_b
+        .rebuild(&tmp.path().join("missing-wiki"))
+        .expect_err("writer lock should be checked before wiki scanning");
+    assert!(
+        matches!(err, WikiError::IndexLocked { .. }),
+        "expected IndexLocked before any page scan error, got {err:?}"
+    );
+}
+
+#[test]
 fn failed_rebuild_preserves_last_committed_index() {
     let tmp = TempDir::new().unwrap();
     let index_dir = tmp.path().join("index");


### PR DESCRIPTION
## What changed

- Added regression coverage for #63: `ingest_source` rejects traversal in `raw_subdir`.
- Added regression coverage for #64: failed search index rebuilds preserve the last committed index.
- Hardened `ingest_source` by applying the same single-component `raw_subdir` validation already used by `ingest_content`.
- Reworked Tantivy rebuilds so page documents are prepared before mutating the writer, then published in a single commit with rollback on failure.

## Why

- #63 allowed caller-controlled `raw_subdir` to escape `<wiki>/raw/` when ingesting source files.
- #64 committed `delete_all_documents()` before reading and indexing replacement pages, so an early rebuild failure could publish an empty index.

## Validation

- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo fmt --all -- --check`
