### PR TITLE
[codex] fix symlink-safe page listing and config saves

### DIFF
--- a/crates/lw-cli/src/config.rs
+++ b/crates/lw-cli/src/config.rs
@@ -55,10 +55,21 @@ impl Config {
         tmp.as_file().sync_all()?;
         tmp.persist(path).map_err(|e| e.error)?;
 
-        let dir = fs::File::open(parent)?;
-        dir.sync_all()?;
+        sync_parent_dir(parent)?;
         Ok(())
     }
+}
+
+#[cfg(unix)]
+fn sync_parent_dir(parent: &Path) -> anyhow::Result<()> {
+    let dir = fs::File::open(parent)?;
+    dir.sync_all()?;
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn sync_parent_dir(_parent: &Path) -> anyhow::Result<()> {
+    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/lw-cli/src/config.rs
+++ b/crates/lw-cli/src/config.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::fs;
-use std::io;
+use std::io::{self, Write};
 use std::path::{Path, PathBuf};
 
 #[derive(Debug, Default, Serialize, Deserialize, PartialEq)]
@@ -41,18 +41,22 @@ impl Config {
         }
     }
 
-    /// Atomic write: stage to .tmp sibling, fsync, rename.
+    /// Atomic write: stage to a unique temp file in the target dir, fsync, rename.
     pub fn save_to(&self, path: &Path) -> anyhow::Result<()> {
-        if let Some(parent) = path.parent() {
-            fs::create_dir_all(parent)?;
-        }
-        let tmp = path.with_extension("toml.tmp");
+        let parent = path
+            .parent()
+            .filter(|p| !p.as_os_str().is_empty())
+            .unwrap_or_else(|| Path::new("."));
+        fs::create_dir_all(parent)?;
+
         let body = toml::to_string_pretty(self)?;
-        fs::write(&tmp, body)?;
-        // fsync the file so rename is durable
-        let f = fs::File::open(&tmp)?;
-        f.sync_all()?;
-        fs::rename(&tmp, path)?;
+        let mut tmp = tempfile::NamedTempFile::new_in(parent)?;
+        tmp.write_all(body.as_bytes())?;
+        tmp.as_file().sync_all()?;
+        tmp.persist(path).map_err(|e| e.error)?;
+
+        let dir = fs::File::open(parent)?;
+        dir.sync_all()?;
         Ok(())
     }
 }
@@ -151,5 +155,30 @@ mod io_tests {
             .map(|e| e.unwrap().file_name().to_string_lossy().to_string())
             .collect();
         assert_eq!(entries, vec!["config.toml".to_string()]);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn save_does_not_follow_preexisting_tmp_symlink() {
+        use std::os::unix::fs::symlink;
+
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().join("config.toml");
+        let victim = dir.path().join("victim.txt");
+        fs::write(&victim, "do not overwrite").unwrap();
+        symlink(&victim, path.with_extension("toml.tmp")).unwrap();
+
+        let mut cfg = Config::default();
+        cfg.workspace.current = Some("safe".into());
+        cfg.save_to(&path).unwrap();
+
+        assert_eq!(fs::read_to_string(&victim).unwrap(), "do not overwrite");
+        assert!(
+            !fs::symlink_metadata(&path)
+                .unwrap()
+                .file_type()
+                .is_symlink()
+        );
+        assert_eq!(Config::load_from(&path).unwrap(), cfg);
     }
 }

--- a/crates/lw-core/src/fs.rs
+++ b/crates/lw-core/src/fs.rs
@@ -52,9 +52,14 @@ fn walk_md(base: &Path, dir: &Path, out: &mut Vec<PathBuf>) -> Result<()> {
     for entry in entries {
         let entry = entry?;
         let path = entry.path();
-        if path.is_dir() {
+        let file_type = entry.file_type()?;
+        if file_type.is_symlink() {
+            continue;
+        }
+        if file_type.is_dir() {
             walk_md(base, &path, out)?;
-        } else if path.extension().is_some_and(|ext| ext == "md")
+        } else if file_type.is_file()
+            && path.extension().is_some_and(|ext| ext == "md")
             && let Ok(rel) = path.strip_prefix(base)
         {
             out.push(rel.to_path_buf());

--- a/crates/lw-core/src/link.rs
+++ b/crates/lw-core/src/link.rs
@@ -25,13 +25,20 @@ pub fn resolve_link(target: &str, wiki_dir: &Path) -> Option<PathBuf> {
     let filename = format!("{}.md", target);
     let entries = std::fs::read_dir(wiki_dir).ok()?;
     for entry in entries.flatten() {
+        let Ok(file_type) = entry.file_type() else {
+            continue;
+        };
+        if file_type.is_symlink() || !file_type.is_dir() {
+            continue;
+        }
         let path = entry.path();
-        if path.is_dir() {
-            let candidate = path.join(&filename);
-            if candidate.exists() {
-                let cat = path.file_name()?;
-                return Some(PathBuf::from(cat).join(&filename));
-            }
+        let candidate = path.join(&filename);
+        if candidate
+            .symlink_metadata()
+            .is_ok_and(|metadata| metadata.file_type().is_file())
+        {
+            let cat = path.file_name()?;
+            return Some(PathBuf::from(cat).join(&filename));
         }
     }
     None

--- a/crates/lw-core/tests/fs_test.rs
+++ b/crates/lw-core/tests/fs_test.rs
@@ -75,6 +75,52 @@ fn list_pages_finds_markdown() {
     assert_eq!(pages.len(), 2);
 }
 
+#[cfg(unix)]
+#[test]
+fn list_pages_ignores_symlinked_files_and_directories() {
+    use std::os::unix::fs::symlink;
+
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    init_wiki(root, &WikiSchema::default()).unwrap();
+
+    let wiki_dir = root.join("wiki");
+    let real_page = wiki_dir.join("architecture/real.md");
+    std::fs::write(&real_page, "---\ntitle: Real\n---\n\ninside\n").unwrap();
+
+    let outside = tmp.path().join("outside");
+    std::fs::create_dir_all(&outside).unwrap();
+    std::fs::write(
+        outside.join("secret.md"),
+        "---\ntitle: Secret\n---\n\noutside\n",
+    )
+    .unwrap();
+    std::fs::create_dir_all(outside.join("collection")).unwrap();
+    std::fs::write(
+        outside.join("collection/nested.md"),
+        "---\ntitle: Nested\n---\n\noutside\n",
+    )
+    .unwrap();
+
+    symlink(
+        outside.join("secret.md"),
+        wiki_dir.join("architecture/secret.md"),
+    )
+    .unwrap();
+    symlink(
+        outside.join("collection"),
+        wiki_dir.join("architecture/collection"),
+    )
+    .unwrap();
+
+    let pages = list_pages(&wiki_dir).unwrap();
+
+    assert_eq!(
+        pages,
+        vec![std::path::PathBuf::from("architecture/real.md")]
+    );
+}
+
 #[test]
 fn read_nonexistent_page_errors() {
     let result = read_page(Path::new("/nonexistent/page.md"));

--- a/crates/lw-core/tests/link_test.rs
+++ b/crates/lw-core/tests/link_test.rs
@@ -75,3 +75,29 @@ fn find_broken_links_detects_missing() {
     let broken = find_broken_links(body, &wiki_dir);
     assert_eq!(broken, vec!["nonexistent"]);
 }
+
+#[cfg(unix)]
+#[test]
+fn find_broken_links_treats_symlinked_targets_as_missing() {
+    use std::os::unix::fs::symlink;
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    let wiki_dir = tmp.path().join("wiki");
+    std::fs::create_dir_all(wiki_dir.join("architecture")).unwrap();
+
+    let outside = tmp.path().join("outside");
+    std::fs::create_dir_all(outside.join("category")).unwrap();
+    std::fs::write(outside.join("secret-file.md"), "x").unwrap();
+    std::fs::write(outside.join("category/secret-dir.md"), "x").unwrap();
+
+    symlink(
+        outside.join("secret-file.md"),
+        wiki_dir.join("architecture/secret-file.md"),
+    )
+    .unwrap();
+    symlink(outside.join("category"), wiki_dir.join("leaked")).unwrap();
+
+    let broken = find_broken_links("See [[secret-file]] and [[secret-dir]].", &wiki_dir);
+
+    assert_eq!(broken, vec!["secret-file", "secret-dir"]);
+}


### PR DESCRIPTION
## Summary
- skip symlinked files and directories when listing wiki pages
- save workspace config through a unique temp file instead of a predictable config.toml.tmp sibling
- add regression coverage for both symlink escape paths

## Root Cause
- `list_pages` used path metadata, so directory symlinks were followed and markdown symlink entries were included
- `Config::save_to()` wrote through a fixed `config.toml.tmp` path, allowing pre-existing symlinks to redirect the write

## Validation
- `cargo fmt --check`
- `cargo test -p lw-core`
- `cargo test -p lw-cli`