### PR TITLE
fix(search): reload tantivy reader before search and is_empty (closes #65)

### DIFF
--- a/crates/lw-cli/src/integrate.rs
+++ b/crates/lw-cli/src/integrate.rs
@@ -1,8 +1,8 @@
 use crate::integrations::{
-    descriptor::{expand_tilde, Descriptor, McpFormat},
+    descriptor::{Descriptor, McpFormat, expand_tilde},
     integrations_root, load_all, mcp, skills,
 };
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use std::io::IsTerminal;
 
 pub struct IntegrateOpts {

--- a/crates/lw-core/src/search.rs
+++ b/crates/lw-core/src/search.rs
@@ -124,7 +124,16 @@ impl TantivySearcher {
     /// Callers use this to skip work that would otherwise open the
     /// writer — e.g. a `lw serve` startup rebuild, which would hold
     /// the writer lock for the server's lifetime.
+    ///
+    /// Reloads the reader before checking so long-lived instances see
+    /// commits made by other processes (ReloadPolicy::Manual requires
+    /// explicit reload — it does not auto-refresh).
     pub fn is_empty(&self) -> bool {
+        // Ignore reload errors: is_empty() returns bool, and a stale
+        // snapshot is better than panicking. On success the reader sees
+        // the current on-disk state; on error it falls back to whatever
+        // snapshot it already holds.
+        let _ = self.reader.reload();
         self.reader.searcher().num_docs() == 0
     }
 
@@ -236,6 +245,11 @@ impl Searcher for TantivySearcher {
     #[tracing::instrument(skip(self))]
     fn search(&self, query: &SearchQuery) -> Result<SearchResults> {
         use tantivy::query::AllQuery;
+
+        // Reload before querying so a long-lived instance (e.g. `lw serve`)
+        // sees commits made by other processes. ReloadPolicy::Manual never
+        // auto-refreshes; without this call external writes are invisible.
+        self.reader.reload()?;
 
         let searcher = self.reader.searcher();
 

--- a/crates/lw-core/tests/search_test.rs
+++ b/crates/lw-core/tests/search_test.rs
@@ -1,6 +1,6 @@
-use lw_core::WikiError;
 use lw_core::page::Page;
 use lw_core::search::{SearchQuery, Searcher, TantivySearcher};
+use lw_core::WikiError;
 use tempfile::TempDir;
 
 fn make_page(title: &str, tags: &[&str], body: &str) -> (String, Page) {
@@ -493,5 +493,82 @@ fn is_empty_reflects_persisted_index_across_instances() {
     assert!(
         !reopened.is_empty(),
         "reopened index must see previously-persisted docs"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// External-commit visibility (issue #65)
+//
+// A long-lived TantivySearcher with ReloadPolicy::Manual must call
+// reader.reload() before search() and is_empty() so it sees commits made
+// by other TantivySearcher instances (or other processes) without restart.
+// ---------------------------------------------------------------------------
+
+/// Criterion 1 + 3: searcher A is constructed before searcher B writes any
+/// docs. After B commits, A's search() must return the new document.
+///
+/// This test FAILS on the unpatched code because A's reader snapshot was
+/// taken at construction time and ReloadPolicy::Manual means it will never
+/// refresh unless reload() is called explicitly.
+#[test]
+fn search_sees_external_commit_without_restart() {
+    let tmp = TempDir::new().unwrap();
+
+    // Searcher A: constructed on an empty index — no docs yet.
+    let searcher_a = TantivySearcher::new(tmp.path()).unwrap();
+
+    // Searcher B: writes and commits a document to the same index.
+    let searcher_b = TantivySearcher::new(tmp.path()).unwrap();
+    let (path, page) = make_page(
+        "External Commit",
+        &["reload"],
+        "This document was committed by an external searcher instance.",
+    );
+    searcher_b.index_page(&path, &page).unwrap();
+    searcher_b.commit().unwrap();
+
+    // Searcher A must see the document that B committed — without being
+    // reconstructed. This requires search() to call reader.reload() first.
+    let query = SearchQuery {
+        text: Some("external searcher".into()),
+        tags: vec![],
+        category: None,
+        limit: 10,
+    };
+    let results = searcher_a.search(&query).unwrap();
+    assert_eq!(
+        results.total, 1,
+        "searcher A must see docs committed by searcher B without restart \
+         (requires reader.reload() in search())"
+    );
+    assert_eq!(results.hits[0].title, "External Commit");
+}
+
+/// Criterion 2: is_empty() must reload before checking num_docs(), so a
+/// long-lived searcher that was constructed when the index was empty sees
+/// the current on-disk state after another instance has written to it.
+#[test]
+fn is_empty_sees_external_commit_without_restart() {
+    let tmp = TempDir::new().unwrap();
+
+    // Searcher A: constructed on an empty index.
+    let searcher_a = TantivySearcher::new(tmp.path()).unwrap();
+    assert!(
+        searcher_a.is_empty(),
+        "fresh index must be empty before any writes"
+    );
+
+    // Searcher B: writes and commits a document.
+    let searcher_b = TantivySearcher::new(tmp.path()).unwrap();
+    let (path, page) = make_page("IsEmpty Reload", &[], "Body for is_empty reload test.");
+    searcher_b.index_page(&path, &page).unwrap();
+    searcher_b.commit().unwrap();
+
+    // Searcher A's is_empty() must return false now — requires reader.reload()
+    // inside is_empty() before the num_docs() check.
+    assert!(
+        !searcher_a.is_empty(),
+        "is_empty() must return false after an external commit \
+         (requires reader.reload() inside is_empty())"
     );
 }

--- a/crates/lw-core/tests/search_test.rs
+++ b/crates/lw-core/tests/search_test.rs
@@ -1,6 +1,6 @@
+use lw_core::WikiError;
 use lw_core::page::Page;
 use lw_core::search::{SearchQuery, Searcher, TantivySearcher};
-use lw_core::WikiError;
 use tempfile::TempDir;
 
 fn make_page(title: &str, tags: &[&str], body: &str) -> (String, Page) {


### PR DESCRIPTION
## Summary

- Fixes #65
- **Root cause:** `TantivySearcher` reader is configured with `ReloadPolicy::Manual`, so it never sees commits made by another process — a long-lived `lw serve` keeps serving a stale snapshot.
- **Fix:** Call `reader.reload()` at the start of `search()` and inside `is_empty()` so the searcher syncs with on-disk state before each query/decision.

## Acceptance Criteria Evidence

- [x] Criterion 1 — `search()` reloads — Evidence: `crates/lw-core/src/search.rs:252` (`self.reader.reload()?;` at top of `Searcher::search`)
- [x] Criterion 2 — `is_empty()` reloads — Evidence: `crates/lw-core/src/search.rs:136` (`let _ = self.reader.reload();` inside `TantivySearcher::is_empty`); covers the `lw-mcp/src/lib.rs:644` startup-rebuild gate.
- [x] Criterion 3 — Regression test — Evidence: `crates/lw-core/tests/search_test.rs::search_sees_external_commit_without_restart` and `::is_empty_sees_external_commit_without_restart` (added in b34ffa1). Verified failing on the unpatched search.rs (stash test) and passing here.
- [x] Criterion 4 — `cargo test --workspace` + `cargo clippy --all-targets -- -D warnings` green — Evidence: full workspace `288 passed (26 suites)`; clippy `No issues found`; `cargo fmt --all -- --check` clean.

## Test Plan

- [x] New tests exercise external-commit visibility (verified failing on main, passing here)
- [x] Full workspace test suite passes single-threaded (`cargo test --workspace -- --test-threads=1`)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)