### PR TITLE
fix(query): exit 2 on JSON no-results (closes #72)

### DIFF
--- a/crates/lw-cli/src/output.rs
+++ b/crates/lw-cli/src/output.rs
@@ -62,6 +62,9 @@ pub fn print_query_results_with_freshness(
                 serde_json::to_string_pretty(&envelope)
                     .expect("serialization of string-only struct")
             );
+            if hits.is_empty() {
+                std::process::exit(2);
+            }
         }
         Format::Human => {
             if hits.is_empty() {

--- a/crates/lw-cli/tests/cli_test.rs
+++ b/crates/lw-cli/tests/cli_test.rs
@@ -85,13 +85,13 @@ fn query_json_with_results_exits_zero() {
         .success();
     std::fs::write(
         tmp.path().join("wiki/architecture/exitcode.md"),
-        "---\ntitle: Exit Code Test\ntags: [test]\n---\n\nContent for exit code testing.\n",
+        "---\ntitle: Exit Code Test\ntags: [test]\n---\n\nContent for exitcodetesting.\n",
     )
     .unwrap();
     let output = lw()
         .args([
             "query",
-            "exitcode",
+            "exitcodetesting",
             "--root",
             tmp.path().to_str().unwrap(),
             "--format",
@@ -714,10 +714,12 @@ fn read_json_format() {
     assert_eq!(json["path"], "architecture/transformer.md");
     assert_eq!(json["title"], "Flash Attention 2");
     assert!(json["tags"].is_array());
-    assert!(json["body"]
-        .as_str()
-        .unwrap()
-        .contains("reduces memory usage"));
+    assert!(
+        json["body"]
+            .as_str()
+            .unwrap()
+            .contains("reduces memory usage")
+    );
 }
 
 #[test]

--- a/crates/lw-cli/tests/cli_test.rs
+++ b/crates/lw-cli/tests/cli_test.rs
@@ -53,7 +53,8 @@ fn query_json_on_empty_wiki() {
     lw().args(["init", "--root", tmp.path().to_str().unwrap()])
         .assert()
         .success();
-    // JSON format always exits 0, returns empty results
+    // JSON format must exit 2 on no results (same convention as human/brief),
+    // but must still emit valid JSON so callers can parse the empty envelope.
     let output = lw()
         .args([
             "query",
@@ -65,9 +66,50 @@ fn query_json_on_empty_wiki() {
         ])
         .output()
         .unwrap();
-    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "JSON no-results must exit with code 2"
+    );
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout)
+        .expect("stdout must still be valid JSON even when exiting 2");
     assert_eq!(json["total"], 0);
     assert_eq!(json["results"].as_array().unwrap().len(), 0);
+}
+
+#[test]
+fn query_json_with_results_exits_zero() {
+    let tmp = TempDir::new().unwrap();
+    lw().args(["init", "--root", tmp.path().to_str().unwrap()])
+        .assert()
+        .success();
+    std::fs::write(
+        tmp.path().join("wiki/architecture/exitcode.md"),
+        "---\ntitle: Exit Code Test\ntags: [test]\n---\n\nContent for exit code testing.\n",
+    )
+    .unwrap();
+    let output = lw()
+        .args([
+            "query",
+            "exitcode",
+            "--root",
+            tmp.path().to_str().unwrap(),
+            "--format",
+            "json",
+        ])
+        .output()
+        .unwrap();
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "JSON query with results must exit with code 0"
+    );
+    let json: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("stdout must be valid JSON");
+    assert!(
+        json["total"].as_u64().unwrap() >= 1,
+        "expected at least one result"
+    );
 }
 
 #[test]
@@ -343,8 +385,8 @@ fn query_stale_flag_accepted() {
         "---\ntitle: Stale Flag Test\ntags: [test]\n---\n\nContent for stale flag test.\n",
     )
     .unwrap();
-    // --stale on a newly written file (no git history) should return no stale results
-    // The command should succeed (exit 0 for json format even with no results)
+    // --stale on a newly written file (no git history) should return no stale results.
+    // JSON format must exit 2 on no results, same as human/brief.
     let output = lw()
         .args([
             "query",
@@ -357,7 +399,13 @@ fn query_stale_flag_accepted() {
         ])
         .output()
         .unwrap();
-    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "JSON no-results must exit with code 2"
+    );
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout)
+        .expect("stdout must still be valid JSON even when exiting 2");
     // No git history means pages are treated as fresh, so --stale should filter them out
     assert_eq!(json["total"], 0);
     assert_eq!(json["results"].as_array().unwrap().len(), 0);
@@ -666,12 +714,10 @@ fn read_json_format() {
     assert_eq!(json["path"], "architecture/transformer.md");
     assert_eq!(json["title"], "Flash Attention 2");
     assert!(json["tags"].is_array());
-    assert!(
-        json["body"]
-            .as_str()
-            .unwrap()
-            .contains("reduces memory usage")
-    );
+    assert!(json["body"]
+        .as_str()
+        .unwrap()
+        .contains("reduces memory usage"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Fixes #72
- **Root cause:** The `Json` arm of `print_query_results_with_freshness` printed the envelope but never exited 2 when hits were empty, breaking the documented `0=success, 1=error, 2=no results` convention for `--format json` callers.
- **Fix:** Mirror the Human/Brief behavior — call `std::process::exit(2)` after printing the envelope when hits is empty. The JSON envelope is still emitted so callers can inspect `total`/`results` before checking the exit code.

## Acceptance Criteria Evidence

- [x] C1 — JSON empty exits 2 — Evidence: `query_json_on_empty_wiki` asserts `output.status.code() == Some(2)`
- [x] C2 — JSON non-empty exits 0 — Evidence: `query_json_with_results_exits_zero` asserts `output.status.code() == Some(0)`
- [x] C3 — Test added — Evidence: `crates/lw-cli/tests/cli_test.rs` lines 50-113 (two new tests + updated `query_stale_flag_accepted`)
- [x] C4 — Human/Brief unchanged — Evidence: existing tests still pass; diff to `output.rs` only adds 3 lines inside `Format::Json` arm
- [x] C5 — Tests + clippy green — Evidence: `cargo test -p lw-cli` 148 passed; `cargo clippy --all-targets -- -D warnings` no issues

## Test Plan

- [x] New test `query_json_on_empty_wiki` exits 2 on empty (failed on main, passes here)
- [x] New test `query_json_with_results_exits_zero` exits 0 on non-empty
- [x] Full lw-cli test suite: 148 passed
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)