### PR TITLE
feat(schema): per-category templates and required fields (closes #58)

### DIFF
--- a/crates/lw-core/src/schema.rs
+++ b/crates/lw-core/src/schema.rs
@@ -16,8 +16,7 @@ pub struct CategoryConfig {
 pub struct WikiSchema {
     pub wiki: WikiConfig,
     pub tags: TagsConfig,
-    /// Stub: always empty — not loaded from TOML until GREEN commit.
-    #[serde(skip)]
+    #[serde(default)]
     pub categories: HashMap<String, CategoryConfig>,
 }
 
@@ -58,9 +57,8 @@ impl WikiSchema {
     }
 
     /// Return the [`CategoryConfig`] for a named category, or `None` if not configured.
-    /// Stub: always returns `None` until GREEN commit.
-    pub fn category_config(&self, _name: &str) -> Option<&CategoryConfig> {
-        None
+    pub fn category_config(&self, name: &str) -> Option<&CategoryConfig> {
+        self.categories.get(name)
     }
 }
 

--- a/crates/lw-core/src/schema.rs
+++ b/crates/lw-core/src/schema.rs
@@ -2,10 +2,23 @@ use crate::{Result, WikiError};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
+/// Per-category configuration block (`[categories.<name>]` in schema.toml).
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CategoryConfig {
+    pub review_days: Option<u32>,
+    #[serde(default)]
+    pub required_fields: Vec<String>,
+    #[serde(default)]
+    pub template: String,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WikiSchema {
     pub wiki: WikiConfig,
     pub tags: TagsConfig,
+    /// Stub: always empty — not loaded from TOML until GREEN commit.
+    #[serde(skip)]
+    pub categories: HashMap<String, CategoryConfig>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -43,6 +56,12 @@ impl WikiSchema {
         dirs.push("_uncategorized".to_string());
         dirs
     }
+
+    /// Return the [`CategoryConfig`] for a named category, or `None` if not configured.
+    /// Stub: always returns `None` until GREEN commit.
+    pub fn category_config(&self, _name: &str) -> Option<&CategoryConfig> {
+        None
+    }
 }
 
 impl Default for WikiSchema {
@@ -70,6 +89,7 @@ impl Default for WikiSchema {
                     ("ops".into(), "normal".into()),
                 ]),
             },
+            categories: HashMap::new(),
         }
     }
 }

--- a/crates/lw-core/tests/schema_test.rs
+++ b/crates/lw-core/tests/schema_test.rs
@@ -1,4 +1,4 @@
-use lw_core::schema::WikiSchema;
+use lw_core::schema::{CategoryConfig, WikiSchema};
 
 #[test]
 fn parse_full_schema() {
@@ -42,4 +42,187 @@ fn decay_for_category() {
     assert_eq!(schema.decay_for_category("product"), "fast");
     assert_eq!(schema.decay_for_category("architecture"), "normal");
     assert_eq!(schema.decay_for_category("unknown"), "normal");
+}
+
+// ── Per-category templates (issue #58) ────────────────────────────────────────
+
+/// Acceptance criterion 1: parse [categories.<name>] blocks with all three fields.
+#[test]
+fn parse_category_blocks_all_fields() {
+    let toml_str = r#"
+[wiki]
+name = "Test Wiki"
+default_review_days = 90
+
+[tags]
+categories = ["tools", "concepts"]
+
+[categories.tools]
+review_days = 90
+required_fields = ["title", "tags"]
+template = """
+## Overview
+
+## Usage
+
+## See Also
+"""
+
+[categories.concepts]
+review_days = 180
+required_fields = ["title", "tags", "aliases"]
+template = """
+## Definition
+
+## Key Properties
+
+## Examples
+
+## Related Concepts
+"""
+"#;
+    let schema = WikiSchema::parse(toml_str).unwrap();
+
+    // tools category
+    let tools = schema.categories.get("tools").unwrap();
+    assert_eq!(tools.review_days, Some(90));
+    assert_eq!(tools.required_fields, vec!["title", "tags"]);
+    assert!(tools.template.contains("## Overview"));
+    assert!(tools.template.contains("## Usage"));
+    assert!(tools.template.contains("## See Also"));
+
+    // concepts category
+    let concepts = schema.categories.get("concepts").unwrap();
+    assert_eq!(concepts.review_days, Some(180));
+    assert_eq!(concepts.required_fields, vec!["title", "tags", "aliases"]);
+    assert!(concepts.template.contains("## Definition"));
+    assert!(concepts.template.contains("## Key Properties"));
+    assert!(concepts.template.contains("## Examples"));
+    assert!(concepts.template.contains("## Related Concepts"));
+}
+
+/// Acceptance criterion 2: schema without any [categories] block still parses (backward compat).
+#[test]
+fn parse_schema_without_categories_block() {
+    let toml_str = r#"
+[wiki]
+name = "Backward Compat Wiki"
+default_review_days = 60
+
+[tags]
+categories = ["architecture", "infra"]
+"#;
+    let schema = WikiSchema::parse(toml_str).unwrap();
+    assert!(
+        schema.categories.is_empty(),
+        "categories map should be empty when [categories] is absent"
+    );
+}
+
+/// Acceptance criterion 3: round-trip — deserialize → serialize → deserialize preserves categories.
+#[test]
+fn round_trip_preserves_categories() {
+    let toml_str = r#"
+[wiki]
+name = "Round-trip Wiki"
+default_review_days = 90
+
+[tags]
+categories = ["tools"]
+
+[categories.tools]
+review_days = 90
+required_fields = ["title", "tags"]
+template = """
+## Overview
+
+## Usage
+"""
+"#;
+    let schema = WikiSchema::parse(toml_str).unwrap();
+    let serialized = schema.to_toml();
+    let reparsed = WikiSchema::parse(&serialized).unwrap();
+
+    assert_eq!(reparsed.categories.len(), schema.categories.len());
+    let orig_tools = schema.categories.get("tools").unwrap();
+    let reparsed_tools = reparsed.categories.get("tools").unwrap();
+    assert_eq!(reparsed_tools.review_days, orig_tools.review_days);
+    assert_eq!(reparsed_tools.required_fields, orig_tools.required_fields);
+    assert_eq!(reparsed_tools.template, orig_tools.template);
+}
+
+/// Acceptance criterion 4: category_config helper returns Some for known, None for unknown.
+#[test]
+fn category_config_helper() {
+    let toml_str = r#"
+[wiki]
+name = "Helper Wiki"
+default_review_days = 90
+
+[tags]
+categories = ["tools"]
+
+[categories.tools]
+review_days = 45
+required_fields = ["title"]
+template = ""
+"#;
+    let schema = WikiSchema::parse(toml_str).unwrap();
+
+    let cfg: Option<&CategoryConfig> = schema.category_config("tools");
+    assert!(cfg.is_some(), "known category should return Some");
+    assert_eq!(cfg.unwrap().review_days, Some(45));
+
+    let missing = schema.category_config("nonexistent");
+    assert!(missing.is_none(), "unknown category should return None");
+}
+
+/// Edge case: CategoryConfig with review_days absent (optional field).
+#[test]
+fn category_config_review_days_optional() {
+    let toml_str = r#"
+[wiki]
+name = "No-ReviewDays Wiki"
+default_review_days = 90
+
+[tags]
+categories = ["notes"]
+
+[categories.notes]
+required_fields = []
+template = ""
+"#;
+    let schema = WikiSchema::parse(toml_str).unwrap();
+    let notes = schema.categories.get("notes").unwrap();
+    assert!(
+        notes.review_days.is_none(),
+        "review_days should be None when absent"
+    );
+    assert!(notes.required_fields.is_empty());
+}
+
+/// Edge case: CategoryConfig with empty required_fields (default).
+#[test]
+fn category_config_empty_required_fields_default() {
+    let toml_str = r#"
+[wiki]
+name = "Minimal Category Wiki"
+default_review_days = 90
+
+[tags]
+categories = ["misc"]
+
+[categories.misc]
+review_days = 30
+"#;
+    let schema = WikiSchema::parse(toml_str).unwrap();
+    let misc = schema.categories.get("misc").unwrap();
+    assert!(
+        misc.required_fields.is_empty(),
+        "required_fields should default to empty vec"
+    );
+    assert!(
+        misc.template.is_empty(),
+        "template should default to empty string"
+    );
 }


### PR DESCRIPTION
## Summary

- Closes #58
- Adds `CategoryConfig` struct with `review_days` / `required_fields` / `template`.
- Adds `WikiSchema.categories: HashMap<String, CategoryConfig>` (backward compatible — `#[serde(default)]`).
- Adds `WikiSchema::category_config(name)` accessor for downstream consumers (#59).
- Pure parser-side change. No CLI / MCP surface.

## Acceptance Criteria Evidence

- [x] **Parses `[categories.<name>]` blocks** — `crates/lw-core/tests/schema_test.rs::parse_category_blocks_all_fields` (lines 51–102): parses both `tools` (review_days=90, 2 required_fields, template with 3 sections) and `concepts` (review_days=180, 3 required_fields, template with 4 sections) blocks and asserts all three fields on each.
- [x] **Backward compat** — `crates/lw-core/tests/schema_test.rs::parse_schema_without_categories_block` (lines 105–120): parses a schema with no `[categories]` block and asserts `schema.categories.is_empty()`.
- [x] **Round-trip preservation** — `crates/lw-core/tests/schema_test.rs::round_trip_preserves_categories` (lines 123–152): serializes via `to_toml()` and re-parses, asserting equality of `review_days`, `required_fields`, and `template` on the re-parsed `categories` map.
- [x] **Helper `category_config`** — method defined at `crates/lw-core/src/schema.rs:60`; tested at `crates/lw-core/tests/schema_test.rs::category_config_helper` (lines 155–178) for both `Some` (known category, asserts `review_days`) and `None` (unknown key) paths.
- [x] **No CLI/MCP changes** — `git diff --name-only $(git merge-base origin/main HEAD) HEAD` lists only `crates/lw-core/src/schema.rs` and `crates/lw-core/tests/schema_test.rs`.

## Additional Edge Cases Tested

- `category_config_review_days_optional` (lines 181–202): `review_days` absent → `None`.
- `category_config_empty_required_fields_default` (lines 205–228): no `required_fields` in TOML → empty `Vec`, no `template` → empty `String`.

## Test Plan

- [x] New unit tests added for all 5 criteria + 2 edge cases.
- [x] `cargo test -p lw-core` — 147 tests pass.
- [x] `cargo test` (full workspace) — 308 tests pass.
- [x] `cargo clippy --all-targets -- -D warnings` clean.
- [x] `cargo fmt --all` — no changes needed.
- [ ] CI passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)