### PR TITLE
feat(core): lw_core::new_page schema-enforced page creation (closes #59)

### DIFF
--- a/crates/lw-core/src/error.rs
+++ b/crates/lw-core/src/error.rs
@@ -42,6 +42,18 @@ pub enum WikiError {
         "index at {path} is locked by another lw process (likely `lw serve`) — try again once it exits"
     )]
     IndexLocked { path: PathBuf },
+
+    #[error("page already exists: {path}")]
+    PageAlreadyExists { path: PathBuf },
+
+    #[error("unknown category: {name} (valid: {valid})")]
+    UnknownCategory { name: String, valid: String },
+
+    #[error("category {category} requires field: {field}")]
+    MissingRequiredField { category: String, field: String },
+
+    #[error("invalid slug: {slug} (must match [a-z0-9_-]+, no path separators)")]
+    InvalidSlug { slug: String },
 }
 
 pub type Result<T> = std::result::Result<T, WikiError>;

--- a/crates/lw-core/src/fs.rs
+++ b/crates/lw-core/src/fs.rs
@@ -207,6 +207,47 @@ pub fn canonicalize_ancestor(path: &Path) -> PathBuf {
     result
 }
 
+/// Request parameters for creating a new wiki page.
+pub struct NewPageRequest<'a> {
+    pub category: &'a str,
+    pub slug: &'a str,
+    pub title: String,
+    pub tags: Vec<String>,
+    pub author: Option<String>,
+}
+
+/// Create a new wiki page with schema-enforced frontmatter and body template.
+///
+/// Validates the slug, checks the category against the schema, enforces required
+/// fields, refuses to overwrite an existing file, then calls `write_page` (which
+/// uses `atomic_write` internally).
+///
+/// # Errors
+///
+/// - `InvalidSlug` — slug is empty, contains `/` or `..`, starts with `.`, or
+///   contains characters outside `[a-z0-9_-]`
+/// - `UnknownCategory` — category is not `_uncategorized` and not listed in
+///   `schema.tags.categories`
+/// - `MissingRequiredField` — a field declared in the category's `required_fields`
+///   is not satisfied by the request
+/// - `PageAlreadyExists` — a file already exists at the computed path
+///
+/// # Stub (RED state)
+///
+/// This stub always returns `Err(WikiError::InvalidSlug)` so that happy-path
+/// tests fail at runtime while the project compiles. Replace with the real
+/// implementation in the GREEN commit.
+#[tracing::instrument(skip_all)]
+pub fn new_page(
+    _wiki_root: &Path,
+    _schema: &WikiSchema,
+    req: NewPageRequest<'_>,
+) -> Result<(PathBuf, Page)> {
+    Err(WikiError::InvalidSlug {
+        slug: req.slug.to_string(),
+    })
+}
+
 /// Walk up from `start` to find the wiki root (directory containing `.lw/schema.toml`).
 /// Similar to how git finds `.git/`.
 #[tracing::instrument]

--- a/crates/lw-core/src/fs.rs
+++ b/crates/lw-core/src/fs.rs
@@ -231,21 +231,100 @@ pub struct NewPageRequest<'a> {
 /// - `MissingRequiredField` — a field declared in the category's `required_fields`
 ///   is not satisfied by the request
 /// - `PageAlreadyExists` — a file already exists at the computed path
-///
-/// # Stub (RED state)
-///
-/// This stub always returns `Err(WikiError::InvalidSlug)` so that happy-path
-/// tests fail at runtime while the project compiles. Replace with the real
-/// implementation in the GREEN commit.
 #[tracing::instrument(skip_all)]
 pub fn new_page(
-    _wiki_root: &Path,
-    _schema: &WikiSchema,
+    wiki_root: &Path,
+    schema: &WikiSchema,
     req: NewPageRequest<'_>,
 ) -> Result<(PathBuf, Page)> {
-    Err(WikiError::InvalidSlug {
-        slug: req.slug.to_string(),
-    })
+    // Step 1: validate slug — must match ^[a-z0-9_-]+$
+    validate_slug(req.slug)?;
+
+    // Step 2: validate category
+    let category = req.category;
+    if category != "_uncategorized" && !schema.tags.categories.contains(&category.to_string()) {
+        let valid = schema.tags.categories.join(", ");
+        return Err(WikiError::UnknownCategory {
+            name: category.to_string(),
+            valid,
+        });
+    }
+
+    // Step 3: look up CategoryConfig (None → empty template, no required fields)
+    let (template, required_fields) = match schema.category_config(category) {
+        Some(cfg) => (cfg.template.clone(), cfg.required_fields.clone()),
+        None => (String::new(), Vec::new()),
+    };
+
+    // Step 4: check required fields
+    for field in &required_fields {
+        let satisfied = match field.as_str() {
+            "title" => !req.title.is_empty(),
+            "tags" => !req.tags.is_empty(),
+            "author" => req.author.is_some(),
+            // Any field not representable in NewPageRequest is unsatisfiable
+            _ => false,
+        };
+        if !satisfied {
+            return Err(WikiError::MissingRequiredField {
+                category: category.to_string(),
+                field: field.clone(),
+            });
+        }
+    }
+
+    // Step 5: compute target path; refuse to overwrite
+    let target = wiki_root
+        .join("wiki")
+        .join(category)
+        .join(format!("{}.md", req.slug));
+    if target.exists() {
+        return Err(WikiError::PageAlreadyExists { path: target });
+    }
+
+    // Step 6: build Page
+    let page = Page {
+        title: req.title,
+        tags: req.tags,
+        decay: None,
+        sources: vec![],
+        author: req.author,
+        generator: None,
+        related: None,
+        body: template,
+    };
+
+    // Step 7: write atomically via write_page (which calls atomic_write internally)
+    write_page(&target, &page)?;
+
+    // Step 8: return path + page
+    Ok((target, page))
+}
+
+/// Validate that a slug matches `^[a-z0-9_-]+$` and contains no path-separator
+/// sequences (`/`, `..`, leading `.`).
+fn validate_slug(slug: &str) -> Result<()> {
+    if slug.is_empty() {
+        return Err(WikiError::InvalidSlug {
+            slug: slug.to_string(),
+        });
+    }
+    // Reject leading dot (hidden files / relative-path abuse)
+    if slug.starts_with('.') {
+        return Err(WikiError::InvalidSlug {
+            slug: slug.to_string(),
+        });
+    }
+    // Reject any character outside [a-z0-9_-]
+    let valid = slug
+        .chars()
+        .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '_' || c == '-');
+    if !valid {
+        return Err(WikiError::InvalidSlug {
+            slug: slug.to_string(),
+        });
+    }
+    Ok(())
 }
 
 /// Walk up from `start` to find the wiki root (directory containing `.lw/schema.toml`).

--- a/crates/lw-core/tests/new_page_test.rs
+++ b/crates/lw-core/tests/new_page_test.rs
@@ -1,5 +1,3 @@
-use lw_core::fs::{init_wiki, new_page, read_page, NewPageRequest};
-use lw_core::schema::{CategoryConfig, WikiSchema};
 /// Tests for `lw_core::fs::new_page` (issue #59)
 ///
 /// These tests cover all acceptance criteria from the spec:
@@ -12,7 +10,8 @@ use lw_core::schema::{CategoryConfig, WikiSchema};
 ///   7. Category without `[categories.<name>]` block uses empty template (no crash)
 ///   8. Display strings for all four new error variants match canonical spec wording
 use lw_core::WikiError;
-use std::collections::HashMap;
+use lw_core::fs::{NewPageRequest, init_wiki, new_page, read_page};
+use lw_core::schema::{CategoryConfig, WikiSchema};
 use tempfile::TempDir;
 
 // ── helpers ──────────────────────────────────────────────────────────────────
@@ -424,8 +423,3 @@ fn no_author_is_accepted() {
     assert!(path.exists());
     assert_eq!(page.author, None);
 }
-
-// ── Unused import suppression ─────────────────────────────────────────────────
-// HashMap is used only to construct schemas inside helpers; keep lint quiet.
-#[allow(unused_imports)]
-use std::collections::HashMap as _HashMap;

--- a/crates/lw-core/tests/new_page_test.rs
+++ b/crates/lw-core/tests/new_page_test.rs
@@ -1,0 +1,431 @@
+use lw_core::fs::{init_wiki, new_page, read_page, NewPageRequest};
+use lw_core::schema::{CategoryConfig, WikiSchema};
+/// Tests for `lw_core::fs::new_page` (issue #59)
+///
+/// These tests cover all acceptance criteria from the spec:
+///   1. Happy path — file created, frontmatter correct, body == category template
+///   2. Duplicate slug → `PageAlreadyExists`, file unchanged
+///   3. Missing required field → `MissingRequiredField`
+///   4. Unknown category → `UnknownCategory`
+///   5. `_uncategorized` accepted with empty template (no crash)
+///   6. Invalid slugs (`/`, `..`, empty, uppercase) → `InvalidSlug`
+///   7. Category without `[categories.<name>]` block uses empty template (no crash)
+///   8. Display strings for all four new error variants match canonical spec wording
+use lw_core::WikiError;
+use std::collections::HashMap;
+use tempfile::TempDir;
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+/// Build a `WikiSchema` with one category that has a template + required field.
+fn schema_with_tools_category() -> WikiSchema {
+    let mut schema = WikiSchema::default();
+    // "tools" is already in default categories; give it a template + required field.
+    schema.categories.insert(
+        "tools".to_string(),
+        CategoryConfig {
+            review_days: None,
+            required_fields: vec!["title".to_string()],
+            template: "## Overview\n\nDescribe the tool here.\n".to_string(),
+        },
+    );
+    schema
+}
+
+fn req<'a>(category: &'a str, slug: &'a str, title: &str) -> NewPageRequest<'a> {
+    NewPageRequest {
+        category,
+        slug,
+        title: title.to_string(),
+        tags: vec!["rust".to_string()],
+        author: Some("alice".to_string()),
+    }
+}
+
+// ── Acceptance criterion 1: happy path ───────────────────────────────────────
+
+/// Happy path: file is created, frontmatter matches request, body == template.
+#[test]
+fn happy_path_creates_file_with_correct_content() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    let schema = schema_with_tools_category();
+    init_wiki(root, &schema).unwrap();
+
+    let request = NewPageRequest {
+        category: "tools",
+        slug: "my-tool",
+        title: "My Tool".to_string(),
+        tags: vec!["rust".to_string(), "cli".to_string()],
+        author: Some("alice".to_string()),
+    };
+
+    let (path, page) = new_page(root, &schema, request).unwrap();
+
+    // Path must be under wiki_root/wiki/tools/my-tool.md
+    assert_eq!(path, root.join("wiki/tools/my-tool.md"));
+    assert!(path.exists(), "file should have been written to disk");
+
+    // Frontmatter
+    assert_eq!(page.title, "My Tool");
+    assert_eq!(page.tags, vec!["rust".to_string(), "cli".to_string()]);
+    assert_eq!(page.author, Some("alice".to_string()));
+
+    // Body == category template
+    assert_eq!(
+        page.body, "## Overview\n\nDescribe the tool here.\n",
+        "body must equal the category template"
+    );
+
+    // Round-trip: read back from disk and verify
+    let loaded = read_page(&path).unwrap();
+    assert_eq!(loaded.title, "My Tool");
+    assert_eq!(loaded.tags, vec!["rust".to_string(), "cli".to_string()]);
+}
+
+// ── Acceptance criterion 2: duplicate slug → PageAlreadyExists ───────────────
+
+/// Writing the same slug twice must return `PageAlreadyExists` on the second call,
+/// and must NOT overwrite the first file.
+#[test]
+fn duplicate_slug_returns_page_already_exists() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    let schema = schema_with_tools_category();
+    init_wiki(root, &schema).unwrap();
+
+    let make_req = || NewPageRequest {
+        category: "tools",
+        slug: "duplicate",
+        title: "Duplicate Tool".to_string(),
+        tags: vec![],
+        author: None,
+    };
+
+    // First write succeeds
+    let (path, _) = new_page(root, &schema, make_req()).unwrap();
+    let original_content = std::fs::read_to_string(&path).unwrap();
+
+    // Second write must fail
+    let err = new_page(root, &schema, make_req()).unwrap_err();
+    match err {
+        WikiError::PageAlreadyExists { path: err_path } => {
+            assert_eq!(err_path, root.join("wiki/tools/duplicate.md"));
+        }
+        other => panic!("expected PageAlreadyExists, got {other:?}"),
+    }
+
+    // File must be unchanged
+    let after_content = std::fs::read_to_string(&path).unwrap();
+    assert_eq!(
+        original_content, after_content,
+        "duplicate write must not modify the existing file"
+    );
+}
+
+// ── Acceptance criterion 3: missing required field → MissingRequiredField ────
+
+/// When a category declares `required_fields = ["title"]` and the request has
+/// an empty title, `MissingRequiredField` must be returned.
+#[test]
+fn missing_required_title_returns_error() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    let schema = schema_with_tools_category();
+    init_wiki(root, &schema).unwrap();
+
+    let request = NewPageRequest {
+        category: "tools",
+        slug: "empty-title",
+        title: String::new(), // ← empty title
+        tags: vec![],
+        author: None,
+    };
+
+    let err = new_page(root, &schema, request).unwrap_err();
+    match err {
+        WikiError::MissingRequiredField { category, field } => {
+            assert_eq!(category, "tools");
+            assert_eq!(field, "title");
+        }
+        other => panic!("expected MissingRequiredField, got {other:?}"),
+    }
+}
+
+/// When a category declares `required_fields = ["tags"]` and the request has
+/// empty tags, `MissingRequiredField` must be returned.
+#[test]
+fn missing_required_tags_returns_error() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    let mut schema = WikiSchema::default();
+    schema.categories.insert(
+        "tools".to_string(),
+        CategoryConfig {
+            review_days: None,
+            required_fields: vec!["tags".to_string()],
+            template: String::new(),
+        },
+    );
+    init_wiki(root, &schema).unwrap();
+
+    let request = NewPageRequest {
+        category: "tools",
+        slug: "notags",
+        title: "No Tags".to_string(),
+        tags: vec![], // ← empty tags
+        author: None,
+    };
+
+    let err = new_page(root, &schema, request).unwrap_err();
+    match err {
+        WikiError::MissingRequiredField { category, field } => {
+            assert_eq!(category, "tools");
+            assert_eq!(field, "tags");
+        }
+        other => panic!("expected MissingRequiredField, got {other:?}"),
+    }
+}
+
+// ── Acceptance criterion 4: unknown category → UnknownCategory ───────────────
+
+/// A category that is not in `schema.tags.categories` (and not `_uncategorized`)
+/// must return `UnknownCategory`.
+#[test]
+fn unknown_category_returns_error() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    let schema = WikiSchema::default();
+    init_wiki(root, &schema).unwrap();
+
+    let request = req("nonexistent-category", "some-slug", "Title");
+    let err = new_page(root, &schema, request).unwrap_err();
+    match err {
+        WikiError::UnknownCategory { name, valid } => {
+            assert_eq!(name, "nonexistent-category");
+            // valid must be a comma-separated list of schema categories
+            for cat in &schema.tags.categories {
+                assert!(
+                    valid.contains(cat.as_str()),
+                    "valid list '{valid}' must contain '{cat}'"
+                );
+            }
+        }
+        other => panic!("expected UnknownCategory, got {other:?}"),
+    }
+}
+
+// ── Acceptance criterion 5: _uncategorized accepted with empty template ───────
+
+/// `_uncategorized` is always a valid category and must succeed with an empty body.
+#[test]
+fn uncategorized_accepted_with_empty_template() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    let schema = WikiSchema::default();
+    init_wiki(root, &schema).unwrap();
+
+    let request = NewPageRequest {
+        category: "_uncategorized",
+        slug: "misc-note",
+        title: "Misc Note".to_string(),
+        tags: vec![],
+        author: None,
+    };
+
+    let (path, page) = new_page(root, &schema, request).unwrap();
+    assert_eq!(path, root.join("wiki/_uncategorized/misc-note.md"));
+    assert!(path.exists());
+    // No template configured → body must be empty (or at most whitespace)
+    assert!(
+        page.body.trim().is_empty(),
+        "uncategorized page body must be empty when no template configured"
+    );
+}
+
+// ── Acceptance criterion 6: invalid slugs → InvalidSlug ─────────────────────
+
+fn assert_invalid_slug(slug: &str) {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    let schema = WikiSchema::default();
+    init_wiki(root, &schema).unwrap();
+
+    let request = NewPageRequest {
+        category: "tools",
+        slug,
+        title: "Title".to_string(),
+        tags: vec![],
+        author: None,
+    };
+
+    let err = new_page(root, &schema, request).unwrap_err();
+    match err {
+        WikiError::InvalidSlug { slug: bad } => {
+            assert_eq!(bad, slug, "error slug must echo the input");
+        }
+        other => panic!("expected InvalidSlug for slug={slug:?}, got {other:?}"),
+    }
+}
+
+#[test]
+fn empty_slug_is_invalid() {
+    assert_invalid_slug("");
+}
+
+#[test]
+fn slug_with_slash_is_invalid() {
+    assert_invalid_slug("foo/bar");
+}
+
+#[test]
+fn slug_double_dot_is_invalid() {
+    assert_invalid_slug("..");
+}
+
+#[test]
+fn slug_leading_dot_is_invalid() {
+    assert_invalid_slug(".hidden");
+}
+
+#[test]
+fn slug_uppercase_is_invalid() {
+    assert_invalid_slug("FooBar");
+}
+
+#[test]
+fn slug_with_space_is_invalid() {
+    assert_invalid_slug("foo bar");
+}
+
+/// Valid slugs must not return an error.
+#[test]
+fn valid_slugs_are_accepted() {
+    for valid in &["foo", "foo-bar", "foo_bar", "foo123", "123", "a-b-c"] {
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        let schema = WikiSchema::default();
+        init_wiki(root, &schema).unwrap();
+
+        let request = NewPageRequest {
+            category: "tools",
+            slug: valid,
+            title: "T".to_string(),
+            tags: vec![],
+            author: None,
+        };
+
+        new_page(root, &schema, request)
+            .unwrap_or_else(|e| panic!("slug {valid:?} should be valid but got {e:?}"));
+    }
+}
+
+// ── Acceptance criterion 7: category without config block uses empty template ─
+
+/// A category that is listed in `schema.tags.categories` but has no
+/// `[categories.<name>]` block must produce an empty-body page (no crash).
+#[test]
+fn category_without_config_block_uses_empty_template() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    // Default schema has "architecture" with no CategoryConfig entry
+    let schema = WikiSchema::default();
+    assert!(
+        schema.category_config("architecture").is_none(),
+        "test setup: architecture must have no config block in default schema"
+    );
+    init_wiki(root, &schema).unwrap();
+
+    let request = NewPageRequest {
+        category: "architecture",
+        slug: "transformer",
+        title: "Transformer".to_string(),
+        tags: vec!["ml".to_string()],
+        author: None,
+    };
+
+    let (path, page) = new_page(root, &schema, request).unwrap();
+    assert_eq!(path, root.join("wiki/architecture/transformer.md"));
+    assert!(path.exists());
+    assert!(
+        page.body.trim().is_empty(),
+        "category without config block must produce empty body"
+    );
+}
+
+// ── Acceptance criterion 8: Display strings match canonical spec wording ──────
+
+/// Verify that the four new `WikiError` variants produce exactly the strings
+/// specified in issue #59. These strings are the contract reused by #60 and #61.
+#[test]
+fn display_strings_match_spec() {
+    // PageAlreadyExists
+    let e = WikiError::PageAlreadyExists {
+        path: std::path::PathBuf::from("/wiki/tools/foo.md"),
+    };
+    assert_eq!(
+        e.to_string(),
+        "page already exists: /wiki/tools/foo.md",
+        "PageAlreadyExists display must match spec"
+    );
+
+    // UnknownCategory
+    let e = WikiError::UnknownCategory {
+        name: "bogus".to_string(),
+        valid: "tools, infra".to_string(),
+    };
+    assert_eq!(
+        e.to_string(),
+        "unknown category: bogus (valid: tools, infra)",
+        "UnknownCategory display must match spec"
+    );
+
+    // MissingRequiredField
+    let e = WikiError::MissingRequiredField {
+        category: "tools".to_string(),
+        field: "title".to_string(),
+    };
+    assert_eq!(
+        e.to_string(),
+        "category tools requires field: title",
+        "MissingRequiredField display must match spec"
+    );
+
+    // InvalidSlug
+    let e = WikiError::InvalidSlug {
+        slug: "Bad/Slug".to_string(),
+    };
+    assert_eq!(
+        e.to_string(),
+        "invalid slug: Bad/Slug (must match [a-z0-9_-]+, no path separators)",
+        "InvalidSlug display must match spec"
+    );
+}
+
+// ── Extra: author is optional ─────────────────────────────────────────────────
+
+/// Ensure new_page works when author is None.
+#[test]
+fn no_author_is_accepted() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    let schema = WikiSchema::default();
+    init_wiki(root, &schema).unwrap();
+
+    let request = NewPageRequest {
+        category: "tools",
+        slug: "no-author",
+        title: "No Author".to_string(),
+        tags: vec![],
+        author: None,
+    };
+
+    let (path, page) = new_page(root, &schema, request).unwrap();
+    assert!(path.exists());
+    assert_eq!(page.author, None);
+}
+
+// ── Unused import suppression ─────────────────────────────────────────────────
+// HashMap is used only to construct schemas inside helpers; keep lint quiet.
+#[allow(unused_imports)]
+use std::collections::HashMap as _HashMap;


### PR DESCRIPTION
## Summary

- Closes #59
- Adds `NewPageRequest<'a>` struct and `new_page(wiki_root, schema, req) -> Result<(PathBuf, Page)>` in `crates/lw-core/src/fs.rs`.
- Adds four `WikiError` variants with canonical Display strings (contract reused verbatim by #60/#61): `PageAlreadyExists`, `UnknownCategory`, `MissingRequiredField`, `InvalidSlug`.
- Validates slug via char loop (no new deps), enforces category existence + required fields, refuses overwrite, calls existing `write_page` (atomic_write under the hood).
- 100% `lw-core` only — zero CLI/MCP surface changes.

## Acceptance Criteria Evidence

- [x] Happy path — `happy_path_creates_file_with_correct_content` (lines 47-83): creates file at `wiki/tools/my-tool.md`, asserts title/tags/author frontmatter and body == category template; round-trips through `read_page`.
- [x] Duplicate slug → `PageAlreadyExists`, file unchanged — `duplicate_slug_returns_page_already_exists` (lines 89-123): writes twice, asserts error variant + path, asserts file content byte-identical.
- [x] Missing required field → `MissingRequiredField` — `missing_required_title_returns_error` (lines 129-152) and `missing_required_tags_returns_error` (lines 156-187): each asserts category + field names.
- [x] Unknown category → `UnknownCategory` — `unknown_category_returns_error` (lines 193-213): asserts name and that valid list contains all schema categories.
- [x] `_uncategorized` accepted with empty template — `uncategorized_accepted_with_empty_template` (lines 217-238): asserts path under `wiki/_uncategorized/`, body is empty/whitespace.
- [x] Invalid slug (`/`, `..`, empty, uppercase, space, leading-dot) → `InvalidSlug` — `empty_slug_is_invalid`, `slug_with_slash_is_invalid`, `slug_double_dot_is_invalid`, `slug_leading_dot_is_invalid`, `slug_uppercase_is_invalid`, `slug_with_space_is_invalid` (lines 242-290); `valid_slugs_are_accepted` (lines 292-313) green-lights `foo`, `foo-bar`, `foo_bar`, `foo123`, etc.
- [x] Category without `[categories.<name>]` block uses empty template — `category_without_config_block_uses_empty_template` (lines 319-352): uses default schema where `architecture` has no config, asserts no crash + empty body.
- [x] Display impls for 4 variants match canonical strings — `display_strings_match_spec` (lines 356-402): asserts `.to_string()` for each variant equals the exact spec-mandated strings.

## TDD discipline

- RED: `adabd74` — stub `new_page()` always returns `Err(InvalidSlug)`; 9 of 16 tests fail at runtime. Failure output in commit message body.
- GREEN: `4985553` — minimal implementation; all 16 tests pass, full workspace 324 passed.

## Test Plan

- [x] 16 unit/integration tests added (7 acceptance criteria × multiple cases + Display-strings test + author-optional test).
- [x] `cargo test` (full workspace, 324 tests) passes locally.
- [x] `cargo clippy --all-targets -- -D warnings` clean.
- [x] `cargo fmt --all -- --check` clean.
- [ ] CI passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)