### PR TITLE
feat(cli): lw new subcommand (closes #60)

### DIFF
--- a/crates/lw-cli/src/main.rs
+++ b/crates/lw-cli/src/main.rs
@@ -7,6 +7,7 @@ mod install_prefix;
 mod integrate;
 mod integrations;
 mod lint;
+mod new;
 mod output;
 mod query;
 mod read;
@@ -168,6 +169,27 @@ enum Commands {
     /// Start MCP server (stdio)
     #[command(after_help = "Examples:\n  lw serve\n  lw serve --root /path/to/wiki")]
     Serve,
+
+    /// Create a new wiki page with schema-enforced frontmatter and body template
+    #[command(
+        after_help = "Examples:\n  lw new tools/comrak-ast-parser --title \"Comrak AST Parser\" --tags rust,markdown,parsing\n  lw new tools/foo --title \"Foo\" --tags a,b --format json\n  lw new architecture/transformer --title \"Transformer\" --tags ml,architecture --author alice"
+    )]
+    New {
+        /// Page path as \"<category>/<slug>\" (e.g. tools/comrak-ast-parser)
+        path: String,
+        /// Page title
+        #[arg(long)]
+        title: Option<String>,
+        /// Tags (comma-separated, e.g. rust,markdown,parsing)
+        #[arg(long)]
+        tags: Option<String>,
+        /// Author name
+        #[arg(long)]
+        author: Option<String>,
+        /// Output format
+        #[arg(short = 'o', long, default_value = "human")]
+        format: Format,
+    },
 
     /// Write or update a wiki page (overwrite, append to section, or upsert section)
     #[command(
@@ -424,6 +446,19 @@ fn main() {
         },
         Commands::Serve => match resolve_root(cli.root) {
             Ok(root) => serve::run(&root),
+            Err(e) => {
+                eprintln!("Error: {e}");
+                process::exit(1);
+            }
+        },
+        Commands::New {
+            path,
+            title,
+            tags,
+            author,
+            format,
+        } => match resolve_root(cli.root) {
+            Ok(root) => new::run(&root, &path, title, tags, author, &format),
             Err(e) => {
                 eprintln!("Error: {e}");
                 process::exit(1);

--- a/crates/lw-cli/src/new.rs
+++ b/crates/lw-cli/src/new.rs
@@ -1,37 +1,21 @@
 use crate::output::Format;
+use lw_core::fs::{load_schema, new_page, NewPageRequest};
+use serde::Serialize;
 use std::path::Path;
+
+#[derive(Serialize)]
+struct NewPageOutput {
+    path: String,
+    category: String,
+    slug: String,
+}
 
 /// Create a new wiki page with schema-enforced frontmatter and body template.
 ///
-/// # Arguments
-///
-/// - `path_arg`: `"<category>/<slug>"` (split on first `/`)
-/// - `title`: page title (required when schema demands it)
-/// - `tags`: comma-separated tag list
-/// - `author`: optional author name
-/// - `format`: output format
-/// - `root`: resolved wiki root directory
-///
 /// # Errors
 ///
-/// Propagates `WikiError` variants as `anyhow::Error`, printing to stderr and
-/// exiting with code 1 via the standard error path in `main.rs`.
-///
-/// # Examples
-///
-/// ```bash
-/// lw new tools/comrak-ast-parser --title "Comrak AST Parser" --tags rust,markdown,parsing
-/// # => wrote wiki/tools/comrak-ast-parser.md
-///
-/// lw new tools/comrak-ast-parser --title "..." --format json
-/// # => {"path": "wiki/tools/comrak-ast-parser.md", "category": "tools", "slug": "comrak-ast-parser"}
-///
-/// lw new tools/foo --title "Foo"
-/// # error: category tools requires field: tags
-///
-/// lw new tools/comrak-ast-parser --title "..." --tags rust
-/// # error: page already exists: wiki/tools/comrak-ast-parser.md
-/// ```
+/// Propagates `WikiError` variants as `anyhow::Error`. The caller in `main.rs`
+/// prints the error message to stderr and exits with code 1.
 pub fn run(
     root: &Path,
     path_arg: &str,
@@ -40,7 +24,59 @@ pub fn run(
     author: Option<String>,
     format: &Format,
 ) -> anyhow::Result<()> {
-    // RED stub — always errors
-    let _ = (root, path_arg, title, tags, author, format);
-    anyhow::bail!("new_page CLI not implemented yet (RED stub)")
+    // Split "<category>/<slug>" on the first '/'
+    let (category, slug) = match path_arg.split_once('/') {
+        Some(pair) => pair,
+        None => {
+            anyhow::bail!("path must be '<category>/<slug>' (e.g. tools/my-page), got: {path_arg}")
+        }
+    };
+
+    // Load wiki schema
+    let schema = load_schema(root)?;
+
+    // Parse comma-separated tags
+    let parsed_tags: Vec<String> = match &tags {
+        Some(t) if !t.trim().is_empty() => t
+            .split(',')
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .collect(),
+        _ => vec![],
+    };
+
+    let req = NewPageRequest {
+        category,
+        slug,
+        title: title.unwrap_or_default(),
+        tags: parsed_tags,
+        author,
+    };
+
+    let (abs_path, _page) = new_page(root, &schema, req)?;
+
+    // Compute a wiki-relative display path: strip the wiki_root prefix
+    let display_path = abs_path
+        .strip_prefix(root)
+        .map(|p| p.to_string_lossy().into_owned())
+        .unwrap_or_else(|_| abs_path.to_string_lossy().into_owned());
+
+    match format {
+        Format::Json => {
+            let out = NewPageOutput {
+                path: display_path,
+                category: category.to_string(),
+                slug: slug.to_string(),
+            };
+            println!(
+                "{}",
+                serde_json::to_string_pretty(&out).expect("serialization cannot fail")
+            );
+        }
+        Format::Human | Format::Brief => {
+            println!("wrote {display_path}");
+        }
+    }
+
+    Ok(())
 }

--- a/crates/lw-cli/src/new.rs
+++ b/crates/lw-cli/src/new.rs
@@ -1,0 +1,46 @@
+use crate::output::Format;
+use std::path::Path;
+
+/// Create a new wiki page with schema-enforced frontmatter and body template.
+///
+/// # Arguments
+///
+/// - `path_arg`: `"<category>/<slug>"` (split on first `/`)
+/// - `title`: page title (required when schema demands it)
+/// - `tags`: comma-separated tag list
+/// - `author`: optional author name
+/// - `format`: output format
+/// - `root`: resolved wiki root directory
+///
+/// # Errors
+///
+/// Propagates `WikiError` variants as `anyhow::Error`, printing to stderr and
+/// exiting with code 1 via the standard error path in `main.rs`.
+///
+/// # Examples
+///
+/// ```bash
+/// lw new tools/comrak-ast-parser --title "Comrak AST Parser" --tags rust,markdown,parsing
+/// # => wrote wiki/tools/comrak-ast-parser.md
+///
+/// lw new tools/comrak-ast-parser --title "..." --format json
+/// # => {"path": "wiki/tools/comrak-ast-parser.md", "category": "tools", "slug": "comrak-ast-parser"}
+///
+/// lw new tools/foo --title "Foo"
+/// # error: category tools requires field: tags
+///
+/// lw new tools/comrak-ast-parser --title "..." --tags rust
+/// # error: page already exists: wiki/tools/comrak-ast-parser.md
+/// ```
+pub fn run(
+    root: &Path,
+    path_arg: &str,
+    title: Option<String>,
+    tags: Option<String>,
+    author: Option<String>,
+    format: &Format,
+) -> anyhow::Result<()> {
+    // RED stub — always errors
+    let _ = (root, path_arg, title, tags, author, format);
+    anyhow::bail!("new_page CLI not implemented yet (RED stub)")
+}

--- a/crates/lw-cli/src/new.rs
+++ b/crates/lw-cli/src/new.rs
@@ -1,5 +1,5 @@
 use crate::output::Format;
-use lw_core::fs::{load_schema, new_page, NewPageRequest};
+use lw_core::fs::{NewPageRequest, load_schema, new_page};
 use serde::Serialize;
 use std::path::Path;
 

--- a/crates/lw-cli/tests/new_test.rs
+++ b/crates/lw-cli/tests/new_test.rs
@@ -212,6 +212,6 @@ fn help_shows_examples_section() {
 #[test]
 fn assert_cmd_and_tempdir_are_used() {
     let _tmp = TempDir::new().unwrap(); // TempDir used
-                                        // assert_cmd::Command used throughout (see lw() helper above)
+    // assert_cmd::Command used throughout (see lw() helper above)
     lw().args(["--version"]).assert().success();
 }

--- a/crates/lw-cli/tests/new_test.rs
+++ b/crates/lw-cli/tests/new_test.rs
@@ -56,7 +56,7 @@ fn happy_path_creates_file() {
         "frontmatter missing title; content:\n{content}"
     );
     assert!(
-        content.contains('a') && content.contains('b'),
+        content.contains("- a") && content.contains("- b"),
         "frontmatter missing tags; content:\n{content}"
     );
 
@@ -119,11 +119,11 @@ fn format_json_emits_metadata() {
         "JSON 'slug' field mismatch"
     );
 
-    // path must contain category and slug
+    // path must be vault-relative: "wiki/tools/bar.md"
     let path_val = json["path"].as_str().unwrap();
-    assert!(
-        path_val.contains("tools") && path_val.contains("bar"),
-        "path value '{path_val}' doesn't contain category/slug"
+    assert_eq!(
+        path_val, "wiki/tools/bar.md",
+        "path must be vault-relative, got '{path_val}'"
     );
 }
 

--- a/crates/lw-cli/tests/new_test.rs
+++ b/crates/lw-cli/tests/new_test.rs
@@ -1,0 +1,217 @@
+use assert_cmd::Command;
+use predicates::prelude::*;
+use tempfile::TempDir;
+
+fn lw() -> Command {
+    Command::cargo_bin("lw").unwrap()
+}
+
+/// Scaffold a minimal wiki with a `tools` category that has required_fields = ["title", "tags"]
+/// and a body template.
+fn setup_vault_with_tools_category() -> TempDir {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+
+    // Run `lw init` to create the skeleton
+    lw().args(["init", "--root", root.to_str().unwrap()])
+        .assert()
+        .success();
+
+    // Overwrite the schema to add a [categories.tools] block with required fields + template
+    let schema_toml = "[wiki]\nname = \"Test Wiki\"\ndefault_review_days = 90\n\n[tags]\ncategories = [\"architecture\", \"training\", \"infra\", \"tools\", \"product\", \"ops\"]\n\n[categories.tools]\nrequired_fields = [\"title\", \"tags\"]\ntemplate = \"## Overview\\n\\n## Usage\\n\"\n";
+    std::fs::write(root.join(".lw/schema.toml"), schema_toml).unwrap();
+
+    tmp
+}
+
+// ── happy_path_creates_file ───────────────────────────────────────────────────
+
+#[test]
+fn happy_path_creates_file() {
+    let tmp = setup_vault_with_tools_category();
+    let root = tmp.path();
+
+    lw().args([
+        "new",
+        "tools/foo",
+        "--title",
+        "Foo",
+        "--tags",
+        "a,b",
+        "--root",
+        root.to_str().unwrap(),
+    ])
+    .assert()
+    .success();
+
+    // File must exist at the expected path
+    let page_path = root.join("wiki/tools/foo.md");
+    assert!(page_path.exists(), "page file was not created");
+
+    let content = std::fs::read_to_string(&page_path).unwrap();
+
+    // Frontmatter: title and tags
+    assert!(
+        content.contains("title: Foo"),
+        "frontmatter missing title; content:\n{content}"
+    );
+    assert!(
+        content.contains('a') && content.contains('b'),
+        "frontmatter missing tags; content:\n{content}"
+    );
+
+    // Body: category body template
+    assert!(
+        content.contains("## Overview"),
+        "body missing '## Overview' template section; content:\n{content}"
+    );
+    assert!(
+        content.contains("## Usage"),
+        "body missing '## Usage' template section; content:\n{content}"
+    );
+}
+
+// ── format_json_emits_metadata ────────────────────────────────────────────────
+
+#[test]
+fn format_json_emits_metadata() {
+    let tmp = setup_vault_with_tools_category();
+    let root = tmp.path();
+
+    let output = lw()
+        .args([
+            "new",
+            "tools/bar",
+            "--title",
+            "Bar",
+            "--tags",
+            "rust,cli",
+            "--format",
+            "json",
+            "--root",
+            root.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "expected success; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let json: serde_json::Value = serde_json::from_str(&stdout).expect("stdout must be valid JSON");
+
+    // Must contain path, category, slug fields
+    assert!(
+        json["path"].is_string(),
+        "JSON missing 'path' field; got: {json}"
+    );
+    assert_eq!(
+        json["category"].as_str(),
+        Some("tools"),
+        "JSON 'category' field mismatch"
+    );
+    assert_eq!(
+        json["slug"].as_str(),
+        Some("bar"),
+        "JSON 'slug' field mismatch"
+    );
+
+    // path must contain category and slug
+    let path_val = json["path"].as_str().unwrap();
+    assert!(
+        path_val.contains("tools") && path_val.contains("bar"),
+        "path value '{path_val}' doesn't contain category/slug"
+    );
+}
+
+// ── duplicate_slug_exits_with_error ──────────────────────────────────────────
+
+#[test]
+fn duplicate_slug_exits_with_error() {
+    let tmp = setup_vault_with_tools_category();
+    let root = tmp.path();
+
+    let args = [
+        "new",
+        "tools/dup",
+        "--title",
+        "Dup",
+        "--tags",
+        "x",
+        "--root",
+        root.to_str().unwrap(),
+    ];
+
+    // First call: success
+    lw().args(args).assert().success();
+
+    // Read file content before second call
+    let page_path = root.join("wiki/tools/dup.md");
+    let before = std::fs::read_to_string(&page_path).unwrap();
+
+    // Second call: must fail with exit 1 and a clear message
+    lw().args(args)
+        .assert()
+        .failure()
+        .code(1)
+        .stderr(predicate::str::contains("page already exists:"));
+
+    // File content must be unchanged
+    let after = std::fs::read_to_string(&page_path).unwrap();
+    assert_eq!(
+        before, after,
+        "file content changed after duplicate-slug error"
+    );
+}
+
+// ── unknown_category_exits_with_error ────────────────────────────────────────
+
+#[test]
+fn unknown_category_exits_with_error() {
+    let tmp = setup_vault_with_tools_category();
+    let root = tmp.path();
+
+    lw().args([
+        "new",
+        "bogus/foo",
+        "--title",
+        "x",
+        "--tags",
+        "a",
+        "--root",
+        root.to_str().unwrap(),
+    ])
+    .assert()
+    .failure()
+    .code(1)
+    // WikiError::UnknownCategory Display: "unknown category: bogus (valid: ...)"
+    .stderr(predicate::str::contains("unknown category: bogus"))
+    // valid list must be present so the user knows their options
+    .stderr(predicate::str::contains("valid:"));
+}
+
+// ── help_shows_examples_section ──────────────────────────────────────────────
+
+#[test]
+fn help_shows_examples_section() {
+    lw().args(["new", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::is_match("(?i)examples").unwrap());
+}
+
+// ── integration_test_uses_assert_cmd_and_tempdir ─────────────────────────────
+//
+// This test documents that the test file satisfies the structural criterion
+// "Integration test in crates/lw-cli/tests/ using assert_cmd + TempDir".
+// It is a meta-test: it passes iff the binary can be located via assert_cmd.
+
+#[test]
+fn assert_cmd_and_tempdir_are_used() {
+    let _tmp = TempDir::new().unwrap(); // TempDir used
+                                        // assert_cmd::Command used throughout (see lw() helper above)
+    lw().args(["--version"]).assert().success();
+}


### PR DESCRIPTION
## Summary

- Closes #60
- Adds `lw new <category>/<slug> --title --tags --author --format` subcommand
- Thin wrapper over `lw_core::new_page`; maps `WikiError` Display to stderr + exit 1
- `--help` includes Examples section per project convention

## Acceptance Criteria Evidence

- [x] Happy path creates file with frontmatter + template — `tests/new_test.rs::happy_path_creates_file`
- [x] `--format json` emits `{path, category, slug}` — `format_json_emits_metadata`
- [x] Duplicate slug → exit 1, stderr message, unchanged file — `duplicate_slug_exits_with_error`
- [x] Unknown category → exit 1 with valid list — `unknown_category_exits_with_error`
- [x] `--help` shows Examples — `help_shows_examples_section`
- [x] assert_cmd + TempDir — entire test file uses this pattern (`lw()` helper + `setup_vault_with_tools_category()`)

## TDD Discipline

- RED: `2f4ff87` — stub bails with "new_page CLI not implemented yet"; 4 tests fail, 2 structural tests pass
- GREEN: `768b455` — minimal impl wiring `lw_core::new_page` → CLI

## Test Plan

- [x] Integration tests added (`crates/lw-cli/tests/new_test.rs`)
- [x] `cargo test` workspace green (330 tests)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [ ] CI passes

## Files Changed

- `crates/lw-cli/src/main.rs` — added `New` variant to `Commands` enum + dispatch
- `crates/lw-cli/src/new.rs` — new subcommand implementation
- `crates/lw-cli/tests/new_test.rs` — integration tests (6 tests, all green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)