### PR TITLE
feat(mcp): wiki_new tool (closes #61)

### DIFF
--- a/crates/lw-mcp/src/lib.rs
+++ b/crates/lw-mcp/src/lib.rs
@@ -2,11 +2,13 @@
 //! Provides wiki_query, wiki_read, wiki_browse, wiki_tags, wiki_write, wiki_ingest, wiki_lint, wiki_stats tools.
 
 use lw_core::fs::{
-    atomic_write, category_from_path, list_pages, read_page, validate_wiki_path, write_page,
+    NewPageRequest, atomic_write, category_from_path, list_pages, new_page, read_page,
+    validate_wiki_path, write_page,
 };
 use lw_core::git::{self, FreshnessLevel};
 use lw_core::ingest;
 use lw_core::page::Page;
+use lw_core::schema::WikiSchema;
 use lw_core::search::{SearchQuery, Searcher, TantivySearcher};
 use lw_core::status::gather_status;
 use lw_core::tag::Taxonomy;
@@ -157,11 +159,27 @@ pub struct WikiLintArgs {
     pub category: Option<String>,
 }
 
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct WikiNewArgs {
+    /// Target category (must match a category in the schema, e.g. "tools")
+    pub category: String,
+    /// URL-safe slug for the page (e.g. "comrak-ast-parser"); must match [a-z0-9_-]+
+    pub slug: String,
+    /// Human-readable page title
+    pub title: String,
+    /// Tags to attach to the page
+    #[serde(default)]
+    pub tags: Vec<String>,
+    /// Author name (optional)
+    pub author: Option<String>,
+}
+
 // === Server ===
 
 #[derive(Clone)]
 pub struct WikiMcpServer {
     wiki_root: PathBuf,
+    schema: WikiSchema,
     searcher: Arc<TantivySearcher>,
     default_review_days: u32,
     tool_router: ToolRouter<Self>,
@@ -570,6 +588,17 @@ impl WikiMcpServer {
         }
     }
 
+    /// Scaffold a new wiki page with schema-enforced frontmatter and body template.
+    #[tool(
+        name = "wiki_new",
+        description = "Create a new wiki page with schema-enforced frontmatter and body template. Returns the full rendered page content so agents can immediately follow up with wiki_write section calls. Errors if the category is unknown or the slug already exists."
+    )]
+    fn wiki_new(&self, Parameters(args): Parameters<WikiNewArgs>) -> String {
+        // RED stub — replaced in GREEN
+        let _ = (&args.category, &args.slug, &args.title, &args.tags, &args.author);
+        serde_json::json!({"error": "wiki_new not implemented (RED stub)"}).to_string()
+    }
+
     /// Get wiki health statistics: page count, category breakdown, freshness distribution.
     #[tool(
         name = "wiki_stats",
@@ -621,9 +650,9 @@ impl ServerHandler for WikiMcpServer {
             ))
             .with_instructions(
                 "LLM Wiki knowledge base server. Use wiki_query to search, wiki_read to read pages, \
-                 wiki_browse to list pages, wiki_tags to list tags, wiki_write to create/update pages, \
-                 wiki_ingest to import source material, wiki_lint to check freshness, \
-                 and wiki_stats to get wiki health statistics."
+                 wiki_browse to list pages, wiki_tags to list tags, wiki_new to scaffold a new page, \
+                 wiki_write to create/update pages, wiki_ingest to import source material, \
+                 wiki_lint to check freshness, and wiki_stats to get wiki health statistics."
             )
     }
 }
@@ -653,6 +682,7 @@ impl WikiMcpServer {
 
         Ok(Self {
             wiki_root,
+            schema,
             searcher,
             default_review_days,
             tool_router: Self::tool_router(),
@@ -801,5 +831,156 @@ mod tests {
                 || msg.contains("exclusive"),
             "error should name the conflict: {msg}"
         );
+    }
+
+    // ── wiki_new tests ────────────────────────────────────────────────────────
+
+    fn new_args(
+        category: &str,
+        slug: &str,
+        title: &str,
+        tags: Vec<&str>,
+        author: Option<&str>,
+    ) -> WikiNewArgs {
+        WikiNewArgs {
+            category: category.to_string(),
+            slug: slug.to_string(),
+            title: title.to_string(),
+            tags: tags.into_iter().map(String::from).collect(),
+            author: author.map(String::from),
+        }
+    }
+
+    #[tokio::test]
+    async fn wiki_new_happy_path_returns_content() {
+        let (tmp, server) = spawn_server();
+        let args = new_args(
+            "tools",
+            "comrak-ast-parser",
+            "Comrak AST Parser",
+            vec!["rust", "markdown"],
+            Some("claude"),
+        );
+
+        let resp = server.wiki_new(Parameters(args));
+        let v = parse(&resp);
+
+        // No error field
+        assert!(v.get("error").is_none(), "unexpected error: {resp}");
+
+        // Required fields present
+        assert_eq!(v["category"], "tools", "category mismatch: {resp}");
+        assert_eq!(v["slug"], "comrak-ast-parser", "slug mismatch: {resp}");
+        assert!(
+            v.get("path").and_then(|p| p.as_str()).is_some(),
+            "missing path: {resp}"
+        );
+        let content = v["content"].as_str().expect("missing content field");
+        assert!(
+            content.starts_with("---\ntitle:"),
+            "content should start with frontmatter, got: {content}"
+        );
+
+        // File exists on disk
+        let expected = tmp
+            .path()
+            .join("wiki/tools/comrak-ast-parser.md");
+        assert!(expected.exists(), "file not created at {expected:?}");
+    }
+
+    #[tokio::test]
+    async fn wiki_new_duplicate_slug_returns_error_json() {
+        let (_tmp, server) = spawn_server();
+        let args = new_args("tools", "dup-slug", "Dup Slug", vec![], None);
+
+        // First call succeeds
+        let resp1 = server.wiki_new(Parameters(args));
+        let v1 = parse(&resp1);
+        assert!(v1.get("error").is_none(), "first call should succeed: {resp1}");
+
+        // Second call with same args
+        let args2 = new_args("tools", "dup-slug", "Dup Slug", vec![], None);
+        let resp2 = server.wiki_new(Parameters(args2));
+        let v2 = parse(&resp2);
+
+        let msg = v2["error"].as_str().expect("expected error field on duplicate");
+        assert!(
+            msg.starts_with("page already exists:"),
+            "error should be 'page already exists: ...', got: {msg}"
+        );
+    }
+
+    #[tokio::test]
+    async fn wiki_new_unknown_category_returns_error_json() {
+        let (_tmp, server) = spawn_server();
+        let args = new_args("bogus", "some-slug", "Some Title", vec![], None);
+
+        let resp = server.wiki_new(Parameters(args));
+        let v = parse(&resp);
+
+        let msg = v["error"].as_str().expect("expected error field for unknown category");
+        assert!(
+            msg.starts_with("unknown category: bogus"),
+            "error should start with 'unknown category: bogus', got: {msg}"
+        );
+    }
+
+    #[test]
+    fn with_instructions_mentions_wiki_new() {
+        // The instructions string is embedded in get_info(); we verify it at the
+        // source level by checking the hardcoded string constant in the binary.
+        // Construct a server and call get_info() to retrieve the instructions.
+        let tmp = TempDir::new().unwrap();
+        lw_core::fs::init_wiki(tmp.path(), &WikiSchema::default()).unwrap();
+        let server = WikiMcpServer::new(tmp.path().to_path_buf()).unwrap();
+        let info = server.get_info();
+        let instructions = info
+            .instructions
+            .as_deref()
+            .unwrap_or("");
+        assert!(
+            instructions.contains("wiki_new"),
+            "with_instructions should mention wiki_new, got: {instructions}"
+        );
+    }
+
+    #[tokio::test]
+    async fn wiki_query_finds_page_after_wiki_new() {
+        let (_tmp, server) = spawn_server();
+        let args = new_args(
+            "tools",
+            "unique-foo-title",
+            "A Unique Foo Title",
+            vec!["search-test"],
+            None,
+        );
+
+        let resp = server.wiki_new(Parameters(args));
+        let v = parse(&resp);
+        assert!(v.get("error").is_none(), "wiki_new failed: {resp}");
+
+        // Commit the index so wiki_query sees the new page
+        // (wiki_new triggers index_page + commit)
+        let query_args = WikiQueryArgs {
+            query: "Unique Foo".to_string(),
+            tags: None,
+            category: None,
+            limit: Some(10),
+        };
+        let qresp = server.wiki_query(Parameters(query_args));
+        let qv = parse(&qresp);
+
+        let hits = qv["hits"].as_array().expect("expected hits array");
+        assert!(
+            !hits.is_empty(),
+            "wiki_query should find the new page, got: {qresp}"
+        );
+        let found = hits.iter().any(|h| {
+            h["path"]
+                .as_str()
+                .map(|p| p.contains("unique-foo-title"))
+                .unwrap_or(false)
+        });
+        assert!(found, "hits should include unique-foo-title page: {qresp}");
     }
 }

--- a/crates/lw-mcp/src/lib.rs
+++ b/crates/lw-mcp/src/lib.rs
@@ -605,21 +605,32 @@ impl WikiMcpServer {
             Ok((abs_path, page)) => {
                 let content = page.to_markdown();
 
-                // Index the new page so wiki_query can find it immediately.
-                let rel_path = abs_path
+                // Path for JSON response — vault-relative with "wiki/" prefix,
+                // matching the spec example "wiki/tools/foo.md".
+                let json_path = abs_path
                     .strip_prefix(&self.wiki_root)
                     .unwrap_or(&abs_path)
                     .to_string_lossy()
                     .to_string();
-                if let Err(e) = self.searcher.index_page(&rel_path, &page) {
-                    tracing::warn!("Failed to index new page {}: {}", rel_path, e);
+
+                // Path for the Tantivy index — relative to wiki_root/wiki/,
+                // matching the convention used by rebuild() (e.g. "tools/foo.md").
+                let wiki_dir = self.wiki_root.join("wiki");
+                let index_path = abs_path
+                    .strip_prefix(&wiki_dir)
+                    .unwrap_or(&abs_path)
+                    .to_string_lossy()
+                    .to_string();
+
+                if let Err(e) = self.searcher.index_page(&index_path, &page) {
+                    tracing::warn!("Failed to index new page {}: {}", index_path, e);
                 }
                 if let Err(e) = self.searcher.commit() {
                     tracing::warn!("Failed to commit index after wiki_new: {}", e);
                 }
 
                 serde_json::json!({
-                    "path": rel_path,
+                    "path": json_path,
                     "category": args.category,
                     "slug": args.slug,
                     "content": content,
@@ -902,9 +913,10 @@ mod tests {
         // Required fields present
         assert_eq!(v["category"], "tools", "category mismatch: {resp}");
         assert_eq!(v["slug"], "comrak-ast-parser", "slug mismatch: {resp}");
-        assert!(
-            v.get("path").and_then(|p| p.as_str()).is_some(),
-            "missing path: {resp}"
+        assert_eq!(
+            v["path"].as_str(),
+            Some("wiki/tools/comrak-ast-parser.md"),
+            "JSON path must be vault-relative with wiki/ prefix: {resp}"
         );
         let content = v["content"].as_str().expect("missing content field");
         assert!(
@@ -1008,12 +1020,10 @@ mod tests {
             !hits.is_empty(),
             "wiki_query should find the new page, got: {qresp}"
         );
-        let found = hits.iter().any(|h| {
-            h["path"]
-                .as_str()
-                .map(|p| p.contains("unique-foo-title"))
-                .unwrap_or(false)
-        });
-        assert!(found, "hits should include unique-foo-title page: {qresp}");
+        assert!(
+            hits.iter()
+                .any(|h| h["path"].as_str() == Some("tools/unique-foo-title.md")),
+            "expected hit path 'tools/unique-foo-title.md', got {qresp}"
+        );
     }
 }

--- a/crates/lw-mcp/src/lib.rs
+++ b/crates/lw-mcp/src/lib.rs
@@ -594,9 +594,40 @@ impl WikiMcpServer {
         description = "Create a new wiki page with schema-enforced frontmatter and body template. Returns the full rendered page content so agents can immediately follow up with wiki_write section calls. Errors if the category is unknown or the slug already exists."
     )]
     fn wiki_new(&self, Parameters(args): Parameters<WikiNewArgs>) -> String {
-        // RED stub — replaced in GREEN
-        let _ = (&args.category, &args.slug, &args.title, &args.tags, &args.author);
-        serde_json::json!({"error": "wiki_new not implemented (RED stub)"}).to_string()
+        let req = NewPageRequest {
+            category: &args.category,
+            slug: &args.slug,
+            title: args.title,
+            tags: args.tags,
+            author: args.author,
+        };
+        match new_page(&self.wiki_root, &self.schema, req) {
+            Ok((abs_path, page)) => {
+                let content = page.to_markdown();
+
+                // Index the new page so wiki_query can find it immediately.
+                let rel_path = abs_path
+                    .strip_prefix(&self.wiki_root)
+                    .unwrap_or(&abs_path)
+                    .to_string_lossy()
+                    .to_string();
+                if let Err(e) = self.searcher.index_page(&rel_path, &page) {
+                    tracing::warn!("Failed to index new page {}: {}", rel_path, e);
+                }
+                if let Err(e) = self.searcher.commit() {
+                    tracing::warn!("Failed to commit index after wiki_new: {}", e);
+                }
+
+                serde_json::json!({
+                    "path": rel_path,
+                    "category": args.category,
+                    "slug": args.slug,
+                    "content": content,
+                })
+                .to_string()
+            }
+            Err(e) => serde_json::json!({"error": e.to_string()}).to_string(),
+        }
     }
 
     /// Get wiki health statistics: page count, category breakdown, freshness distribution.
@@ -882,9 +913,7 @@ mod tests {
         );
 
         // File exists on disk
-        let expected = tmp
-            .path()
-            .join("wiki/tools/comrak-ast-parser.md");
+        let expected = tmp.path().join("wiki/tools/comrak-ast-parser.md");
         assert!(expected.exists(), "file not created at {expected:?}");
     }
 
@@ -896,14 +925,19 @@ mod tests {
         // First call succeeds
         let resp1 = server.wiki_new(Parameters(args));
         let v1 = parse(&resp1);
-        assert!(v1.get("error").is_none(), "first call should succeed: {resp1}");
+        assert!(
+            v1.get("error").is_none(),
+            "first call should succeed: {resp1}"
+        );
 
         // Second call with same args
         let args2 = new_args("tools", "dup-slug", "Dup Slug", vec![], None);
         let resp2 = server.wiki_new(Parameters(args2));
         let v2 = parse(&resp2);
 
-        let msg = v2["error"].as_str().expect("expected error field on duplicate");
+        let msg = v2["error"]
+            .as_str()
+            .expect("expected error field on duplicate");
         assert!(
             msg.starts_with("page already exists:"),
             "error should be 'page already exists: ...', got: {msg}"
@@ -918,7 +952,9 @@ mod tests {
         let resp = server.wiki_new(Parameters(args));
         let v = parse(&resp);
 
-        let msg = v["error"].as_str().expect("expected error field for unknown category");
+        let msg = v["error"]
+            .as_str()
+            .expect("expected error field for unknown category");
         assert!(
             msg.starts_with("unknown category: bogus"),
             "error should start with 'unknown category: bogus', got: {msg}"
@@ -934,10 +970,7 @@ mod tests {
         lw_core::fs::init_wiki(tmp.path(), &WikiSchema::default()).unwrap();
         let server = WikiMcpServer::new(tmp.path().to_path_buf()).unwrap();
         let info = server.get_info();
-        let instructions = info
-            .instructions
-            .as_deref()
-            .unwrap_or("");
+        let instructions = info.instructions.as_deref().unwrap_or("");
         assert!(
             instructions.contains("wiki_new"),
             "with_instructions should mention wiki_new, got: {instructions}"


### PR DESCRIPTION
## Summary

- Closes #61
- Adds `wiki_new` MCP tool exposing `lw_core::new_page`.
- Response includes full rendered page content (`path`/`category`/`slug`/`content`) so agents can immediately follow up with `wiki_write` section calls without a round-trip read.
- Error JSON uses canonical `WikiError::Display` strings from #59 (`page already exists: <path>`, `unknown category: <name> (valid: ...)`).
- `WikiMcpServer` gains a `schema: WikiSchema` field (stored at construction, not reloaded per call).
- `with_instructions` updated to list `wiki_new`.
- New page is indexed in `TantivySearcher` (index_page + commit) so `wiki_query` finds it immediately.

## Acceptance Criteria Evidence

- [x] Happy path returns `content` field with rendered page — `wiki_new_happy_path_returns_content` (lib.rs:858)
- [x] Duplicate slug → `{"error": "page already exists: ..."}` — `wiki_new_duplicate_slug_returns_error_json` (lib.rs:918)
- [x] Unknown category → `{"error": "unknown category: ..."}` — `wiki_new_unknown_category_returns_error_json` (lib.rs:942)
- [x] `with_instructions` mentions `wiki_new` — `with_instructions_mentions_wiki_new` (lib.rs:955)
- [x] `wiki_query` finds new page — `wiki_query_finds_page_after_wiki_new` (lib.rs:973)

## TDD

- RED: `5f3e581` — stub returns `{"error":"wiki_new not implemented (RED stub)"}`, 4/5 tests fail at runtime (instructions test passes immediately).
- GREEN: `14208b7` — wires `lw_core::new_page` to the tool method; all 18 tests pass.

## Test Plan

- [x] 5 inline `#[tokio::test]` / `#[test]` tests added.
- [x] `cargo test` workspace green (329 passed).
- [x] `cargo clippy` clean.
- [x] `cargo fmt --check` clean.
- [ ] CI passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)