### PR TITLE
fix(core): vault-relative path in PageAlreadyExists (closes #87)

### DIFF
--- a/crates/lw-cli/tests/new_test.rs
+++ b/crates/lw-cli/tests/new_test.rs
@@ -152,12 +152,15 @@ fn duplicate_slug_exits_with_error() {
     let page_path = root.join("wiki/tools/dup.md");
     let before = std::fs::read_to_string(&page_path).unwrap();
 
-    // Second call: must fail with exit 1 and a clear message
+    // Second call: must fail with exit 1, and the message must carry a
+    // VAULT-RELATIVE path (issue #87) — not the absolute host path.
     lw().args(args)
         .assert()
         .failure()
         .code(1)
-        .stderr(predicate::str::contains("page already exists:"));
+        .stderr(predicate::str::contains(
+            "page already exists: wiki/tools/dup.md",
+        ));
 
     // File content must be unchanged
     let after = std::fs::read_to_string(&page_path).unwrap();
@@ -212,6 +215,6 @@ fn help_shows_examples_section() {
 #[test]
 fn assert_cmd_and_tempdir_are_used() {
     let _tmp = TempDir::new().unwrap(); // TempDir used
-    // assert_cmd::Command used throughout (see lw() helper above)
+                                        // assert_cmd::Command used throughout (see lw() helper above)
     lw().args(["--version"]).assert().success();
 }

--- a/crates/lw-cli/tests/new_test.rs
+++ b/crates/lw-cli/tests/new_test.rs
@@ -215,6 +215,6 @@ fn help_shows_examples_section() {
 #[test]
 fn assert_cmd_and_tempdir_are_used() {
     let _tmp = TempDir::new().unwrap(); // TempDir used
-                                        // assert_cmd::Command used throughout (see lw() helper above)
+    // assert_cmd::Command used throughout (see lw() helper above)
     lw().args(["--version"]).assert().success();
 }

--- a/crates/lw-core/src/fs.rs
+++ b/crates/lw-core/src/fs.rs
@@ -273,13 +273,24 @@ pub fn new_page(
         }
     }
 
-    // Step 5: compute target path; refuse to overwrite
+    // Step 5: compute target path; refuse to overwrite.
+    //
+    // Surface the error with a VAULT-RELATIVE path (issue #87) — the Display
+    // string flows out through CLI stderr (#60) and MCP error JSON (#61),
+    // and agents that feed the path back into wiki_read/wiki_write expect
+    // vault-relative input. strip_prefix should always succeed here since
+    // `target` was just built from `wiki_root.join(...)`; the fallback is
+    // defensive in case a future caller passes a non-canonical wiki_root.
     let target = wiki_root
         .join("wiki")
         .join(category)
         .join(format!("{}.md", req.slug));
     if target.exists() {
-        return Err(WikiError::PageAlreadyExists { path: target });
+        let rel = target
+            .strip_prefix(wiki_root)
+            .map(Path::to_path_buf)
+            .unwrap_or_else(|_| target.clone());
+        return Err(WikiError::PageAlreadyExists { path: rel });
     }
 
     // Step 6: build Page

--- a/crates/lw-core/tests/new_page_test.rs
+++ b/crates/lw-core/tests/new_page_test.rs
@@ -1,3 +1,5 @@
+use lw_core::fs::{init_wiki, new_page, read_page, NewPageRequest};
+use lw_core::schema::{CategoryConfig, WikiSchema};
 /// Tests for `lw_core::fs::new_page` (issue #59)
 ///
 /// These tests cover all acceptance criteria from the spec:
@@ -10,8 +12,6 @@
 ///   7. Category without `[categories.<name>]` block uses empty template (no crash)
 ///   8. Display strings for all four new error variants match canonical spec wording
 use lw_core::WikiError;
-use lw_core::fs::{NewPageRequest, init_wiki, new_page, read_page};
-use lw_core::schema::{CategoryConfig, WikiSchema};
 use tempfile::TempDir;
 
 // ── helpers ──────────────────────────────────────────────────────────────────
@@ -105,11 +105,18 @@ fn duplicate_slug_returns_page_already_exists() {
     let (path, _) = new_page(root, &schema, make_req()).unwrap();
     let original_content = std::fs::read_to_string(&path).unwrap();
 
-    // Second write must fail
+    // Second write must fail with a VAULT-RELATIVE path (issue #87) — never the
+    // absolute filesystem path, since the Display string is surfaced verbatim by
+    // CLI stderr (#60) and MCP error JSON (#61), and agents that feed it back
+    // into wiki_read/wiki_write expect vault-relative.
     let err = new_page(root, &schema, make_req()).unwrap_err();
     match err {
         WikiError::PageAlreadyExists { path: err_path } => {
-            assert_eq!(err_path, root.join("wiki/tools/duplicate.md"));
+            assert_eq!(
+                err_path,
+                std::path::PathBuf::from("wiki/tools/duplicate.md"),
+                "PageAlreadyExists.path must be vault-relative, not absolute"
+            );
         }
         other => panic!("expected PageAlreadyExists, got {other:?}"),
     }
@@ -358,13 +365,13 @@ fn category_without_config_block_uses_empty_template() {
 /// specified in issue #59. These strings are the contract reused by #60 and #61.
 #[test]
 fn display_strings_match_spec() {
-    // PageAlreadyExists
+    // PageAlreadyExists — spec example uses vault-relative path (issue #87).
     let e = WikiError::PageAlreadyExists {
-        path: std::path::PathBuf::from("/wiki/tools/foo.md"),
+        path: std::path::PathBuf::from("wiki/tools/foo.md"),
     };
     assert_eq!(
         e.to_string(),
-        "page already exists: /wiki/tools/foo.md",
+        "page already exists: wiki/tools/foo.md",
         "PageAlreadyExists display must match spec"
     );
 

--- a/crates/lw-core/tests/new_page_test.rs
+++ b/crates/lw-core/tests/new_page_test.rs
@@ -1,5 +1,3 @@
-use lw_core::fs::{init_wiki, new_page, read_page, NewPageRequest};
-use lw_core::schema::{CategoryConfig, WikiSchema};
 /// Tests for `lw_core::fs::new_page` (issue #59)
 ///
 /// These tests cover all acceptance criteria from the spec:
@@ -12,6 +10,8 @@ use lw_core::schema::{CategoryConfig, WikiSchema};
 ///   7. Category without `[categories.<name>]` block uses empty template (no crash)
 ///   8. Display strings for all four new error variants match canonical spec wording
 use lw_core::WikiError;
+use lw_core::fs::{NewPageRequest, init_wiki, new_page, read_page};
+use lw_core::schema::{CategoryConfig, WikiSchema};
 use tempfile::TempDir;
 
 // ── helpers ──────────────────────────────────────────────────────────────────

--- a/crates/lw-mcp/src/lib.rs
+++ b/crates/lw-mcp/src/lib.rs
@@ -950,9 +950,11 @@ mod tests {
         let msg = v2["error"]
             .as_str()
             .expect("expected error field on duplicate");
-        assert!(
-            msg.starts_with("page already exists:"),
-            "error should be 'page already exists: ...', got: {msg}"
+        // Path must be VAULT-RELATIVE (issue #87) — agents feed this back into
+        // wiki_read/wiki_write, which expect vault-relative paths.
+        assert_eq!(
+            msg, "page already exists: wiki/tools/dup-slug.md",
+            "error must carry vault-relative path, got: {msg}"
         );
     }
 


### PR DESCRIPTION
## Summary

- Strip `wiki_root` prefix in `lw_core::fs::new_page` so `WikiError::PageAlreadyExists` carries `wiki/<category>/<slug>.md` instead of the host-absolute path.
- Tighten three duplicate-slug tests (lw-core / lw-cli / lw-mcp) to assert the exact vault-relative string, locking in the contract that the Display flows verbatim through CLI stderr (#60) and MCP error JSON (#61).
- Update `display_strings_match_spec` to use the spec example `wiki/tools/foo.md` (no leading slash).

## Why

The Display surfaces directly to agents through CLI #60 and MCP #61. An absolute path leaks host filesystem layout and breaks any agent logic that wants to feed the returned path back into `wiki_read` / `wiki_write`, which expect vault-relative input. Acceptable in #59 in isolation; not acceptable once #60/#61 surface it.

## Audit

`grep PageAlreadyExists --include='*.rs' crates/` shows the variant is constructed in exactly one place — `crates/lw-core/src/fs.rs:282`. No other call sites to fix; no regression risk on that front.

## Test plan

- [x] `cargo test -p lw-core --test new_page_test` — 16 passed (incl. updated `duplicate_slug_returns_page_already_exists`)
- [x] `cargo test -p lw-cli --test new_test` — 6 passed (incl. updated `duplicate_slug_exits_with_error` asserting `wiki/tools/dup.md` in stderr)
- [x] `cargo test -p lw-mcp` — 18 passed (incl. updated `wiki_new_duplicate_slug_returns_error_json` asserting exact `page already exists: wiki/tools/dup-slug.md`)
- [x] `cargo test` — 338 passed, 29 suites
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)