### PR TITLE
docs(claude): smoke isolation rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -191,6 +191,7 @@ Switching workspaces requires restarting the agent tool — MCP processes bind t
    - `lw integrate <tool>` against an MCP entry written by an older lw (regression for the 0.2.0–0.2.3 cross-release Conflict bug)
    - `lw query "..."` **while `lw serve` is running** against the same vault (regression for the 0.2.4 LockBusy bug)
    - `lw doctor` — all integrations should report OK
+   - **Isolation is non-negotiable.** Any smoke that exercises `lw new` / `lw write` / `lw ingest` / `lw sync` MUST scope to a throwaway directory via `--root /tmp/lw-smoke-XXXX` (or `LW_WIKI_ROOT=/tmp/lw-smoke-XXXX`). Workspace resolution is `--root > LW_WIKI_ROOT > registered workspace > cwd auto-discover`, so without explicit scoping the binary resolves to the **registered workspace** (`~/.llm-wiki/config.toml`) — silently writing test pages and auto-committing into the maintainer's real wiki. `cd /tmp/foo && lw new ...` is NOT enough; the registry beats cwd. (Polluted `llm-wiki-data` once on 2026-04-25 with `9816b42 docs(wiki): create wiki/tools/foo.md`; reset locally before push, but use the rule.)
 
 ## Observability
 


### PR DESCRIPTION
## Summary

- Adds a non-negotiable note to Release ritual step 7: any host smoke that exercises `lw new` / `lw write` / `lw ingest` / `lw sync` MUST scope to a throwaway dir via `--root /tmp/lw-smoke-XXXX` or `LW_WIKI_ROOT=/tmp/lw-smoke-XXXX`.
- Without explicit scoping, workspace resolution (`--root > LW_WIKI_ROOT > registered workspace > cwd auto-discover`) lands on the maintainer's real wiki and creates spurious pages + auto-commits there. `cd /tmp/foo && lw new ...` is NOT enough — registry beats cwd.
- One-line addition; pure docs, no code change.

## Why now

I hit this during the /issue-sweep #38 (auto-commit) host smoke — `lw new tools/foo` resolved to the registered `llm-wiki-data` workspace and produced commit \`9816b42 docs(wiki): create wiki/tools/foo.md\` there. Local-only (caught before push), reset cleanly, but the next contributor will trip on the same edge unless we document it.

## Test plan

- [x] `cargo fmt --check` (no Rust touched, but harmless)
- [ ] CI passes (markdown-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)