### PR TITLE
fix(core): suppress dirty-warning false positive on collapsed untracked dirs

### DIFF
--- a/crates/lw-core/src/git.rs
+++ b/crates/lw-core/src/git.rs
@@ -505,8 +505,12 @@ pub fn auto_commit(
 /// `Some(message)` when there are dirty files that aren't being committed.
 fn dirty_elsewhere_warning(repo_root: &Path, paths: &[PathBuf]) -> Option<String> {
     let toplevel = resolve_toplevel(repo_root).ok()?;
+    // `--untracked-files=all` forces individual file listings; without it
+    // git collapses fully-untracked directories (e.g. `?? wiki/`) and our
+    // suffix-matching can't tell whether the targeted page lives inside
+    // that collapse — see the dirty_warning_suppresses_… test below.
     let output = Command::new("git")
-        .args(["status", "--porcelain"])
+        .args(["status", "--porcelain", "--untracked-files=all"])
         .current_dir(&toplevel)
         .output()
         .ok()?;

--- a/crates/lw-core/src/git.rs
+++ b/crates/lw-core/src/git.rs
@@ -1047,4 +1047,61 @@ mod tests {
             "expected note.md in commit; got: {names}"
         );
     }
+
+    /// Build a repo with `README.md` tracked + the target page only, so the
+    /// dirty-warning function sees `?? wiki/` (collapsed) — the case that
+    /// previously false-positive-warned on a fresh `lw init` + `lw new`.
+    fn repo_with_only_target_dirty(root: &Path) {
+        init_repo(root);
+        fs::write(root.join("README.md"), "x").unwrap();
+        let out = Command::new("git")
+            .args(["add", "README.md"])
+            .current_dir(root)
+            .output()
+            .unwrap();
+        assert!(out.status.success());
+        let out = Command::new("git")
+            .args(["commit", "-m", "init"])
+            .current_dir(root)
+            .output()
+            .unwrap();
+        assert!(out.status.success(), "commit init: {out:?}");
+        fs::create_dir_all(root.join("wiki/tools")).unwrap();
+        fs::write(root.join("wiki/tools/foo.md"), "page").unwrap();
+    }
+
+    #[test]
+    fn dirty_warning_suppresses_when_only_dirty_thing_is_target_in_collapsed_dir() {
+        // Regression for #38 reviewer-noted false positive: `git status --porcelain`
+        // collapses an untracked dir (`?? wiki/`) when no tracked files live
+        // under it. Without `--untracked-files=all`, suffix-matching couldn't
+        // see that `wiki/tools/foo.md` lives under that collapse and the
+        // function would warn even though no OTHER file was dirty.
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        repo_with_only_target_dirty(root);
+
+        let warning = dirty_elsewhere_warning(root, &[PathBuf::from("wiki/tools/foo.md")]);
+        assert!(
+            warning.is_none(),
+            "false-positive warning when only the target is dirty: {warning:?}"
+        );
+    }
+
+    #[test]
+    fn dirty_warning_fires_when_truly_other_dirty_files_present() {
+        // Regression guard: the false-positive fix must not silence the
+        // warning when there really are unrelated dirty files.
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        repo_with_only_target_dirty(root);
+        fs::write(root.join("scratch.txt"), "draft").unwrap();
+
+        let warning = dirty_elsewhere_warning(root, &[PathBuf::from("wiki/tools/foo.md")]);
+        let w = warning.expect("warning expected when scratch.txt is also dirty");
+        assert!(
+            w.contains("scratch.txt"),
+            "warning must mention the other dirty file; got: {w}"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- 1-char fix: `git status --porcelain` → `git status --porcelain --untracked-files=all` in `lw_core::git::dirty_elsewhere_warning`.
- Without `--untracked-files=all`, git collapses fully-untracked directories (e.g. `?? wiki/`) into one entry. The function's suffix-matching couldn't see that the targeted page lives inside the collapse and warned "uncommitted changes elsewhere (wiki/)" even when no other file was dirty.
- This was the noted limitation reviewer flagged on PR #90; smoke confirmed it surfaces on the very first `lw new` after `lw init` in a fresh git repo.

## Acceptance evidence

- [x] **`dirty_warning_suppresses_when_only_dirty_thing_is_target_in_collapsed_dir`** — new test, FAILED before fix, PASSES after. Builds the exact bug scenario (tracked README + untracked wiki/tools/foo.md target) and asserts no warning.
- [x] **`dirty_warning_fires_when_truly_other_dirty_files_present`** — regression guard. Adds `scratch.txt` alongside the target, asserts warning fires AND mentions `scratch.txt` by name. Passed pre-fix, still passes — proves we didn't silence legitimate warnings.
- [x] `cargo test` — 381 passed (30 suites)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean

## Why now (not Wave 2 follow-up)

Smoke for #38 surfaced the noise audibly; cleaning it up before piling Wave 2 (#37/#39/#41) onto the auto-commit infrastructure keeps the warning behavior trustworthy in their own smoke runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)