### PR TITLE
feat(core,cli,mcp): lw capture journal-first quick capture (closes #37)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1090,6 +1090,7 @@ dependencies = [
  "tantivy-jieba",
  "tempfile",
  "thiserror 2.0.18",
+ "time",
  "tokio",
  "toml",
  "tracing",
@@ -1219,6 +1220,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -2166,7 +2176,9 @@ checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
+ "libc",
  "num-conv",
+ "num_threads",
  "powerfmt",
  "serde_core",
  "time-core",

--- a/crates/lw-cli/src/capture.rs
+++ b/crates/lw-cli/src/capture.rs
@@ -1,9 +1,15 @@
-//! `lw capture` subcommand stub (issue #37).
+//! `lw capture` subcommand (issue #37).
 //!
-//! Real implementation lands in the GREEN step.
+//! Files a single timestamped entry into today's journal page at
+//! `wiki/_journal/YYYY-MM-DD.md`, auto-creating the page on first use,
+//! then runs the project's auto-commit policy with `CommitAction::Capture`.
 
+use crate::git_commit::{AutoCommitFlags, run_auto_commit};
+use lw_core::git::CommitAction;
+use lw_core::journal::{append_capture, local_now};
 use std::path::Path;
 
+/// Auto-commit options forwarded from the CLI parser.
 pub struct CommitOpts {
     pub no_commit: bool,
     pub push: bool,
@@ -11,11 +17,50 @@ pub struct CommitOpts {
 }
 
 pub fn run(
-    _root: &Path,
-    _content: &str,
-    _tags: Vec<String>,
-    _source: Option<String>,
-    _commit_opts: CommitOpts,
+    root: &Path,
+    content: &str,
+    tags: Vec<String>,
+    source: Option<String>,
+    commit_opts: CommitOpts,
 ) -> anyhow::Result<()> {
-    unimplemented!("`lw capture` not yet implemented (#37)")
+    // Pre-flight: refuse empty captures with a clear error before we
+    // touch the filesystem. `append_capture` also rejects this, but the
+    // earlier exit produces a tidier error message in CLI mode.
+    if content.trim().is_empty() {
+        anyhow::bail!("capture content must not be empty (provide a non-blank message)");
+    }
+
+    let now = local_now();
+    let date = now.date();
+    let time = now.time();
+
+    let outcome = append_capture(root, date, time, content, &tags, source.as_deref())?;
+
+    eprintln!(
+        "{} {} ({})",
+        if outcome.created {
+            "Created"
+        } else {
+            "Appended to"
+        },
+        outcome.display_path,
+        outcome.line.trim_start_matches("- "),
+    );
+
+    // Auto-commit (issue #38). Page slug for the commit subject is the
+    // vault-relative path, so reviewers can see the date at a glance.
+    run_auto_commit(
+        root,
+        std::slice::from_ref(&outcome.path),
+        CommitAction::Capture,
+        &outcome.display_path,
+        AutoCommitFlags {
+            no_commit: commit_opts.no_commit,
+            push: commit_opts.push,
+            author: commit_opts.author.as_deref(),
+            source: source.as_deref(),
+        },
+    )?;
+
+    Ok(())
 }

--- a/crates/lw-cli/src/capture.rs
+++ b/crates/lw-cli/src/capture.rs
@@ -1,0 +1,21 @@
+//! `lw capture` subcommand stub (issue #37).
+//!
+//! Real implementation lands in the GREEN step.
+
+use std::path::Path;
+
+pub struct CommitOpts {
+    pub no_commit: bool,
+    pub push: bool,
+    pub author: Option<String>,
+}
+
+pub fn run(
+    _root: &Path,
+    _content: &str,
+    _tags: Vec<String>,
+    _source: Option<String>,
+    _commit_opts: CommitOpts,
+) -> anyhow::Result<()> {
+    unimplemented!("`lw capture` not yet implemented (#37)")
+}

--- a/crates/lw-cli/src/git_commit.rs
+++ b/crates/lw-cli/src/git_commit.rs
@@ -57,5 +57,6 @@ fn action_str(a: CommitAction) -> &'static str {
         CommitAction::Append => "append",
         CommitAction::Upsert => "upsert",
         CommitAction::Ingest => "ingest",
+        CommitAction::Capture => "capture",
     }
 }

--- a/crates/lw-cli/src/lint.rs
+++ b/crates/lw-cli/src/lint.rs
@@ -21,6 +21,7 @@ fn print_human_report(report: &LintReport) {
         + report.broken_related.len()
         + report.orphan_pages.len()
         + report.missing_concepts.len()
+        + report.stale_journal_pages.len()
         + report.freshness.stale;
 
     println!("Wiki Lint Report");
@@ -54,6 +55,17 @@ fn print_human_report(report: &LintReport) {
     if !report.missing_concepts.is_empty() {
         println!("Missing Concepts ({}):", report.missing_concepts.len());
         for f in &report.missing_concepts {
+            println!("  - {}: {}", f.path, f.detail);
+        }
+        println!();
+    }
+
+    if !report.stale_journal_pages.is_empty() {
+        println!(
+            "Unprocessed Journal Captures ({}):",
+            report.stale_journal_pages.len()
+        );
+        for f in &report.stale_journal_pages {
             println!("  - {}: {}", f.path, f.detail);
         }
         println!();

--- a/crates/lw-cli/src/main.rs
+++ b/crates/lw-cli/src/main.rs
@@ -1,3 +1,4 @@
+mod capture;
 mod config;
 mod doctor;
 mod git_commit;
@@ -251,6 +252,30 @@ enum Commands {
         /// Force-push with lease (after the rebase)
         #[arg(long)]
         force: bool,
+    },
+
+    /// Append a quick-capture entry to today's journal (wiki/_journal/YYYY-MM-DD.md)
+    #[command(
+        after_help = "Examples:\n  lw capture \"comrak round-trips markdown via arena AST\"\n  lw capture --tag rust --tag markdown \"see docs.rs/comrak\"\n  lw capture --source \"https://example.com/article\" \"key insight\"\n  lw capture --no-commit \"draft thought, don't commit yet\""
+    )]
+    Capture {
+        /// Capture text. Wrap multi-word content in quotes.
+        content: String,
+        /// Tag to attach to the capture line (`#tag`). Repeatable.
+        #[arg(long)]
+        tag: Vec<String>,
+        /// Source URL/identifier rendered as `([source](URL))` at end of line.
+        #[arg(long)]
+        source: Option<String>,
+        /// Skip the auto-commit that normally follows a capture
+        #[arg(long)]
+        no_commit: bool,
+        /// Also `git push` after committing
+        #[arg(long)]
+        push: bool,
+        /// Override commit author as `"Name <email>"`
+        #[arg(long)]
+        author: Option<String>,
     },
 
     /// Manage registered wiki workspaces (Obsidian-style vaults)
@@ -567,6 +592,30 @@ fn main() {
         },
         Commands::Sync { force } => match resolve_root(cli.root) {
             Ok(root) => sync::run(&root, force),
+            Err(e) => {
+                eprintln!("Error: {e}");
+                process::exit(1);
+            }
+        },
+        Commands::Capture {
+            content,
+            tag,
+            source,
+            no_commit,
+            push,
+            author,
+        } => match resolve_root(cli.root) {
+            Ok(root) => capture::run(
+                &root,
+                &content,
+                tag,
+                source,
+                capture::CommitOpts {
+                    no_commit,
+                    push,
+                    author,
+                },
+            ),
             Err(e) => {
                 eprintln!("Error: {e}");
                 process::exit(1);

--- a/crates/lw-cli/tests/capture_test.rs
+++ b/crates/lw-cli/tests/capture_test.rs
@@ -1,0 +1,304 @@
+//! CLI integration tests for `lw capture` (issue #37).
+//!
+//! Coverage map:
+//!   AC1 — `lw capture "text"` appends to today's journal: `appends_to_today_journal`
+//!   AC2 — Auto-creates frontmatter:                       `auto_creates_frontmatter`
+//!   AC3 — HH:MM timestamp prefix:                         `appends_to_today_journal`
+//!   AC4 — `--tag` and `--source` flags:                   `tag_flag_renders`, `source_flag_renders`
+//!   AC6 — `_journal` scaffolded by `lw init`:             `init_creates_journal_dir`
+//!
+//! Auto-commit interaction is also covered: a `lw capture` inside a git
+//! repo produces a `docs(wiki): capture _journal/<DATE>` commit.
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use std::fs;
+use std::path::Path;
+use std::process::Command as StdCommand;
+use tempfile::TempDir;
+
+fn lw() -> Command {
+    Command::cargo_bin("lw").unwrap()
+}
+
+/// `lw init` + git init inside `tmp.path()`. Returns the wiki root TempDir.
+fn setup_wiki_in_git_repo() -> TempDir {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    lw().args(["init", "--root", root.to_str().unwrap()])
+        .assert()
+        .success();
+    init_repo(root);
+    StdCommand::new("git")
+        .args(["add", "."])
+        .current_dir(root)
+        .output()
+        .unwrap();
+    StdCommand::new("git")
+        .args(["commit", "-m", "seed"])
+        .current_dir(root)
+        .output()
+        .unwrap();
+    tmp
+}
+
+fn init_repo(path: &Path) {
+    StdCommand::new("git")
+        .args(["init", "--initial-branch=main"])
+        .current_dir(path)
+        .output()
+        .unwrap();
+    StdCommand::new("git")
+        .args(["config", "user.name", "T"])
+        .current_dir(path)
+        .output()
+        .unwrap();
+    StdCommand::new("git")
+        .args(["config", "user.email", "t@example.com"])
+        .current_dir(path)
+        .output()
+        .unwrap();
+    StdCommand::new("git")
+        .args(["config", "commit.gpgsign", "false"])
+        .current_dir(path)
+        .output()
+        .unwrap();
+}
+
+fn today_iso() -> String {
+    use lw_core::journal::{format_date_iso, local_now};
+    format_date_iso(local_now().date())
+}
+
+fn read_today_journal(root: &Path) -> String {
+    let path = root
+        .join("wiki/_journal")
+        .join(format!("{}.md", today_iso()));
+    fs::read_to_string(&path).unwrap_or_else(|_| panic!("journal not found at {path:?}"))
+}
+
+// ── AC6: `lw init` scaffolds `_journal/` ──────────────────────────────────────
+
+#[test]
+fn init_creates_journal_dir() {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+    lw().args(["init", "--root", root.to_str().unwrap()])
+        .assert()
+        .success();
+    assert!(
+        root.join("wiki/_journal").is_dir(),
+        "lw init must scaffold wiki/_journal/ directory"
+    );
+}
+
+// ── AC1 + AC3: lw capture writes the timestamped line ─────────────────────────
+
+#[test]
+fn appends_to_today_journal() {
+    let tmp = setup_wiki_in_git_repo();
+    let root = tmp.path();
+
+    lw().args([
+        "--root",
+        root.to_str().unwrap(),
+        "capture",
+        "comrak can round-trip markdown via arena AST",
+    ])
+    .assert()
+    .success();
+
+    let content = read_today_journal(root);
+    assert!(
+        content.contains("comrak can round-trip markdown via arena AST"),
+        "captured text missing; content:\n{content}"
+    );
+    // Timestamp prefix shape: `**HH:MM**`. Use a regex predicate.
+    let re = predicates::str::is_match(r"\*\*\d{2}:\d{2}\*\* comrak can round-trip").unwrap();
+    assert!(
+        re.eval(&content),
+        "expected `**HH:MM** comrak can …` in journal; got:\n{content}"
+    );
+}
+
+// ── AC2: auto-created frontmatter ─────────────────────────────────────────────
+
+#[test]
+fn auto_creates_frontmatter() {
+    let tmp = setup_wiki_in_git_repo();
+    let root = tmp.path();
+
+    lw().args([
+        "--root",
+        root.to_str().unwrap(),
+        "capture",
+        "first ever capture",
+    ])
+    .assert()
+    .success();
+
+    let content = read_today_journal(root);
+    assert!(
+        content.starts_with("---\n"),
+        "page must start with frontmatter; got:\n{content}"
+    );
+    assert!(
+        content.contains("tags: [journal]") || content.contains("- journal"),
+        "frontmatter must include `journal` tag; got:\n{content}"
+    );
+    assert!(
+        content.contains(&format!("created: {}", today_iso())),
+        "frontmatter must include `created: <today>`; got:\n{content}"
+    );
+    assert!(
+        content.contains("## Captures"),
+        "page must include `## Captures` heading; got:\n{content}"
+    );
+}
+
+// ── AC4: --tag + --source flags ───────────────────────────────────────────────
+
+#[test]
+fn tag_flag_renders() {
+    let tmp = setup_wiki_in_git_repo();
+    let root = tmp.path();
+
+    lw().args([
+        "--root",
+        root.to_str().unwrap(),
+        "capture",
+        "with tags",
+        "--tag",
+        "rust",
+        "--tag",
+        "markdown",
+    ])
+    .assert()
+    .success();
+
+    let content = read_today_journal(root);
+    assert!(
+        content.contains("with tags `#rust` `#markdown`"),
+        "tag flags must render after content; got:\n{content}"
+    );
+}
+
+#[test]
+fn source_flag_renders() {
+    let tmp = setup_wiki_in_git_repo();
+    let root = tmp.path();
+
+    lw().args([
+        "--root",
+        root.to_str().unwrap(),
+        "capture",
+        "with source",
+        "--source",
+        "https://example.com/article",
+    ])
+    .assert()
+    .success();
+
+    let content = read_today_journal(root);
+    assert!(
+        content.contains("with source ([source](https://example.com/article))"),
+        "source flag must render at end of line; got:\n{content}"
+    );
+}
+
+// ── Auto-commit interaction ───────────────────────────────────────────────────
+
+#[test]
+fn capture_inside_git_repo_auto_commits_with_capture_action() {
+    let tmp = setup_wiki_in_git_repo();
+    let root = tmp.path();
+
+    let before = commit_count(root);
+    lw().args([
+        "--root",
+        root.to_str().unwrap(),
+        "capture",
+        "auto-commit me",
+    ])
+    .assert()
+    .success();
+
+    let after = commit_count(root);
+    assert_eq!(
+        after,
+        before + 1,
+        "lw capture inside a git repo must auto-commit"
+    );
+    let subj = head_subject(root);
+    assert!(
+        subj.starts_with("docs(wiki): capture"),
+        "commit subject must be 'docs(wiki): capture <slug>'; got: {subj}"
+    );
+}
+
+#[test]
+fn capture_no_commit_skips_commit() {
+    let tmp = setup_wiki_in_git_repo();
+    let root = tmp.path();
+
+    let before = commit_count(root);
+    lw().args([
+        "--root",
+        root.to_str().unwrap(),
+        "capture",
+        "no-commit thought",
+        "--no-commit",
+    ])
+    .assert()
+    .success();
+
+    assert_eq!(
+        commit_count(root),
+        before,
+        "--no-commit must suppress the auto-commit"
+    );
+}
+
+// ── Help string ───────────────────────────────────────────────────────────────
+
+#[test]
+fn capture_help_shows_examples() {
+    lw().args(["capture", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::is_match("(?i)examples").unwrap());
+}
+
+// ── Empty content rejected ────────────────────────────────────────────────────
+
+#[test]
+fn empty_capture_exits_with_error() {
+    let tmp = setup_wiki_in_git_repo();
+    let root = tmp.path();
+    lw().args(["--root", root.to_str().unwrap(), "capture", "   "])
+        .assert()
+        .failure();
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+fn head_subject(repo: &Path) -> String {
+    let out = StdCommand::new("git")
+        .args(["log", "-1", "--format=%s"])
+        .current_dir(repo)
+        .output()
+        .unwrap();
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+fn commit_count(repo: &Path) -> u32 {
+    let out = StdCommand::new("git")
+        .args(["rev-list", "--count", "HEAD"])
+        .current_dir(repo)
+        .output()
+        .unwrap();
+    String::from_utf8_lossy(&out.stdout)
+        .trim()
+        .parse()
+        .unwrap_or(0)
+}

--- a/crates/lw-core/Cargo.toml
+++ b/crates/lw-core/Cargo.toml
@@ -16,7 +16,9 @@ regex = "1"
 tracing = { workspace = true }
 comrak = { version = "0.36", default-features = false }
 tempfile = "3"
+time = { version = "0.3", features = ["formatting", "macros", "local-offset"] }
 
 [dev-dependencies]
 tempfile = "3"
 tokio = { workspace = true }
+time = { version = "0.3", features = ["formatting", "macros"] }

--- a/crates/lw-core/src/git.rs
+++ b/crates/lw-core/src/git.rs
@@ -373,8 +373,8 @@ pub fn pull_rebase(repo_root: &Path) -> Result<()> {
 // ─── High-level auto-commit policy (CLI / MCP shared) ───────────────────────
 
 /// Action recorded in the conventional-commit subject. The string forms
-/// (`"create"`, `"update"`, `"append"`, `"upsert"`, `"ingest"`) match the
-/// terms specified in issue #38.
+/// (`"create"`, `"update"`, `"append"`, `"upsert"`, `"ingest"`, `"capture"`)
+/// match the terms specified in issues #38 and #37.
 #[derive(Debug, Clone, Copy)]
 pub enum CommitAction {
     Create,
@@ -382,6 +382,8 @@ pub enum CommitAction {
     Append,
     Upsert,
     Ingest,
+    /// Quick-capture journal entry (`lw capture` / `wiki_capture`, issue #37).
+    Capture,
 }
 
 impl CommitAction {
@@ -392,6 +394,7 @@ impl CommitAction {
             CommitAction::Append => "append",
             CommitAction::Upsert => "upsert",
             CommitAction::Ingest => "ingest",
+            CommitAction::Capture => "capture",
         }
     }
 }

--- a/crates/lw-core/src/journal.rs
+++ b/crates/lw-core/src/journal.rs
@@ -1,0 +1,68 @@
+//! Journal-first quick capture (issue #37) — STUB.
+//!
+//! Real implementation lands in the GREEN step. This stub keeps the crate
+//! compiling so the failing tests have something to call.
+
+use crate::Result;
+use std::path::{Path, PathBuf};
+use time::{Date, OffsetDateTime, Time};
+
+pub const JOURNAL_DIR: &str = "_journal";
+pub const DEFAULT_STALE_AFTER_DAYS: u32 = 7;
+
+#[derive(Debug)]
+pub struct CaptureAppend {
+    pub path: PathBuf,
+    pub created: bool,
+    pub line: String,
+    pub display_path: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct StaleJournalFinding {
+    pub path: String,
+    pub age_days: i64,
+}
+
+pub fn append_capture(
+    _wiki_root: &Path,
+    _date: Date,
+    _time: Time,
+    _content: &str,
+    _tags: &[String],
+    _source: Option<&str>,
+) -> Result<CaptureAppend> {
+    unimplemented!("journal::append_capture not yet implemented (#37)")
+}
+
+pub fn format_date_iso(_date: Date) -> String {
+    unimplemented!()
+}
+
+pub fn format_time_hm(_time: Time) -> String {
+    unimplemented!()
+}
+
+pub fn journal_path_for_date(_wiki_root: &Path, _date: Date) -> PathBuf {
+    unimplemented!()
+}
+
+pub fn format_capture_line(
+    _time: Time,
+    _content: &str,
+    _tags: &[String],
+    _source: Option<&str>,
+) -> String {
+    unimplemented!()
+}
+
+pub fn local_now() -> OffsetDateTime {
+    unimplemented!()
+}
+
+pub fn find_stale_captures(
+    _wiki_root: &Path,
+    _threshold_days: u32,
+) -> Result<Vec<StaleJournalFinding>> {
+    unimplemented!()
+}

--- a/crates/lw-core/src/journal.rs
+++ b/crates/lw-core/src/journal.rs
@@ -234,7 +234,8 @@ pub fn find_stale_captures(
             });
         }
     }
-    out.sort_by(|a, b| b.age_days.cmp(&a.age_days));
+    // Oldest first — note `Reverse` to flip the natural ascending sort.
+    out.sort_by_key(|f| std::cmp::Reverse(f.age_days));
     Ok(out)
 }
 

--- a/crates/lw-core/src/journal.rs
+++ b/crates/lw-core/src/journal.rs
@@ -1,68 +1,271 @@
-//! Journal-first quick capture (issue #37) — STUB.
+//! Journal-first quick capture (issue #37).
 //!
-//! Real implementation lands in the GREEN step. This stub keeps the crate
-//! compiling so the failing tests have something to call.
+//! Provides `append_capture` for filing a single timestamped entry into the
+//! day's journal page (`wiki/_journal/YYYY-MM-DD.md`) and `find_stale_captures`
+//! used by `lw lint` to flag unprocessed captures older than a threshold.
+//!
+//! Design rules (CLAUDE.md):
+//! - Auto-creates the day's page (with frontmatter) if missing.
+//! - All file writes go through `crate::fs::atomic_write` so concurrent
+//!   readers (e.g. `lw serve`) never see a torn file.
+//! - The function takes an injectable `(date, time)` pair so tests aren't
+//!   wall-clock-dependent. Production callers pass the current local
+//!   timestamp via `local_now()`.
 
-use crate::Result;
+use crate::fs::atomic_write;
+use crate::{Result, WikiError};
 use std::path::{Path, PathBuf};
-use time::{Date, OffsetDateTime, Time};
+use time::macros::format_description;
+use time::{Date, OffsetDateTime, Time, UtcOffset};
 
+/// Vault-relative directory where journal pages live.
 pub const JOURNAL_DIR: &str = "_journal";
+
+/// Default for `stale_after_days` when the schema does not configure
+/// `[journal] stale_after_days = N`.
 pub const DEFAULT_STALE_AFTER_DAYS: u32 = 7;
 
+/// Outcome of `append_capture`.
 #[derive(Debug)]
 pub struct CaptureAppend {
+    /// Absolute path to the journal page that received the capture.
     pub path: PathBuf,
+    /// True iff the journal page was just auto-created.
     pub created: bool,
+    /// The literal line appended (without the trailing newline). Useful for
+    /// rendering the CLI/MCP success message.
     pub line: String,
+    /// Vault-relative path (e.g. `wiki/_journal/2026-04-25.md`).
     pub display_path: String,
 }
 
+/// Append a capture entry to the journal page for `date`. Auto-creates the
+/// page (with frontmatter) when it doesn't exist. The capture line carries
+/// the `time` prefix in `HH:MM` form, the `content`, then optional tag
+/// (`#rust`) and source (`([source](URL))`) suffixes.
+///
+/// `content` must not be empty (after trimming) — empty captures aren't
+/// useful and would muddy the journal.
+///
+/// # Errors
+///
+/// - `WikiError::Internal` if `content.trim()` is empty.
+/// - `WikiError::Io` for any filesystem failure.
+#[tracing::instrument(skip(content, tags, source))]
+pub fn append_capture(
+    wiki_root: &Path,
+    date: Date,
+    time: Time,
+    content: &str,
+    tags: &[String],
+    source: Option<&str>,
+) -> Result<CaptureAppend> {
+    let trimmed = content.trim();
+    if trimmed.is_empty() {
+        return Err(WikiError::Internal(
+            "capture content must not be empty".to_string(),
+        ));
+    }
+
+    let path = journal_path_for_date(wiki_root, date);
+    let display_path = format!("wiki/{}/{}.md", JOURNAL_DIR, format_date_iso(date));
+
+    let line = format_capture_line(time, trimmed, tags, source);
+
+    // If the file doesn't exist, scaffold it with frontmatter +
+    // ## Captures section + the new line. If it exists, append the line
+    // to the end of the file (ensuring the file ends with a newline first).
+    let (body, created) = if path.exists() {
+        let existing = std::fs::read_to_string(&path)?;
+        let mut out = existing;
+        if !out.ends_with('\n') {
+            out.push('\n');
+        }
+        out.push_str(&line);
+        out.push('\n');
+        (out, false)
+    } else {
+        (scaffold_journal_page(date, &line), true)
+    };
+
+    atomic_write(&path, body.as_bytes())?;
+    Ok(CaptureAppend {
+        path,
+        created,
+        line,
+        display_path,
+    })
+}
+
+/// Format `date` as `YYYY-MM-DD`.
+pub fn format_date_iso(date: Date) -> String {
+    let fmt = format_description!("[year]-[month]-[day]");
+    date.format(&fmt).unwrap_or_else(|_| {
+        // Format string is statically valid; only OOM-class failures are
+        // possible. Fall back to manual formatting if the impossible happens.
+        format!(
+            "{:04}-{:02}-{:02}",
+            date.year(),
+            u8::from(date.month()),
+            date.day()
+        )
+    })
+}
+
+/// Format `time` as `HH:MM` (24h).
+pub fn format_time_hm(time: Time) -> String {
+    let fmt = format_description!("[hour]:[minute]");
+    time.format(&fmt)
+        .unwrap_or_else(|_| format!("{:02}:{:02}", time.hour(), time.minute()))
+}
+
+/// Compute the vault-absolute path to the journal page for `date`.
+pub fn journal_path_for_date(wiki_root: &Path, date: Date) -> PathBuf {
+    wiki_root
+        .join("wiki")
+        .join(JOURNAL_DIR)
+        .join(format!("{}.md", format_date_iso(date)))
+}
+
+/// Build the formatted capture line (no trailing newline).
+///
+/// Examples:
+/// - `- **10:23** comrak can round-trip markdown via arena AST`
+/// - `- **10:25** see docs.rs/comrak \`#rust\` \`#markdown\``
+/// - `- **10:30** key insight ([source](https://example.com))`
+pub fn format_capture_line(
+    time: Time,
+    content: &str,
+    tags: &[String],
+    source: Option<&str>,
+) -> String {
+    let mut line = format!("- **{}** {}", format_time_hm(time), content.trim());
+    for tag in tags {
+        let t = tag.trim().trim_start_matches('#');
+        if !t.is_empty() {
+            line.push_str(&format!(" `#{t}`"));
+        }
+    }
+    if let Some(url) = source {
+        let url = url.trim();
+        if !url.is_empty() {
+            line.push_str(&format!(" ([source]({url}))"));
+        }
+    }
+    line
+}
+
+/// Scaffold a journal page with frontmatter and a `## Captures` section
+/// containing the first entry.
+///
+/// We hand-build the YAML rather than going through `Page::to_markdown`
+/// because the spec requires a `created: YYYY-MM-DD` field that the `Page`
+/// struct doesn't carry (the project rule keeps time data in git, but the
+/// spec example shows `created` literally in the journal frontmatter so
+/// agents can read the date without filename parsing).
+fn scaffold_journal_page(date: Date, first_line: &str) -> String {
+    let date_str = format_date_iso(date);
+    // Quote the title so YAML parsers treat the colons in the date string
+    // as part of the value rather than nested mapping syntax.
+    let yaml = format!(
+        "title: \"{date}\"\ntags: [journal]\ncreated: {date}\n",
+        date = date_str
+    );
+    format!("---\n{yaml}---\n\n## Captures\n\n{first_line}\n")
+}
+
+/// Best-effort: get the current local time. Falls back to UTC if the
+/// system rejects the offset lookup (some sandboxed test runners).
+pub fn local_now() -> OffsetDateTime {
+    let utc = OffsetDateTime::now_utc();
+    match UtcOffset::current_local_offset() {
+        Ok(off) => utc.to_offset(off),
+        Err(_) => utc,
+    }
+}
+
+/// One stale-journal lint finding.
 #[derive(Debug, Clone)]
 pub struct StaleJournalFinding {
+    /// Wiki-relative path (e.g. `_journal/2026-04-15.md`).
     pub path: String,
+    /// Age in days at lint time (since the journal page's last commit).
     pub age_days: i64,
 }
 
-pub fn append_capture(
-    _wiki_root: &Path,
-    _date: Date,
-    _time: Time,
-    _content: &str,
-    _tags: &[String],
-    _source: Option<&str>,
-) -> Result<CaptureAppend> {
-    unimplemented!("journal::append_capture not yet implemented (#37)")
-}
-
-pub fn format_date_iso(_date: Date) -> String {
-    unimplemented!()
-}
-
-pub fn format_time_hm(_time: Time) -> String {
-    unimplemented!()
-}
-
-pub fn journal_path_for_date(_wiki_root: &Path, _date: Date) -> PathBuf {
-    unimplemented!()
-}
-
-pub fn format_capture_line(
-    _time: Time,
-    _content: &str,
-    _tags: &[String],
-    _source: Option<&str>,
-) -> String {
-    unimplemented!()
-}
-
-pub fn local_now() -> OffsetDateTime {
-    unimplemented!()
-}
-
+/// Find journal pages whose last git commit is older than `threshold_days`.
+/// Pages without git history are silently skipped (matches the rule used in
+/// `lint::run_lint`).
+///
+/// Returns the findings sorted oldest-first.
 pub fn find_stale_captures(
-    _wiki_root: &Path,
-    _threshold_days: u32,
+    wiki_root: &Path,
+    threshold_days: u32,
 ) -> Result<Vec<StaleJournalFinding>> {
-    unimplemented!()
+    let journal_dir = wiki_root.join("wiki").join(JOURNAL_DIR);
+    if !journal_dir.exists() {
+        return Ok(Vec::new());
+    }
+    let mut out = Vec::new();
+    for entry in std::fs::read_dir(&journal_dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        if !path.is_file()
+            || path.extension().is_none_or(|e| e != "md")
+            || path
+                .file_name()
+                .and_then(|n| n.to_str())
+                .is_some_and(|n| n.starts_with('.'))
+        {
+            continue;
+        }
+        let age = match age_days_in_repo(wiki_root, &path) {
+            Some(a) => a,
+            None => continue, // no git history: not actionable
+        };
+        if age > threshold_days as i64 {
+            let rel = path
+                .strip_prefix(wiki_root.join("wiki"))
+                .map(|p| p.to_string_lossy().to_string())
+                .unwrap_or_else(|_| path.to_string_lossy().to_string());
+            out.push(StaleJournalFinding {
+                path: rel,
+                age_days: age,
+            });
+        }
+    }
+    out.sort_by(|a, b| b.age_days.cmp(&a.age_days));
+    Ok(out)
+}
+
+/// `crate::git::page_age_days` doesn't pin its working directory, so it
+/// queries the cwd's git repo — useless when callers (CLI, MCP, lint)
+/// are running in some other directory. This helper sets `current_dir`
+/// to `wiki_root` so the lookup hits the right repo even when the
+/// process cwd points elsewhere (e.g. tests running from the worktree).
+fn age_days_in_repo(wiki_root: &Path, abs_path: &Path) -> Option<i64> {
+    let out = std::process::Command::new("git")
+        .args([
+            "log",
+            "--follow",
+            "-1",
+            "--format=%at",
+            "--",
+            abs_path.to_str()?,
+        ])
+        .current_dir(wiki_root)
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let ts: i64 = String::from_utf8(out.stdout).ok()?.trim().parse().ok()?;
+    if ts == 0 {
+        return None;
+    }
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .ok()?
+        .as_secs() as i64;
+    Some((now - ts) / 86400)
 }

--- a/crates/lw-core/src/lib.rs
+++ b/crates/lw-core/src/lib.rs
@@ -3,6 +3,7 @@ pub mod fs;
 pub mod git;
 pub mod import;
 pub mod ingest;
+pub mod journal;
 pub mod link;
 pub mod lint;
 pub mod page;

--- a/crates/lw-core/src/lint.rs
+++ b/crates/lw-core/src/lint.rs
@@ -34,6 +34,11 @@ pub struct LintReport {
     pub orphan_pages: Vec<LintFinding>,
     pub missing_concepts: Vec<LintFinding>,
     pub freshness: FreshnessReport,
+    /// Journal pages whose last git commit is older than the threshold
+    /// configured via `[journal] stale_after_days = N` (default 7 days).
+    /// Issue #37: signals captures that haven't been triaged.
+    #[serde(default)]
+    pub stale_journal_pages: Vec<LintFinding>,
 }
 
 /// Run all lint checks on the wiki at `root`.
@@ -172,5 +177,6 @@ pub fn run_lint(root: &Path, category: Option<&str>) -> crate::Result<LintReport
             stale: freshness_stale,
             stale_pages,
         },
+        stale_journal_pages: Vec::new(),
     })
 }

--- a/crates/lw-core/src/lint.rs
+++ b/crates/lw-core/src/lint.rs
@@ -166,6 +166,33 @@ pub fn run_lint(root: &Path, category: Option<&str>) -> crate::Result<LintReport
         })
         .collect();
 
+    // Journal triage check (issue #37): journal pages whose last git
+    // commit is older than `[journal] stale_after_days` are flagged as
+    // unprocessed captures awaiting promotion to permanent pages.
+    let stale_threshold = schema.journal_stale_after_days();
+    let stale_journal_pages: Vec<LintFinding> =
+        crate::journal::find_stale_captures(root, stale_threshold)
+            .unwrap_or_default()
+            .into_iter()
+            .filter(|finding| {
+                // Honor the `--category` filter the same way other checks do.
+                // The stale-finder returns wiki-relative paths starting with
+                // `_journal/`; if the user filtered to a different category,
+                // suppress these findings.
+                match category {
+                    Some(filter) => finding.path.starts_with(&format!("{filter}/")),
+                    None => true,
+                }
+            })
+            .map(|finding| LintFinding {
+                path: finding.path,
+                detail: format!(
+                    "stale capture (age={}d, threshold={}d) — promote or archive",
+                    finding.age_days, stale_threshold
+                ),
+            })
+            .collect();
+
     Ok(LintReport {
         todo_pages,
         broken_related,
@@ -177,6 +204,6 @@ pub fn run_lint(root: &Path, category: Option<&str>) -> crate::Result<LintReport
             stale: freshness_stale,
             stale_pages,
         },
-        stale_journal_pages: Vec::new(),
+        stale_journal_pages,
     })
 }

--- a/crates/lw-core/src/schema.rs
+++ b/crates/lw-core/src/schema.rs
@@ -18,6 +18,19 @@ pub struct WikiSchema {
     pub tags: TagsConfig,
     #[serde(default)]
     pub categories: HashMap<String, CategoryConfig>,
+    /// Optional `[journal]` block. Configures how `lw lint` flags
+    /// unprocessed journal entries (issue #37).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub journal: Option<JournalConfig>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct JournalConfig {
+    /// Threshold (in days, since the journal page's last git commit) above
+    /// which `lw lint` flags the page as an unprocessed capture. When the
+    /// `[journal]` block is missing, the default is 7.
+    #[serde(default)]
+    pub stale_after_days: Option<u32>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -60,10 +73,30 @@ impl WikiSchema {
     pub fn category_config(&self, name: &str) -> Option<&CategoryConfig> {
         self.categories.get(name)
     }
+
+    /// Effective `stale_after_days` for journal pages. Falls back to
+    /// [`crate::journal::DEFAULT_STALE_AFTER_DAYS`] when the schema does not
+    /// configure `[journal] stale_after_days = N`.
+    pub fn journal_stale_after_days(&self) -> u32 {
+        self.journal
+            .as_ref()
+            .and_then(|j| j.stale_after_days)
+            .unwrap_or(crate::journal::DEFAULT_STALE_AFTER_DAYS)
+    }
 }
 
 impl Default for WikiSchema {
     fn default() -> Self {
+        let mut categories: HashMap<String, CategoryConfig> = HashMap::new();
+        categories.insert(
+            "_journal".to_string(),
+            CategoryConfig {
+                review_days: None,
+                // Captures must be friction-free — no required_fields.
+                required_fields: Vec::new(),
+                template: "## Captures\n".to_string(),
+            },
+        );
         Self {
             wiki: WikiConfig {
                 name: "LLM Wiki".to_string(),
@@ -77,6 +110,7 @@ impl Default for WikiSchema {
                     "tools".into(),
                     "product".into(),
                     "ops".into(),
+                    "_journal".into(),
                 ],
                 decay_defaults: HashMap::from([
                     ("product".into(), "fast".into()),
@@ -85,9 +119,14 @@ impl Default for WikiSchema {
                     ("infra".into(), "normal".into()),
                     ("tools".into(), "fast".into()),
                     ("ops".into(), "normal".into()),
+                    // Journal pages are write-once, never go stale via decay.
+                    ("_journal".into(), "evergreen".into()),
                 ]),
             },
-            categories: HashMap::new(),
+            categories,
+            journal: Some(JournalConfig {
+                stale_after_days: Some(crate::journal::DEFAULT_STALE_AFTER_DAYS),
+            }),
         }
     }
 }

--- a/crates/lw-core/tests/journal_test.rs
+++ b/crates/lw-core/tests/journal_test.rs
@@ -8,13 +8,13 @@
 //!   4. `--tag <tag>` (repeatable) and `--source <url>` flags render correctly.
 //!   7. `find_stale_captures` reports journal pages older than the threshold.
 
+use lw_core::WikiError;
 use lw_core::fs::init_wiki;
 use lw_core::journal::{
-    append_capture, find_stale_captures, format_capture_line, format_date_iso, format_time_hm,
-    journal_path_for_date, DEFAULT_STALE_AFTER_DAYS, JOURNAL_DIR,
+    DEFAULT_STALE_AFTER_DAYS, JOURNAL_DIR, append_capture, find_stale_captures,
+    format_capture_line, format_date_iso, format_time_hm, journal_path_for_date,
 };
 use lw_core::schema::WikiSchema;
-use lw_core::WikiError;
 use std::fs;
 use std::path::Path;
 use std::process::Command;
@@ -26,6 +26,22 @@ fn fresh_wiki() -> TempDir {
     let tmp = TempDir::new().expect("tempdir");
     init_wiki(tmp.path(), &WikiSchema::default()).expect("init_wiki");
     tmp
+}
+
+/// Build an RFC 2822 timestamp 30 days in the past. Git accepts this form
+/// regardless of locale or natural-date support.
+fn thirty_days_ago_rfc2822() -> String {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("time before epoch?");
+    let unix = now.as_secs() as i64 - 30 * 86400;
+    // Hand off to git itself: `git -C <dir> rev-parse` doesn't help here,
+    // but we can use the `time` crate (already a dev-dep) to format.
+    let dt = time::OffsetDateTime::from_unix_timestamp(unix).expect("valid timestamp");
+    let fmt = time::macros::format_description!(
+        "[weekday repr:short], [day] [month repr:short] [year] [hour]:[minute]:[second] +0000"
+    );
+    dt.format(&fmt).expect("format ok")
 }
 
 /// Initialise a git repo at `path` with sane identity config.
@@ -392,12 +408,14 @@ fn find_stale_captures_flags_old_journal_pages_via_git_age() {
         .current_dir(tmp.path())
         .output()
         .unwrap();
-    // Commit with date 30 days in the past.
-    let backdate = "30 days ago";
+    // Commit with a wall-clock date 30 days in the past. Using an explicit
+    // RFC 2822 date avoids "fatal: invalid date format" on git versions
+    // that don't accept the natural-language `"30 days ago"` form.
+    let backdate = thirty_days_ago_rfc2822();
     let out = Command::new("git")
         .args(["commit", "-m", "backdate"])
-        .env("GIT_AUTHOR_DATE", backdate)
-        .env("GIT_COMMITTER_DATE", backdate)
+        .env("GIT_AUTHOR_DATE", &backdate)
+        .env("GIT_COMMITTER_DATE", &backdate)
         .current_dir(tmp.path())
         .output()
         .unwrap();

--- a/crates/lw-core/tests/journal_test.rs
+++ b/crates/lw-core/tests/journal_test.rs
@@ -1,0 +1,465 @@
+//! Tests for `lw_core::journal::append_capture` and friends (issue #37).
+//!
+//! Acceptance criteria covered:
+//!   1. `lw capture "text"` appends to today's journal.
+//!   2. Journal page auto-created with frontmatter (`title`, `tags: [journal]`,
+//!      `created: YYYY-MM-DD`) when not yet present.
+//!   3. Each line is timestamped `HH:MM` (24h, local timezone).
+//!   4. `--tag <tag>` (repeatable) and `--source <url>` flags render correctly.
+//!   7. `find_stale_captures` reports journal pages older than the threshold.
+
+use lw_core::fs::init_wiki;
+use lw_core::journal::{
+    append_capture, find_stale_captures, format_capture_line, format_date_iso, format_time_hm,
+    journal_path_for_date, DEFAULT_STALE_AFTER_DAYS, JOURNAL_DIR,
+};
+use lw_core::schema::WikiSchema;
+use lw_core::WikiError;
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+use tempfile::TempDir;
+use time::macros::{date, time};
+
+/// Init a fresh wiki under `tmp` and return its root.
+fn fresh_wiki() -> TempDir {
+    let tmp = TempDir::new().expect("tempdir");
+    init_wiki(tmp.path(), &WikiSchema::default()).expect("init_wiki");
+    tmp
+}
+
+/// Initialise a git repo at `path` with sane identity config.
+fn init_repo(path: &Path) {
+    let out = Command::new("git")
+        .args(["init", "--initial-branch=main"])
+        .current_dir(path)
+        .output()
+        .expect("git init");
+    assert!(out.status.success());
+    Command::new("git")
+        .args(["config", "user.name", "Test User"])
+        .current_dir(path)
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["config", "user.email", "test@example.com"])
+        .current_dir(path)
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["config", "commit.gpgsign", "false"])
+        .current_dir(path)
+        .output()
+        .unwrap();
+}
+
+// ── Acceptance criterion 1 + 3: append + timestamp ───────────────────────────
+
+#[test]
+fn append_capture_creates_today_journal_with_timestamp_line() {
+    let tmp = fresh_wiki();
+    let d = date!(2026 - 04 - 25);
+    let t = time!(10:23);
+
+    let result = append_capture(
+        tmp.path(),
+        d,
+        t,
+        "comrak can round-trip markdown via arena AST",
+        &[],
+        None,
+    )
+    .expect("capture must succeed");
+
+    assert!(result.created, "first capture must auto-create the page");
+    let expected_path = tmp.path().join("wiki/_journal/2026-04-25.md");
+    assert_eq!(result.path, expected_path);
+    assert_eq!(result.display_path, "wiki/_journal/2026-04-25.md");
+    assert!(expected_path.exists(), "file must exist on disk");
+
+    let content = fs::read_to_string(&expected_path).unwrap();
+    assert!(
+        content.contains("- **10:23** comrak can round-trip markdown via arena AST"),
+        "capture line missing or malformed; content: {content}"
+    );
+    // Timestamp prefix is bold + zero-padded HH:MM.
+    assert!(
+        content.contains("**10:23**"),
+        "HH:MM bold prefix missing; got: {content}"
+    );
+}
+
+// ── Acceptance criterion 2: auto-created frontmatter ─────────────────────────
+
+#[test]
+fn auto_created_journal_has_required_frontmatter_fields() {
+    let tmp = fresh_wiki();
+    let d = date!(2026 - 04 - 25);
+    append_capture(tmp.path(), d, time!(09:00), "first capture", &[], None).unwrap();
+
+    let path = tmp.path().join("wiki/_journal/2026-04-25.md");
+    let content = fs::read_to_string(&path).unwrap();
+
+    // Frontmatter delimiters
+    assert!(
+        content.starts_with("---\n"),
+        "page must start with frontmatter; got: {content}"
+    );
+
+    // title: "2026-04-25"
+    assert!(
+        content.contains(r#"title: "2026-04-25""#) || content.contains("title: 2026-04-25"),
+        "frontmatter title missing/malformed: {content}"
+    );
+
+    // tags: [journal]
+    assert!(
+        content.contains("tags: [journal]") || content.contains("- journal"),
+        "frontmatter tags must include `journal`: {content}"
+    );
+
+    // created: 2026-04-25
+    assert!(
+        content.contains("created: 2026-04-25"),
+        "frontmatter must include `created: 2026-04-25`: {content}"
+    );
+
+    // The body must include the ## Captures heading so the page has structure.
+    assert!(
+        content.contains("## Captures"),
+        "auto-created page must include `## Captures` heading: {content}"
+    );
+}
+
+// ── Subsequent captures append (do NOT overwrite) ─────────────────────────────
+
+#[test]
+fn second_capture_same_day_appends_does_not_overwrite() {
+    let tmp = fresh_wiki();
+    let d = date!(2026 - 04 - 25);
+
+    let r1 = append_capture(tmp.path(), d, time!(10:23), "first thought", &[], None).unwrap();
+    assert!(r1.created);
+
+    let r2 = append_capture(tmp.path(), d, time!(10:25), "second thought", &[], None).unwrap();
+    assert!(
+        !r2.created,
+        "second capture must NOT mark file as newly created"
+    );
+
+    let content = fs::read_to_string(&r2.path).unwrap();
+    assert!(content.contains("**10:23** first thought"));
+    assert!(content.contains("**10:25** second thought"));
+    // first line must still come before second
+    let first = content.find("first thought").unwrap();
+    let second = content.find("second thought").unwrap();
+    assert!(
+        first < second,
+        "captures must remain in chronological order"
+    );
+}
+
+// ── Acceptance criterion 4: tags + source flags ──────────────────────────────
+
+#[test]
+fn capture_renders_tags_after_content() {
+    let tmp = fresh_wiki();
+    let d = date!(2026 - 04 - 25);
+    let tags = vec!["rust".to_string(), "markdown".to_string()];
+
+    let r = append_capture(
+        tmp.path(),
+        d,
+        time!(10:25),
+        "see docs.rs/comrak",
+        &tags,
+        None,
+    )
+    .unwrap();
+    let content = fs::read_to_string(&r.path).unwrap();
+    assert!(
+        content.contains("**10:25** see docs.rs/comrak `#rust` `#markdown`"),
+        "tag suffixes missing or wrong format; content: {content}"
+    );
+}
+
+#[test]
+fn capture_renders_source_link_at_end() {
+    let tmp = fresh_wiki();
+    let d = date!(2026 - 04 - 25);
+
+    let r = append_capture(
+        tmp.path(),
+        d,
+        time!(10:30),
+        "key insight",
+        &[],
+        Some("https://example.com/article"),
+    )
+    .unwrap();
+    let content = fs::read_to_string(&r.path).unwrap();
+    assert!(
+        content.contains("**10:30** key insight ([source](https://example.com/article))"),
+        "source link missing or wrong format; content: {content}"
+    );
+}
+
+#[test]
+fn capture_renders_tags_and_source_together() {
+    let tmp = fresh_wiki();
+    let d = date!(2026 - 04 - 25);
+    let tags = vec!["rust".to_string()];
+
+    let r = append_capture(
+        tmp.path(),
+        d,
+        time!(11:00),
+        "combined",
+        &tags,
+        Some("https://example.com"),
+    )
+    .unwrap();
+    let content = fs::read_to_string(&r.path).unwrap();
+    assert!(
+        content.contains("**11:00** combined `#rust` ([source](https://example.com))"),
+        "tags+source combo missing/wrong; content: {content}"
+    );
+}
+
+// ── Empty content rejected ───────────────────────────────────────────────────
+
+#[test]
+fn empty_content_returns_error() {
+    let tmp = fresh_wiki();
+    let err = append_capture(
+        tmp.path(),
+        date!(2026 - 04 - 25),
+        time!(10:00),
+        "   ",
+        &[],
+        None,
+    )
+    .expect_err("empty content must be rejected");
+    matches!(err, WikiError::Internal(_) | WikiError::Io(_));
+}
+
+// ── Multi-day routing ────────────────────────────────────────────────────────
+
+#[test]
+fn captures_on_different_days_route_to_separate_files() {
+    let tmp = fresh_wiki();
+    append_capture(
+        tmp.path(),
+        date!(2026 - 04 - 24),
+        time!(23:00),
+        "yesterday",
+        &[],
+        None,
+    )
+    .unwrap();
+    append_capture(
+        tmp.path(),
+        date!(2026 - 04 - 25),
+        time!(00:01),
+        "today",
+        &[],
+        None,
+    )
+    .unwrap();
+
+    assert!(tmp.path().join("wiki/_journal/2026-04-24.md").exists());
+    assert!(tmp.path().join("wiki/_journal/2026-04-25.md").exists());
+
+    let yesterday = fs::read_to_string(tmp.path().join("wiki/_journal/2026-04-24.md")).unwrap();
+    assert!(yesterday.contains("yesterday"));
+    assert!(!yesterday.contains("today"));
+
+    let today = fs::read_to_string(tmp.path().join("wiki/_journal/2026-04-25.md")).unwrap();
+    assert!(today.contains("today"));
+    assert!(!today.contains("yesterday"));
+}
+
+// ── Special chars / very long content survive round-trip ─────────────────────
+
+#[test]
+fn capture_with_special_chars_round_trips() {
+    let tmp = fresh_wiki();
+    let weird = r#"line with 中文, emoji 🚀, and "quotes" + (parens)"#;
+    let r = append_capture(
+        tmp.path(),
+        date!(2026 - 04 - 25),
+        time!(12:00),
+        weird,
+        &[],
+        None,
+    )
+    .unwrap();
+    let content = fs::read_to_string(&r.path).unwrap();
+    assert!(
+        content.contains(weird),
+        "special chars must survive verbatim; content: {content}"
+    );
+}
+
+#[test]
+fn capture_with_long_content_persists_full_text() {
+    let tmp = fresh_wiki();
+    let long: String = "abcde ".repeat(500);
+    let r = append_capture(
+        tmp.path(),
+        date!(2026 - 04 - 25),
+        time!(13:00),
+        &long,
+        &[],
+        None,
+    )
+    .unwrap();
+    let content = fs::read_to_string(&r.path).unwrap();
+    assert!(content.contains(long.trim()));
+}
+
+// ── Pure-formatting helpers ──────────────────────────────────────────────────
+
+#[test]
+fn format_date_iso_pads_month_and_day() {
+    assert_eq!(format_date_iso(date!(2026 - 01 - 02)), "2026-01-02");
+    assert_eq!(format_date_iso(date!(2026 - 12 - 31)), "2026-12-31");
+}
+
+#[test]
+fn format_time_hm_pads_to_two_digits() {
+    assert_eq!(format_time_hm(time!(09:05)), "09:05");
+    assert_eq!(format_time_hm(time!(23:59)), "23:59");
+    assert_eq!(format_time_hm(time!(00:00)), "00:00");
+}
+
+#[test]
+fn journal_path_for_date_lives_under_wiki_journal_dir() {
+    let p = journal_path_for_date(Path::new("/tmp/v"), date!(2026 - 04 - 25));
+    assert_eq!(p, Path::new("/tmp/v/wiki/_journal/2026-04-25.md"));
+    assert!(p.to_string_lossy().contains(JOURNAL_DIR));
+}
+
+#[test]
+fn format_capture_line_strips_leading_hash_on_tags() {
+    // Caller may pass `rust` or `#rust`; either way the rendered tag is `\`#rust\``.
+    let line = format_capture_line(
+        time!(10:00),
+        "x",
+        &["#rust".to_string(), "markdown".to_string()],
+        None,
+    );
+    assert!(
+        line.ends_with("`#rust` `#markdown`"),
+        "expected normalized tag suffix, got: {line}"
+    );
+}
+
+// ── Acceptance criterion 7: stale journal lint ───────────────────────────────
+
+#[test]
+fn find_stale_captures_returns_empty_when_journal_dir_missing() {
+    let tmp = fresh_wiki();
+    // Default schema scaffolds wiki/_journal/ but no captures yet — even
+    // without the dir, find_stale_captures must not error.
+    let v = find_stale_captures(tmp.path(), DEFAULT_STALE_AFTER_DAYS).unwrap();
+    assert!(v.is_empty());
+}
+
+#[test]
+fn find_stale_captures_flags_old_journal_pages_via_git_age() {
+    // Stand up a wiki inside a git repo, commit a journal page with an
+    // antedated commit, then assert it's flagged stale.
+    let tmp = fresh_wiki();
+    init_repo(tmp.path());
+    // Seed with the .lw scaffold so HEAD exists.
+    Command::new("git")
+        .args(["add", "."])
+        .current_dir(tmp.path())
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["commit", "-m", "seed"])
+        .current_dir(tmp.path())
+        .output()
+        .unwrap();
+
+    // Append a capture for today, then commit it with a backdated date.
+    let today = date!(2026 - 04 - 25);
+    append_capture(tmp.path(), today, time!(10:00), "old capture", &[], None).unwrap();
+    Command::new("git")
+        .args(["add", "wiki/_journal"])
+        .current_dir(tmp.path())
+        .output()
+        .unwrap();
+    // Commit with date 30 days in the past.
+    let backdate = "30 days ago";
+    let out = Command::new("git")
+        .args(["commit", "-m", "backdate"])
+        .env("GIT_AUTHOR_DATE", backdate)
+        .env("GIT_COMMITTER_DATE", backdate)
+        .current_dir(tmp.path())
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "backdated commit failed: {out:?}");
+
+    let stale = find_stale_captures(tmp.path(), 7).unwrap();
+    assert!(
+        !stale.is_empty(),
+        "30-day-old capture must be flagged when threshold=7"
+    );
+    assert!(
+        stale[0].path.contains("_journal"),
+        "stale finding path must contain _journal: {:?}",
+        stale[0].path
+    );
+    assert!(
+        stale[0].age_days >= 7,
+        "stale.age_days must be > threshold; got {}",
+        stale[0].age_days
+    );
+}
+
+#[test]
+fn find_stale_captures_skips_recent_pages() {
+    let tmp = fresh_wiki();
+    init_repo(tmp.path());
+    Command::new("git")
+        .args(["add", "."])
+        .current_dir(tmp.path())
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["commit", "-m", "seed"])
+        .current_dir(tmp.path())
+        .output()
+        .unwrap();
+
+    append_capture(
+        tmp.path(),
+        date!(2026 - 04 - 25),
+        time!(10:00),
+        "recent",
+        &[],
+        None,
+    )
+    .unwrap();
+    Command::new("git")
+        .args(["add", "wiki/_journal"])
+        .current_dir(tmp.path())
+        .output()
+        .unwrap();
+    // Commit with current time — should NOT be flagged.
+    let out = Command::new("git")
+        .args(["commit", "-m", "now"])
+        .current_dir(tmp.path())
+        .output()
+        .unwrap();
+    assert!(out.status.success());
+
+    let stale = find_stale_captures(tmp.path(), 7).unwrap();
+    assert!(
+        stale.is_empty(),
+        "fresh capture must not be flagged stale; got: {stale:?}"
+    );
+}

--- a/crates/lw-core/tests/lint_test.rs
+++ b/crates/lw-core/tests/lint_test.rs
@@ -1,6 +1,6 @@
 mod common;
 
-use common::{make_page, TestWiki};
+use common::{TestWiki, make_page};
 use lw_core::lint::run_lint;
 
 #[test]
@@ -297,10 +297,22 @@ fn lint_reports_stale_journal_entries_older_than_threshold() {
         .current_dir(root)
         .output()
         .unwrap();
+    // RFC 2822 explicit form so git accepts it regardless of natural-date support.
+    let backdate = {
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap();
+        let unix = now.as_secs() as i64 - 30 * 86400;
+        let dt = time::OffsetDateTime::from_unix_timestamp(unix).unwrap();
+        let fmt = time::macros::format_description!(
+            "[weekday repr:short], [day] [month repr:short] [year] [hour]:[minute]:[second] +0000"
+        );
+        dt.format(&fmt).unwrap()
+    };
     let out = Command::new("git")
         .args(["commit", "-m", "old"])
-        .env("GIT_AUTHOR_DATE", "30 days ago")
-        .env("GIT_COMMITTER_DATE", "30 days ago")
+        .env("GIT_AUTHOR_DATE", &backdate)
+        .env("GIT_COMMITTER_DATE", &backdate)
         .current_dir(root)
         .output()
         .unwrap();

--- a/crates/lw-core/tests/lint_test.rs
+++ b/crates/lw-core/tests/lint_test.rs
@@ -1,6 +1,6 @@
 mod common;
 
-use common::{TestWiki, make_page};
+use common::{make_page, TestWiki};
 use lw_core::lint::run_lint;
 
 #[test]
@@ -235,4 +235,91 @@ fn lint_freshness_included() {
     // Freshness info should be present (all fresh since no git history in temp dir)
     let total = report.freshness.fresh + report.freshness.suspect + report.freshness.stale;
     assert!(total > 0);
+}
+
+// ── Stale journal entries (issue #37) ────────────────────────────────────────
+
+/// `lw lint` must surface a `stale_journal_pages` field listing journal pages
+/// older than the schema's `[journal] stale_after_days` threshold.
+#[test]
+fn lint_reports_stale_journal_entries_older_than_threshold() {
+    use lw_core::journal::append_capture;
+    use std::process::Command;
+    use time::macros::{date, time};
+
+    let wiki = TestWiki::new();
+    let root = wiki.root();
+
+    // Init a real git repo so age-via-git-log works.
+    Command::new("git")
+        .args(["init", "--initial-branch=main"])
+        .current_dir(root)
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["config", "user.name", "T"])
+        .current_dir(root)
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["config", "user.email", "t@example.com"])
+        .current_dir(root)
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["config", "commit.gpgsign", "false"])
+        .current_dir(root)
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["add", "."])
+        .current_dir(root)
+        .output()
+        .unwrap();
+    Command::new("git")
+        .args(["commit", "-m", "seed"])
+        .current_dir(root)
+        .output()
+        .unwrap();
+
+    // Append a capture, then commit it with a 30-day-old date.
+    append_capture(
+        root,
+        date!(2026 - 04 - 25),
+        time!(10:00),
+        "stale capture",
+        &[],
+        None,
+    )
+    .unwrap();
+    Command::new("git")
+        .args(["add", "wiki/_journal"])
+        .current_dir(root)
+        .output()
+        .unwrap();
+    let out = Command::new("git")
+        .args(["commit", "-m", "old"])
+        .env("GIT_AUTHOR_DATE", "30 days ago")
+        .env("GIT_COMMITTER_DATE", "30 days ago")
+        .current_dir(root)
+        .output()
+        .unwrap();
+    assert!(out.status.success(), "backdated commit failed: {out:?}");
+
+    let report = run_lint(root, None).expect("lint should succeed");
+    assert!(
+        !report.stale_journal_pages.is_empty(),
+        "lint must surface stale_journal_pages list when entries are old; report: {report:?}"
+    );
+    let finding = &report.stale_journal_pages[0];
+    assert!(
+        finding.path.contains("_journal"),
+        "stale_journal_pages.path must include `_journal`: {:?}",
+        finding.path
+    );
+    assert!(
+        finding.detail.contains("days") || finding.detail.contains("stale"),
+        "stale_journal detail should mention age/stale: {:?}",
+        finding.detail
+    );
 }

--- a/crates/lw-core/tests/schema_test.rs
+++ b/crates/lw-core/tests/schema_test.rs
@@ -201,6 +201,70 @@ template = ""
     assert!(notes.required_fields.is_empty());
 }
 
+// ── Journal config (issue #37) ───────────────────────────────────────────────
+
+/// `_journal` must be in the default schema's category list so `lw init`
+/// scaffolds the directory.
+#[test]
+fn default_schema_includes_journal_category() {
+    let schema = WikiSchema::default();
+    assert!(
+        schema.tags.categories.iter().any(|c| c == "_journal"),
+        "default schema must include `_journal` in categories: {:?}",
+        schema.tags.categories
+    );
+}
+
+/// `[categories._journal]` must come pre-populated with a journal-friendly
+/// template. The template doesn't need any required_fields (those would
+/// fight the journal-as-inbox UX).
+#[test]
+fn default_schema_has_journal_category_block() {
+    let schema = WikiSchema::default();
+    let cfg = schema
+        .category_config("_journal")
+        .expect("_journal must have a [categories._journal] block in default schema");
+    assert!(
+        cfg.required_fields.is_empty(),
+        "journal must not impose required_fields (captures should be frictionless)"
+    );
+}
+
+/// Schema parses a `[journal] stale_after_days = N` block and the helper
+/// returns it.
+#[test]
+fn parse_journal_block_with_stale_after_days() {
+    let toml_str = r#"
+[wiki]
+name = "Journal Wiki"
+default_review_days = 90
+
+[tags]
+categories = ["_journal"]
+
+[journal]
+stale_after_days = 14
+"#;
+    let schema = WikiSchema::parse(toml_str).unwrap();
+    assert_eq!(
+        schema.journal_stale_after_days(),
+        14,
+        "parser must surface custom stale_after_days"
+    );
+}
+
+/// When `[journal]` is absent, `journal_stale_after_days()` returns the
+/// documented default (7).
+#[test]
+fn journal_stale_after_days_defaults_to_7() {
+    let schema = WikiSchema::default();
+    assert_eq!(
+        schema.journal_stale_after_days(),
+        7,
+        "default stale_after_days must be 7"
+    );
+}
+
 /// Edge case: CategoryConfig with empty required_fields (default).
 #[test]
 fn category_config_empty_required_fields_default() {

--- a/crates/lw-mcp/src/lib.rs
+++ b/crates/lw-mcp/src/lib.rs
@@ -786,12 +786,14 @@ impl WikiMcpServer {
                         "broken_related_count": report.broken_related.len(),
                         "orphan_count": report.orphan_pages.len(),
                         "missing_concept_count": report.missing_concepts.len(),
+                        "stale_journal_count": report.stale_journal_pages.len(),
                     },
                     "stale_pages": report.freshness.stale_pages,
                     "todo_pages": report.todo_pages,
                     "broken_related": report.broken_related,
                     "orphan_pages": report.orphan_pages,
                     "missing_concepts": report.missing_concepts,
+                    "stale_journal_pages": report.stale_journal_pages,
                 })
                 .to_string()
             }
@@ -880,8 +882,50 @@ impl WikiMcpServer {
         name = "wiki_capture",
         description = "Append a timestamped capture entry (HH:MM prefix) to the day's journal page at wiki/_journal/YYYY-MM-DD.md. Auto-creates the page with frontmatter (title, tags: [journal], created: YYYY-MM-DD) if not yet present. Use this for low-friction quick capture; promote captures to permanent pages later via wiki_new/wiki_write."
     )]
-    fn wiki_capture(&self, Parameters(_args): Parameters<WikiCaptureArgs>) -> String {
-        unimplemented!("wiki_capture not yet implemented (#37)")
+    fn wiki_capture(&self, Parameters(args): Parameters<WikiCaptureArgs>) -> String {
+        let now = lw_core::journal::local_now();
+        let date = now.date();
+        let time = now.time();
+
+        let outcome = match lw_core::journal::append_capture(
+            &self.wiki_root,
+            date,
+            time,
+            &args.content,
+            &args.tags,
+            args.source.as_deref(),
+        ) {
+            Ok(o) => o,
+            Err(e) => return serde_json::json!({"error": e.to_string()}).to_string(),
+        };
+
+        // Hand the absolute page path to mcp_auto_commit so it can
+        // re-resolve against the actual git toplevel — wiki_root is
+        // allowed to be a subdir of a larger repo.
+        let dirty_warning = match mcp_auto_commit(
+            &self.wiki_root,
+            std::slice::from_ref(&outcome.path),
+            CommitAction::Capture,
+            &outcome.display_path,
+            McpCommitArgs {
+                commit: args.commit,
+                push: args.push,
+                author: args.author.as_deref(),
+                source: args.source.as_deref(),
+            },
+        ) {
+            McpCommitResult::Err(err) => return err,
+            McpCommitResult::Ok { dirty_warning } => dirty_warning,
+        };
+
+        let mut response = serde_json::json!({
+            "status": "ok",
+            "path": outcome.display_path,
+            "created": outcome.created,
+            "line": outcome.line,
+        });
+        attach_warnings(&mut response, dirty_warning);
+        response.to_string()
     }
 
     /// Get wiki health statistics: page count, category breakdown, freshness distribution.
@@ -936,8 +980,9 @@ impl ServerHandler for WikiMcpServer {
             .with_instructions(
                 "LLM Wiki knowledge base server. Use wiki_query to search, wiki_read to read pages, \
                  wiki_browse to list pages, wiki_tags to list tags, wiki_new to scaffold a new page, \
-                 wiki_write to create/update pages, wiki_ingest to import source material, \
-                 wiki_lint to check freshness, and wiki_stats to get wiki health statistics."
+                 wiki_write to create/update pages, wiki_capture to append a timestamped quick-capture \
+                 entry to today's journal, wiki_ingest to import source material, wiki_lint to check \
+                 freshness, and wiki_stats to get wiki health statistics."
             )
     }
 }

--- a/crates/lw-mcp/src/lib.rs
+++ b/crates/lw-mcp/src/lib.rs
@@ -253,6 +253,27 @@ pub struct WikiLintArgs {
 }
 
 #[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct WikiCaptureArgs {
+    /// Capture text. Required, must be non-empty after trimming.
+    pub content: String,
+    /// Tags to render as `\`#tag\`` suffixes after the content.
+    #[serde(default)]
+    pub tags: Vec<String>,
+    /// Optional source URL/identifier rendered as `([source](URL))`.
+    #[serde(default)]
+    pub source: Option<String>,
+    /// Auto-commit the journal page after writing (default: true).
+    #[serde(default)]
+    pub commit: Option<bool>,
+    /// Push after commit (default: false). Requires `commit` to be true.
+    #[serde(default)]
+    pub push: Option<bool>,
+    /// Override commit author as `"Name <email>"`.
+    #[serde(default)]
+    pub author: Option<String>,
+}
+
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
 pub struct WikiNewArgs {
     /// Target category (must match a category in the schema, e.g. "tools")
     pub category: String,
@@ -852,6 +873,15 @@ impl WikiMcpServer {
             }
             Err(e) => serde_json::json!({"error": e.to_string()}).to_string(),
         }
+    }
+
+    /// Append a timestamped capture entry to today's journal page.
+    #[tool(
+        name = "wiki_capture",
+        description = "Append a timestamped capture entry (HH:MM prefix) to the day's journal page at wiki/_journal/YYYY-MM-DD.md. Auto-creates the page with frontmatter (title, tags: [journal], created: YYYY-MM-DD) if not yet present. Use this for low-friction quick capture; promote captures to permanent pages later via wiki_new/wiki_write."
+    )]
+    fn wiki_capture(&self, Parameters(_args): Parameters<WikiCaptureArgs>) -> String {
+        unimplemented!("wiki_capture not yet implemented (#37)")
     }
 
     /// Get wiki health statistics: page count, category breakdown, freshness distribution.
@@ -1533,6 +1563,116 @@ mod tests {
         assert!(
             body_str.contains("generator: lw v"),
             "commit body must contain 'generator: lw v…'; got: {body_str}"
+        );
+    }
+
+    // ── wiki_capture tests (issue #37) ───────────────────────────────────────
+
+    fn capture_args(content: &str, tags: Vec<&str>, source: Option<&str>) -> WikiCaptureArgs {
+        WikiCaptureArgs {
+            content: content.to_string(),
+            tags: tags.into_iter().map(String::from).collect(),
+            source: source.map(String::from),
+            commit: Some(false),
+            push: None,
+            author: None,
+        }
+    }
+
+    fn today_iso_string() -> String {
+        use lw_core::journal::{format_date_iso, local_now};
+        format_date_iso(local_now().date())
+    }
+
+    #[test]
+    fn wiki_capture_appends_to_today_journal_returns_path() {
+        let (tmp, server) = spawn_server();
+        let args = capture_args("MCP-pasted thought", vec![], None);
+
+        let resp = server.wiki_capture(Parameters(args));
+        let v = parse(&resp);
+        assert!(v.get("error").is_none(), "unexpected error: {resp}");
+
+        // Returned vault-relative path must point at today's journal page.
+        let expected = format!("wiki/_journal/{}.md", today_iso_string());
+        assert_eq!(
+            v["path"].as_str(),
+            Some(expected.as_str()),
+            "path must be vault-relative: {resp}"
+        );
+        assert!(
+            v["created"].as_bool().unwrap_or(false),
+            "first capture must report `created: true`: {resp}"
+        );
+
+        // File must exist on disk and contain the captured text.
+        let path = tmp
+            .path()
+            .join("wiki/_journal")
+            .join(format!("{}.md", today_iso_string()));
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert!(content.contains("MCP-pasted thought"));
+    }
+
+    #[test]
+    fn wiki_capture_renders_tags_and_source() {
+        let (tmp, server) = spawn_server();
+
+        let args = capture_args(
+            "with both",
+            vec!["rust", "markdown"],
+            Some("https://example.com"),
+        );
+        let resp = server.wiki_capture(Parameters(args));
+        let v = parse(&resp);
+        assert!(v.get("error").is_none(), "unexpected error: {resp}");
+
+        let path = tmp
+            .path()
+            .join("wiki/_journal")
+            .join(format!("{}.md", today_iso_string()));
+        let content = std::fs::read_to_string(&path).unwrap();
+        assert!(
+            content.contains("with both `#rust` `#markdown` ([source](https://example.com))"),
+            "MCP capture must format tags + source same as CLI; got:\n{content}"
+        );
+    }
+
+    #[test]
+    fn wiki_capture_empty_content_returns_error() {
+        let (_tmp, server) = spawn_server();
+        let args = capture_args("   ", vec![], None);
+        let resp = server.wiki_capture(Parameters(args));
+        let v = parse(&resp);
+        assert!(v.get("error").is_some(), "expected error JSON: {resp}");
+    }
+
+    #[tokio::test]
+    async fn wiki_capture_inside_git_repo_auto_commits() {
+        let (tmp, server) = spawn_server_in_git();
+        let before = commit_count(tmp.path());
+
+        let args = WikiCaptureArgs {
+            content: "auto-committed mcp capture".to_string(),
+            tags: vec![],
+            source: None,
+            commit: None, // default → true
+            push: None,
+            author: None,
+        };
+        let resp = server.wiki_capture(Parameters(args));
+        let v = parse(&resp);
+        assert!(v.get("error").is_none(), "unexpected error: {resp}");
+
+        assert_eq!(
+            commit_count(tmp.path()),
+            before + 1,
+            "wiki_capture must auto-commit by default"
+        );
+        let subj = head_subject(tmp.path());
+        assert!(
+            subj.starts_with("docs(wiki): capture"),
+            "subject must be 'docs(wiki): capture <slug>'; got: {subj}"
         );
     }
 }


### PR DESCRIPTION
## Summary
- Implements #37 — `lw capture "..."` appends timestamped entries to `wiki/_journal/YYYY-MM-DD.md`
- New: `wiki_capture` MCP tool
- Schema default: `_journal` category + `[journal] stale_after_days` block
- New lint check: stale journal entries (default threshold 7 days, configurable via `[journal] stale_after_days = N`)

## Acceptance Criteria Evidence

- [x] **AC1: `lw capture "text"` appends to today's journal**
  Evidence: `crates/lw-cli/tests/capture_test.rs::appends_to_today_journal` (line 91-114)
  Asserts `wiki/_journal/<today>.md` contains the captured text after invoking `lw capture` via `assert_cmd`. Also `crates/lw-core/tests/journal_test.rs::append_capture_creates_today_journal_with_timestamp_line` (line 75-106).

- [x] **AC2: Journal page auto-created with frontmatter (`title`, `tags: [journal]`, `created: YYYY-MM-DD`)**
  Evidence: `crates/lw-core/tests/journal_test.rs::auto_created_journal_has_required_frontmatter_fields` (line 110-148). Asserts the auto-created page contains `---\n`, `title:`, `tags: [journal]` (or `- journal`), `created: <today>`, and `## Captures` heading.
  Also: `crates/lw-cli/tests/capture_test.rs::auto_creates_frontmatter` (line 121-148).

- [x] **AC3: Timestamp prefix HH:MM 24h, local timezone**
  Evidence: `crates/lw-core/tests/journal_test.rs::format_time_hm_pads_to_two_digits` (line 261-265). And the live test `crates/lw-cli/tests/capture_test.rs::appends_to_today_journal` (line 110-113) uses regex `\*\*\d{2}:\d{2}\*\*` to assert the bold-zero-padded prefix shape. Local tz comes from `journal::local_now()` (`OffsetDateTime::now_utc().to_offset(UtcOffset::current_local_offset())`).

- [x] **AC4: `--tag <tag>` (repeatable) and `--source <url>` flags**
  Evidence:
    - `crates/lw-cli/tests/capture_test.rs::tag_flag_renders` (line 152-178) — passes `--tag rust --tag markdown`, asserts `with tags \`#rust\` \`#markdown\`` appears in the file.
    - `crates/lw-cli/tests/capture_test.rs::source_flag_renders` (line 181-201) — asserts `with source ([source](https://example.com/article))`.
    - Combined: `crates/lw-core/tests/journal_test.rs::capture_renders_tags_and_source_together` (line 224-244).

- [x] **AC5: `wiki_capture` MCP tool with `content`, `tags`, `source` args**
  Evidence: `crates/lw-mcp/src/lib.rs::tests::wiki_capture_appends_to_today_journal_returns_path` (line 1547-1577) verifies vault-relative path + `created: true` field. Auto-commit covered by `wiki_capture_inside_git_repo_auto_commits` (line 1623-1647).

- [x] **AC6: `_journal/` category in schema defaults (so `lw init` scaffolds it)**
  Evidence:
    - `crates/lw-core/tests/schema_test.rs::default_schema_includes_journal_category` (line 230-237)
    - `crates/lw-core/tests/schema_test.rs::default_schema_has_journal_category_block` (line 240-251)
    - End-to-end via CLI: `crates/lw-cli/tests/capture_test.rs::init_creates_journal_dir` (line 81-92).

- [x] **AC7: `lw lint` reports unprocessed journal entries older than configurable threshold**
  Evidence: `crates/lw-core/tests/lint_test.rs::lint_reports_stale_journal_entries_older_than_threshold` (line 244-340).
  Uses an RFC-2822 backdated `GIT_AUTHOR_DATE`/`GIT_COMMITTER_DATE` (30 days ago) on a journal-page commit, then asserts `report.stale_journal_pages` is non-empty and the finding's `path` contains `_journal` and the detail mentions `days`/`stale`.
  **Threshold configurable**: `[journal] stale_after_days = N` schema block. Default = 7 days (`journal::DEFAULT_STALE_AFTER_DAYS`). Schema default + parse paths are tested in `crates/lw-core/tests/schema_test.rs::parse_journal_block_with_stale_after_days` and `journal_stale_after_days_defaults_to_7`. **Choice rationale**: schema-driven config matches the existing pattern (`[categories.<name>]`) and avoids adding a CLI flag that would have to be re-asserted on every `lw lint` invocation.

## Test Plan
- [x] core/cli/mcp tests added (TDD: RED commit `8d8e8cc` → GREEN commit `a77164d`)
- [x] cargo test green (416 passed across 32 suites)
- [x] cargo clippy --all-targets -- -D warnings clean
- [x] cargo fmt --check clean
- [x] local smoke (isolated to `/tmp` via `--root`):
  - `lw capture "test thought one"` → journal page created, auto-commit `docs(wiki): capture wiki/_journal/<DATE>.md`
  - `lw capture --tag rust --tag markdown "with tags"` → renders `\`#rust\` \`#markdown\``
  - `lw capture --source "https://example.com" "with source"` → renders `([source](https://example.com))` and adds `source: …` to commit body
  - `lw lint` after a 30-day-backdated commit → "Unprocessed Journal Captures (1)" with `age=30d, threshold=7d`
- [ ] CI passes

## Out-of-scope notes
- The auto-created journal page is currently flagged as an orphan by the existing orphan-pages check (no other page references it). Out of scope for #37; could be addressed by exempting `_journal/*.md` from the orphan check in a follow-up.
- Sub-minute precision is not preserved in the timestamp prefix (HH:MM only, by design — matches the spec example).

🤖 Generated with [Claude Code](https://claude.com/claude-code)