### PR TITLE
feat(core,cli,mcp): backlink index + wiki_backlinks tool (closes #39)

### DIFF
--- a/crates/lw-cli/src/backlinks.rs
+++ b/crates/lw-cli/src/backlinks.rs
@@ -1,0 +1,102 @@
+//! `lw backlinks <slug-or-path>` — show inbound links for a page.
+
+use crate::output::Format;
+use anyhow::Result;
+use lw_core::backlinks;
+use std::path::Path;
+
+pub fn run(root: &Path, target: &str, format: &Format) -> Result<()> {
+    // Normalise the input to a slug: strip "wiki/" prefix, category, ".md".
+    let raw = target.trim_start_matches("wiki/");
+    let slug = Path::new(raw)
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or(raw)
+        .to_string();
+
+    // Ensure the index exists (lazy build on first call).
+    backlinks::ensure_index(root)?;
+
+    // Verify that the target page actually exists.
+    let wiki_dir = root.join("wiki");
+    let target_exists = if wiki_dir.exists() {
+        std::fs::read_dir(&wiki_dir)
+            .ok()
+            .map(|entries| {
+                entries
+                    .flatten()
+                    .filter(|e| e.file_type().is_ok_and(|t| t.is_dir()))
+                    .any(|cat| cat.path().join(format!("{slug}.md")).exists())
+            })
+            .unwrap_or(false)
+    } else {
+        false
+    };
+
+    if !target_exists {
+        eprintln!("no backlinks or page not found: {slug}");
+        std::process::exit(2);
+    }
+
+    let record = backlinks::query(root, &slug)?;
+
+    match format {
+        Format::Json => {
+            let sources = record.as_ref().map(|r| r.sources.as_slice()).unwrap_or(&[]);
+            let entries: Vec<serde_json::Value> = sources
+                .iter()
+                .map(|s| {
+                    serde_json::json!({
+                        "source": s.path,
+                        "kind": serde_json::to_value(&s.kind).unwrap_or_default(),
+                        "context": s.context,
+                    })
+                })
+                .collect();
+            println!(
+                "{}",
+                serde_json::json!({
+                    "target": slug,
+                    "backlinks": entries,
+                })
+            );
+        }
+        _ => match record {
+            None => {
+                eprintln!("no backlinks or page not found: {slug}");
+                std::process::exit(2);
+            }
+            Some(rec) if rec.sources.is_empty() => {
+                eprintln!("no backlinks or page not found: {slug}");
+                std::process::exit(2);
+            }
+            Some(rec) => {
+                println!("Backlinks for: {slug}");
+                println!();
+                for src in &rec.sources {
+                    let kind = match src.kind {
+                        lw_core::backlinks::BacklinkKind::Wikilink => "wikilink",
+                        lw_core::backlinks::BacklinkKind::Related => "related",
+                    };
+                    print!("  {} [{}]", src.path, kind);
+                    if let Some(ref ctx) = src.context {
+                        println!();
+                        println!("    {ctx}");
+                    } else {
+                        println!();
+                    }
+                }
+            }
+        },
+    }
+
+    Ok(())
+}
+
+/// Wire `update_for_page` after a successful CLI write, so the backlink index
+/// stays up to date when the CLI modifies a page directly.
+pub fn update_after_write(root: &Path, rel_path: &Path) {
+    if let Err(e) = backlinks::update_for_page(root, rel_path) {
+        tracing::warn!("backlink update failed for {}: {e}", rel_path.display());
+    }
+}

--- a/crates/lw-cli/src/main.rs
+++ b/crates/lw-cli/src/main.rs
@@ -1,3 +1,4 @@
+mod backlinks;
 mod capture;
 mod config;
 mod doctor;
@@ -212,6 +213,19 @@ enum Commands {
         /// Optional `source:` line recorded in the commit body
         #[arg(long)]
         source: Option<String>,
+    },
+
+    /// Show all pages that link to a given wiki page (inbound backlinks)
+    #[command(
+        after_help = "Examples:\n  lw backlinks bar\n  lw backlinks tools/bar.md\n  lw backlinks wiki/tools/bar.md\n  lw backlinks bar --format json"
+    )]
+    Backlinks {
+        /// Target page: bare slug (e.g. \"bar\"), category-relative path
+        /// (\"tools/bar.md\"), or vault-relative path (\"wiki/tools/bar.md\")
+        target: String,
+        /// Output format (human or json)
+        #[arg(short = 'o', long, default_value = "human")]
+        format: Format,
     },
 
     /// Write or update a wiki page (overwrite, append to section, or upsert section)
@@ -551,6 +565,13 @@ fn main() {
                     source,
                 },
             ),
+            Err(e) => {
+                eprintln!("Error: {e}");
+                process::exit(1);
+            }
+        },
+        Commands::Backlinks { target, format } => match resolve_root(cli.root) {
+            Ok(root) => backlinks::run(&root, &target, &format),
             Err(e) => {
                 eprintln!("Error: {e}");
                 process::exit(1);

--- a/crates/lw-cli/src/new.rs
+++ b/crates/lw-cli/src/new.rs
@@ -1,3 +1,4 @@
+use crate::backlinks::update_after_write;
 use crate::git_commit::{AutoCommitFlags, run_auto_commit};
 use crate::output::Format;
 use lw_core::fs::{NewPageRequest, load_schema, new_page};
@@ -67,6 +68,11 @@ pub fn run(
     };
 
     let (abs_path, _page) = new_page(root, &schema, req)?;
+
+    // Update the backlink index for the new page (issue #39).
+    if let Ok(rel) = abs_path.strip_prefix(root.join("wiki")) {
+        update_after_write(root, rel);
+    }
 
     // Compute a wiki-relative display path: strip the wiki_root prefix
     let display_path = abs_path

--- a/crates/lw-cli/src/write.rs
+++ b/crates/lw-cli/src/write.rs
@@ -1,3 +1,4 @@
+use crate::backlinks::update_after_write;
 use crate::git_commit::{AutoCommitFlags, run_auto_commit};
 use lw_core::fs::{atomic_write, validate_wiki_path, write_page};
 use lw_core::git::CommitAction;
@@ -94,6 +95,11 @@ pub fn run(
     // Auto-commit only when something actually hit disk. An empty append
     // is a no-op for both the file and git.
     if wrote_anything {
+        // Update the backlink index for the modified page (issue #39).
+        if let Ok(rel) = abs_path.strip_prefix(root.join("wiki")) {
+            update_after_write(root, rel);
+        }
+
         // Display path stays wiki-relative for the commit subject; the
         // path handed to `commit_paths` is *absolute* so it works when
         // the wiki root is a subdir of a larger git repo (issue #38).

--- a/crates/lw-cli/tests/backlinks_test.rs
+++ b/crates/lw-cli/tests/backlinks_test.rs
@@ -1,0 +1,132 @@
+//! CLI surface for `lw backlinks`. Exercises happy path, missing page, JSON
+//! format, and slug-vs-path argument acceptance.
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use tempfile::TempDir;
+
+fn lw() -> Command {
+    Command::cargo_bin("lw").unwrap()
+}
+
+/// Set up a minimal wiki with a `tools` category, then create a target page
+/// (`tools/bar.md`) and a source page (`tools/foo.md`) that wikilinks to it.
+fn setup_with_link() -> TempDir {
+    let tmp = TempDir::new().unwrap();
+    let root = tmp.path();
+
+    lw().args(["init", "--root", root.to_str().unwrap()])
+        .assert()
+        .success();
+
+    // Schema: minimal `tools` block (no required_fields so we can easily author).
+    let schema_toml = "[wiki]\nname = \"Test Wiki\"\ndefault_review_days = 90\n\n[tags]\ncategories = [\"architecture\", \"training\", \"infra\", \"tools\", \"product\", \"ops\"]\n\n[categories.tools]\ntemplate = \"\"\n";
+    std::fs::write(root.join(".lw/schema.toml"), schema_toml).unwrap();
+
+    std::fs::create_dir_all(root.join("wiki/tools")).unwrap();
+    // Target page
+    std::fs::write(
+        root.join("wiki/tools/bar.md"),
+        "---\ntitle: Bar\ntags: [tools]\n---\n\nbar body\n",
+    )
+    .unwrap();
+    // Source page wikilinks to bar
+    std::fs::write(
+        root.join("wiki/tools/foo.md"),
+        "---\ntitle: Foo\ntags: [tools]\n---\n\nSee [[bar]] for details.\n",
+    )
+    .unwrap();
+
+    tmp
+}
+
+#[test]
+fn backlinks_happy_path_lists_inbound_links() {
+    let tmp = setup_with_link();
+    let root = tmp.path();
+
+    lw().args(["backlinks", "bar", "--root", root.to_str().unwrap()])
+        .assert()
+        .success()
+        // Human format names the source page so a user can jump to it.
+        .stdout(predicate::str::contains("tools/foo.md"));
+}
+
+#[test]
+fn backlinks_accepts_full_path_arg() {
+    let tmp = setup_with_link();
+    let root = tmp.path();
+
+    // Same call but using the wiki-relative path form.
+    lw().args([
+        "backlinks",
+        "tools/bar.md",
+        "--root",
+        root.to_str().unwrap(),
+    ])
+    .assert()
+    .success()
+    .stdout(predicate::str::contains("tools/foo.md"));
+}
+
+#[test]
+fn backlinks_format_json_emits_structured_payload() {
+    let tmp = setup_with_link();
+    let root = tmp.path();
+
+    let output = lw()
+        .args([
+            "backlinks",
+            "bar",
+            "--format",
+            "json",
+            "--root",
+            root.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "expected success; stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let json: serde_json::Value = serde_json::from_str(&stdout).expect("stdout must be valid JSON");
+
+    let backlinks = json["backlinks"]
+        .as_array()
+        .expect("backlinks array required");
+    assert_eq!(backlinks.len(), 1, "one inbound link: {json}");
+    assert_eq!(
+        backlinks[0]["source"].as_str(),
+        Some("wiki/tools/foo.md"),
+        "source path must use wiki/ prefix: {json}"
+    );
+}
+
+#[test]
+fn backlinks_missing_page_exits_with_error() {
+    let tmp = setup_with_link();
+    let root = tmp.path();
+
+    lw().args([
+        "backlinks",
+        "definitely-not-a-page",
+        "--root",
+        root.to_str().unwrap(),
+    ])
+    .assert()
+    .failure()
+    .code(2)
+    .stderr(predicate::str::contains("no backlinks").or(predicate::str::contains("not found")));
+}
+
+#[test]
+fn backlinks_help_shows_examples() {
+    lw().args(["backlinks", "--help"])
+        .assert()
+        .success()
+        .stdout(predicate::str::is_match("(?i)examples").unwrap());
+}

--- a/crates/lw-core/src/backlinks.rs
+++ b/crates/lw-core/src/backlinks.rs
@@ -1,0 +1,430 @@
+//! Backlink index — answers "what links to this page?"
+//!
+//! Sidecar JSON files at `.lw/backlinks/<target-slug>.json`. Built incrementally
+//! on every successful page write; rebuilt on demand by walking the `wiki/` tree.
+//!
+//! A backlink source is one of:
+//! - a `[[wikilink]]` (with optional `|display`) anywhere in another page's body
+//! - an entry in another page's frontmatter `related:` list
+//!
+//! Bare slug mentions (no `[[…]]` brackets) are intentionally OUT OF SCOPE — see
+//! issue #42.
+
+use crate::Result;
+use crate::fs::{atomic_write, read_page};
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::sync::LazyLock;
+
+static WIKILINK_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"\[\[([^\]]+)\]\]").expect("WIKILINK_RE is a valid regex"));
+
+/// How a source page references a target.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum BacklinkKind {
+    /// `[[target-slug]]` (or `[[target-slug|display]]`) in body.
+    Wikilink,
+    /// Frontmatter `related:` entry pointing at the target page.
+    Related,
+}
+
+/// One inbound reference to a target page.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct BacklinkSource {
+    pub path: String,
+    pub kind: BacklinkKind,
+    pub context: Option<String>,
+}
+
+/// All inbound references to a single target page.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct BacklinkRecord {
+    pub target: String,
+    pub sources: Vec<BacklinkSource>,
+}
+
+/// Relative path (from wiki root) to the backlink-sidecar directory.
+pub const BACKLINKS_DIR: &str = ".lw/backlinks";
+
+/// Extract all `(slug, line)` pairs for every `[[wikilink]]` in `body`.
+/// Each tuple contains the resolved slug (pre-pipe portion) and the full line
+/// containing the link. Wikilinks inside code fences are included intentionally
+/// (Obsidian convention; documented in issue #39).
+pub fn extract_link_lines(body: &str) -> Vec<(String, String)> {
+    let mut results = Vec::new();
+    for line in body.lines() {
+        for cap in WIKILINK_RE.captures_iter(line) {
+            let raw = cap[1].trim();
+            let slug = match raw.split_once('|') {
+                Some((s, _)) => s.trim().to_string(),
+                None => raw.to_string(),
+            };
+            if !slug.is_empty() {
+                results.push((slug, line.to_string()));
+            }
+        }
+    }
+    results
+}
+
+/// Build a context snippet centred on the first occurrence of `[[slug` in `line`.
+/// For short lines the full line is returned. For longer lines, a ~80-character
+/// window around the match is extracted and ellipsis added where truncated.
+pub fn snippet_for(line: &str, slug: &str) -> String {
+    if line.is_empty() {
+        return String::new();
+    }
+    let needle = format!("[[{slug}");
+    let Some(pos) = line.find(&needle) else {
+        return line.to_string();
+    };
+
+    const RADIUS: usize = 80;
+    if line.len() <= RADIUS * 2 {
+        return line.to_string();
+    }
+
+    let start = pos.saturating_sub(RADIUS / 2);
+    let end = (pos + needle.len() + RADIUS / 2).min(line.len());
+
+    // Clamp to valid char boundaries
+    let char_start = line
+        .char_indices()
+        .map(|(i, _)| i)
+        .rfind(|&i| i <= start)
+        .unwrap_or(0);
+    let char_end = line
+        .char_indices()
+        .map(|(i, _)| i)
+        .find(|&i| i >= end)
+        .unwrap_or(line.len());
+
+    let mut snip = line[char_start..char_end].to_string();
+    if char_start > 0 {
+        snip = format!("…{snip}");
+    }
+    if char_end < line.len() {
+        snip = format!("{snip}…");
+    }
+    snip
+}
+
+/// Derive the slug from a path relative to wiki/ (e.g. `"architecture/foo.md"` → `"foo"`).
+/// Returns `None` for empty paths or paths without a file stem.
+pub fn slug_from_wiki_path(rel_path: &Path) -> Option<String> {
+    let stem = rel_path.file_stem()?;
+    let s = stem.to_str()?;
+    if s.is_empty() {
+        None
+    } else {
+        Some(s.to_string())
+    }
+}
+
+/// Walk the `wiki/` subtree and build the full in-memory backlink map.
+/// Returns `BTreeMap<target_slug, Vec<BacklinkSource>>`.
+pub fn build_index(wiki_root: &Path) -> Result<BTreeMap<String, Vec<BacklinkSource>>> {
+    let wiki_dir = wiki_root.join("wiki");
+    let mut map: BTreeMap<String, Vec<BacklinkSource>> = BTreeMap::new();
+
+    if !wiki_dir.exists() {
+        return Ok(map);
+    }
+
+    for entry in walkdir(&wiki_dir)? {
+        let abs_path = entry;
+        let rel = abs_path
+            .strip_prefix(&wiki_dir)
+            .map_err(|e| crate::WikiError::Io(std::io::Error::other(e.to_string())))?;
+
+        if rel.extension().and_then(|e| e.to_str()) != Some("md") {
+            continue;
+        }
+
+        // Path stored in BacklinkSource uses "wiki/" prefix per spec.
+        let source_path = format!("wiki/{}", rel.to_string_lossy().replace('\\', "/"));
+
+        let page = match read_page(&abs_path) {
+            Ok(p) => p,
+            Err(_) => continue,
+        };
+
+        // Body wikilinks
+        let pairs = extract_link_lines(&page.body);
+        for (slug, line) in pairs {
+            let ctx = snippet_for(&line, &slug);
+            map.entry(slug).or_default().push(BacklinkSource {
+                path: source_path.clone(),
+                kind: BacklinkKind::Wikilink,
+                context: Some(ctx),
+            });
+        }
+
+        // Frontmatter related: list — extract slug from path like "tools/bar.md"
+        if let Some(related) = &page.related {
+            for rel_entry in related {
+                let slug = Path::new(rel_entry)
+                    .file_stem()
+                    .and_then(|s| s.to_str())
+                    .map(String::from);
+                if let Some(slug) = slug {
+                    map.entry(slug).or_default().push(BacklinkSource {
+                        path: source_path.clone(),
+                        kind: BacklinkKind::Related,
+                        context: None,
+                    });
+                }
+            }
+        }
+    }
+
+    Ok(map)
+}
+
+/// Persist a `BTreeMap<target_slug, sources>` as individual sidecar JSON files.
+/// Files for slugs with no sources are not written (callers remove them explicitly).
+pub fn write_index(wiki_root: &Path, map: &BTreeMap<String, Vec<BacklinkSource>>) -> Result<()> {
+    let dir = wiki_root.join(BACKLINKS_DIR);
+    std::fs::create_dir_all(&dir)
+        .map_err(|e| crate::WikiError::Io(std::io::Error::other(e.to_string())))?;
+
+    for (target, sources) in map {
+        if sources.is_empty() {
+            continue;
+        }
+        let record = BacklinkRecord {
+            target: target.clone(),
+            sources: sources.clone(),
+        };
+        let json = serde_json::to_vec_pretty(&record)
+            .map_err(|e| crate::WikiError::Io(std::io::Error::other(e.to_string())))?;
+        let path = dir.join(format!("{target}.json"));
+        atomic_write(&path, &json)?;
+    }
+    Ok(())
+}
+
+/// Rebuild the full backlink index from scratch: walk wiki/, build map, persist sidecars.
+pub fn rebuild_index(wiki_root: &Path) -> Result<()> {
+    let map = build_index(wiki_root)?;
+    write_index(wiki_root, &map)
+}
+
+/// Ensure the backlink index directory exists and contains at least one file.
+/// If the directory is absent or empty, runs a full `rebuild_index`.
+pub fn ensure_index(wiki_root: &Path) -> Result<()> {
+    let dir = wiki_root.join(BACKLINKS_DIR);
+    let needs_build = if dir.exists() {
+        // Consider empty dir as needing a build
+        std::fs::read_dir(&dir)
+            .map(|mut d| d.next().is_none())
+            .unwrap_or(true)
+    } else {
+        true
+    };
+    if needs_build {
+        rebuild_index(wiki_root)?;
+    }
+    Ok(())
+}
+
+/// Incrementally update sidecar files for the targets referenced by `source_rel`
+/// (a path relative to `wiki_root/wiki/`).
+///
+/// Algorithm:
+/// 1. Read the new content of `source_rel` to obtain its current outbound links.
+/// 2. For every target whose sidecar may be affected by this source, reload the
+///    sidecar, remove the old source entry, and either write the updated sidecar
+///    or delete the file if no sources remain.
+pub fn update_for_page(wiki_root: &Path, source_rel: &Path) -> Result<()> {
+    let abs_path = wiki_root.join("wiki").join(source_rel);
+    let source_path_str = format!("wiki/{}", source_rel.to_string_lossy().replace('\\', "/"));
+
+    // Collect the new outbound link slugs from this source
+    let new_slugs: Vec<String> = if abs_path.exists() {
+        let page = match read_page(&abs_path) {
+            Ok(p) => p,
+            Err(_) => return Ok(()),
+        };
+        let mut slugs: Vec<String> = extract_link_lines(&page.body)
+            .into_iter()
+            .map(|(slug, _)| slug)
+            .collect();
+        // Also add related: slugs
+        if let Some(related) = &page.related {
+            for r in related {
+                if let Some(slug) = Path::new(r)
+                    .file_stem()
+                    .and_then(|s| s.to_str())
+                    .map(String::from)
+                {
+                    slugs.push(slug);
+                }
+            }
+        }
+        slugs
+    } else {
+        Vec::new()
+    };
+
+    let backlinks_dir = wiki_root.join(BACKLINKS_DIR);
+
+    // Gather all slugs that previously had this source (by scanning existing sidecars).
+    let old_slugs: Vec<String> = if backlinks_dir.exists() {
+        let mut v = Vec::new();
+        for entry in std::fs::read_dir(&backlinks_dir)
+            .map_err(|e| crate::WikiError::Io(std::io::Error::other(e.to_string())))?
+        {
+            let entry =
+                entry.map_err(|e| crate::WikiError::Io(std::io::Error::other(e.to_string())))?;
+            let path = entry.path();
+            if path.extension().and_then(|e| e.to_str()) == Some("json") {
+                let raw = std::fs::read_to_string(&path)
+                    .map_err(|e| crate::WikiError::Io(std::io::Error::other(e.to_string())))?;
+                if let Ok(record) = serde_json::from_str::<BacklinkRecord>(&raw)
+                    && record.sources.iter().any(|s| s.path == source_path_str)
+                {
+                    v.push(record.target);
+                }
+            }
+        }
+        v
+    } else {
+        Vec::new()
+    };
+
+    // Union of old and new slugs — sidecars that need updating
+    let mut all_slugs: Vec<String> = old_slugs;
+    for slug in &new_slugs {
+        if !all_slugs.contains(slug) {
+            all_slugs.push(slug.clone());
+        }
+    }
+
+    std::fs::create_dir_all(&backlinks_dir)
+        .map_err(|e| crate::WikiError::Io(std::io::Error::other(e.to_string())))?;
+
+    // Re-read current page for snippet generation
+    let page = if abs_path.exists() {
+        read_page(&abs_path).ok()
+    } else {
+        None
+    };
+
+    for slug in all_slugs {
+        let sidecar = sidecar_path(wiki_root, &slug);
+
+        // Load existing record (if any) and strip old entries from this source
+        let mut existing_sources: Vec<BacklinkSource> = if sidecar.exists() {
+            let raw = std::fs::read_to_string(&sidecar)
+                .map_err(|e| crate::WikiError::Io(std::io::Error::other(e.to_string())))?;
+            serde_json::from_str::<BacklinkRecord>(&raw)
+                .map(|r| r.sources)
+                .unwrap_or_default()
+        } else {
+            Vec::new()
+        };
+        existing_sources.retain(|s| s.path != source_path_str);
+
+        // Add new entries if this slug is still referenced
+        if new_slugs.contains(&slug)
+            && let Some(ref p) = page
+        {
+            // Wikilink entries
+            for (link_slug, line) in extract_link_lines(&p.body) {
+                if link_slug == slug {
+                    let ctx = snippet_for(&line, &slug);
+                    existing_sources.push(BacklinkSource {
+                        path: source_path_str.clone(),
+                        kind: BacklinkKind::Wikilink,
+                        context: Some(ctx),
+                    });
+                }
+            }
+            // Related: entries
+            if let Some(related) = &p.related {
+                for r in related {
+                    let r_slug = Path::new(r)
+                        .file_stem()
+                        .and_then(|s| s.to_str())
+                        .map(String::from);
+                    if r_slug.as_deref() == Some(slug.as_str()) {
+                        existing_sources.push(BacklinkSource {
+                            path: source_path_str.clone(),
+                            kind: BacklinkKind::Related,
+                            context: None,
+                        });
+                    }
+                }
+            }
+        }
+
+        if existing_sources.is_empty() {
+            // Remove sidecar when no sources remain
+            if sidecar.exists() {
+                std::fs::remove_file(&sidecar)
+                    .map_err(|e| crate::WikiError::Io(std::io::Error::other(e.to_string())))?;
+            }
+        } else {
+            let record = BacklinkRecord {
+                target: slug,
+                sources: existing_sources,
+            };
+            let json = serde_json::to_vec_pretty(&record)
+                .map_err(|e| crate::WikiError::Io(std::io::Error::other(e.to_string())))?;
+            atomic_write(&sidecar, &json)?;
+        }
+    }
+
+    Ok(())
+}
+
+/// Query the backlink index for a given target slug.
+/// Returns `None` when no sidecar exists (i.e. no pages link to this target).
+pub fn query(wiki_root: &Path, target: &str) -> Result<Option<BacklinkRecord>> {
+    let path = sidecar_path(wiki_root, target);
+    if !path.exists() {
+        return Ok(None);
+    }
+    let raw = std::fs::read_to_string(&path)
+        .map_err(|e| crate::WikiError::Io(std::io::Error::other(e.to_string())))?;
+    let record: BacklinkRecord = serde_json::from_str(&raw)
+        .map_err(|e| crate::WikiError::Io(std::io::Error::other(e.to_string())))?;
+    Ok(Some(record))
+}
+
+/// Path to the sidecar file for a given target slug.
+pub fn sidecar_path(wiki_root: &Path, target: &str) -> PathBuf {
+    wiki_root.join(BACKLINKS_DIR).join(format!("{target}.json"))
+}
+
+// ─── Internal helpers ─────────────────────────────────────────────────────────
+
+/// Collect all markdown file paths (absolute) under `wiki_dir`.
+fn walkdir(wiki_dir: &Path) -> Result<Vec<PathBuf>> {
+    let mut result = Vec::new();
+    collect_md(wiki_dir, &mut result)?;
+    Ok(result)
+}
+
+fn collect_md(dir: &Path, out: &mut Vec<PathBuf>) -> Result<()> {
+    let read_dir = std::fs::read_dir(dir)
+        .map_err(|e| crate::WikiError::Io(std::io::Error::other(e.to_string())))?;
+    for entry in read_dir {
+        let entry =
+            entry.map_err(|e| crate::WikiError::Io(std::io::Error::other(e.to_string())))?;
+        let path = entry.path();
+        let file_type = entry
+            .file_type()
+            .map_err(|e| crate::WikiError::Io(std::io::Error::other(e.to_string())))?;
+        if file_type.is_dir() {
+            collect_md(&path, out)?;
+        } else if file_type.is_file() && path.extension().and_then(|e| e.to_str()) == Some("md") {
+            out.push(path);
+        }
+    }
+    Ok(())
+}

--- a/crates/lw-core/src/backlinks.rs
+++ b/crates/lw-core/src/backlinks.rs
@@ -49,6 +49,13 @@ pub struct BacklinkRecord {
 /// Relative path (from wiki root) to the backlink-sidecar directory.
 pub const BACKLINKS_DIR: &str = ".lw/backlinks";
 
+/// Filename of the sentinel file written by `rebuild_index` to mark the
+/// index as built. Its existence is what `ensure_index` checks to decide
+/// whether a rebuild is necessary — the previous "directory non-empty"
+/// heuristic incorrectly forced a full O(n_pages) rebuild on every call
+/// for any wiki with no inter-page wikilinks.
+const BUILT_SENTINEL: &str = ".built";
+
 /// Extract all `(slug, line)` pairs for every `[[wikilink]]` in `body`.
 /// Each tuple contains the resolved slug (pre-pipe portion) and the full line
 /// containing the link. Wikilinks inside code fences are included intentionally
@@ -208,24 +215,32 @@ pub fn write_index(wiki_root: &Path, map: &BTreeMap<String, Vec<BacklinkSource>>
 }
 
 /// Rebuild the full backlink index from scratch: walk wiki/, build map, persist sidecars.
+/// Writes the `.built` sentinel on success so subsequent `ensure_index` calls short-circuit
+/// even when the wiki has no inter-page links (and thus no sidecar files).
 pub fn rebuild_index(wiki_root: &Path) -> Result<()> {
     let map = build_index(wiki_root)?;
-    write_index(wiki_root, &map)
+    write_index(wiki_root, &map)?;
+
+    // Mark the index as built. We do this only after write_index returns
+    // Ok so a partial rebuild does not falsely advertise itself as
+    // complete. The sentinel content is intentionally empty — only
+    // existence is the signal.
+    let dir = wiki_root.join(BACKLINKS_DIR);
+    std::fs::create_dir_all(&dir)
+        .map_err(|e| crate::WikiError::Io(std::io::Error::other(e.to_string())))?;
+    let sentinel = dir.join(BUILT_SENTINEL);
+    atomic_write(&sentinel, b"")?;
+    Ok(())
 }
 
-/// Ensure the backlink index directory exists and contains at least one file.
-/// If the directory is absent or empty, runs a full `rebuild_index`.
+/// Ensure the backlink index has been built. Checks the `.built` sentinel
+/// file; runs a full `rebuild_index` only when the sentinel is absent.
+/// This avoids the previous bug where a wiki with no `[[wikilinks]]`
+/// kept `.lw/backlinks/` empty and forced an O(n_pages) rebuild on every
+/// `wiki_backlinks` / `lw backlinks` invocation.
 pub fn ensure_index(wiki_root: &Path) -> Result<()> {
-    let dir = wiki_root.join(BACKLINKS_DIR);
-    let needs_build = if dir.exists() {
-        // Consider empty dir as needing a build
-        std::fs::read_dir(&dir)
-            .map(|mut d| d.next().is_none())
-            .unwrap_or(true)
-    } else {
-        true
-    };
-    if needs_build {
+    let sentinel = wiki_root.join(BACKLINKS_DIR).join(BUILT_SENTINEL);
+    if !sentinel.exists() {
         rebuild_index(wiki_root)?;
     }
     Ok(())
@@ -273,6 +288,10 @@ pub fn update_for_page(wiki_root: &Path, source_rel: &Path) -> Result<()> {
     let backlinks_dir = wiki_root.join(BACKLINKS_DIR);
 
     // Gather all slugs that previously had this source (by scanning existing sidecars).
+    // FIXME: O(n_sidecars) scan over the whole index on every page write —
+    // acceptable for typical vaults (<1000 pages) but warrants benchmarking
+    // before scaling further. A reverse-index (source-page → outbound slugs)
+    // would let us skip this walk.
     let old_slugs: Vec<String> = if backlinks_dir.exists() {
         let mut v = Vec::new();
         for entry in std::fs::read_dir(&backlinks_dir)

--- a/crates/lw-core/src/lib.rs
+++ b/crates/lw-core/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod backlinks;
 pub mod error;
 pub mod fs;
 pub mod git;

--- a/crates/lw-core/src/lint.rs
+++ b/crates/lw-core/src/lint.rs
@@ -80,9 +80,11 @@ pub fn run_lint(root: &Path, category: Option<&str>) -> crate::Result<LintReport
 
         let rel_str = rel_path.to_string_lossy().to_string();
 
-        // Skip special wiki files from orphan detection
+        // Skip special wiki files and _journal/* pages from orphan detection.
+        // Journal pages are intentionally capture-not-linked (issue #39).
         let is_special = matches!(rel_str.as_str(), "index.md" | "log.md");
-        if !is_special {
+        let is_journal = rel_str.starts_with("_journal/") || rel_str.starts_with("_journal\\");
+        if !is_special && !is_journal {
             orphan_candidates.insert(rel_str.clone());
         }
 

--- a/crates/lw-core/tests/backlinks_test.rs
+++ b/crates/lw-core/tests/backlinks_test.rs
@@ -1,0 +1,273 @@
+mod common;
+
+use common::{TestWiki, make_page};
+use lw_core::backlinks::{
+    BACKLINKS_DIR, BacklinkKind, BacklinkRecord, build_index, ensure_index, extract_link_lines,
+    query, rebuild_index, sidecar_path, slug_from_wiki_path, snippet_for, update_for_page,
+};
+use std::path::Path;
+
+// ─── Pure helpers ─────────────────────────────────────────────────────────────
+
+#[test]
+fn extract_link_lines_finds_wikilinks_per_line() {
+    let body = "first line has [[foo]]\nsecond line links [[bar]] and [[baz]]\nthird is plain";
+    let pairs = extract_link_lines(body);
+    let slugs: Vec<&str> = pairs.iter().map(|(s, _)| s.as_str()).collect();
+    assert!(slugs.contains(&"foo"), "should find foo: {slugs:?}");
+    assert!(slugs.contains(&"bar"), "should find bar: {slugs:?}");
+    assert!(slugs.contains(&"baz"), "should find baz: {slugs:?}");
+    assert_eq!(slugs.len(), 3, "no extra slugs: {slugs:?}");
+
+    // Each pair must carry the surrounding line so callers can build a snippet.
+    for (slug, line) in &pairs {
+        assert!(
+            line.contains(&format!("[[{slug}")),
+            "line for slug {slug} must contain the wikilink: {line}"
+        );
+    }
+}
+
+#[test]
+fn extract_link_lines_handles_pipe_display() {
+    let body = "ref [[slug-x|some display]] inline";
+    let pairs = extract_link_lines(body);
+    assert_eq!(pairs.len(), 1, "one wikilink: {pairs:?}");
+    assert_eq!(pairs[0].0, "slug-x", "slug must be the pre-pipe portion");
+}
+
+#[test]
+fn extract_link_lines_includes_code_fenced_links() {
+    // Per spec we follow Obsidian's convention: links inside code fences DO count.
+    // Documented in the PR description.
+    let body = "```\nfn x() { let _ = \"[[code-link]]\"; }\n```";
+    let pairs = extract_link_lines(body);
+    let slugs: Vec<&str> = pairs.iter().map(|(s, _)| s.as_str()).collect();
+    assert!(
+        slugs.contains(&"code-link"),
+        "code-fenced link counts: {slugs:?}"
+    );
+}
+
+#[test]
+fn snippet_for_centers_around_match() {
+    let line =
+        "Lorem ipsum dolor sit amet consectetur adipiscing elit, [[transformer]] is great today";
+    let snip = snippet_for(line, "transformer");
+    assert!(
+        snip.contains("[[transformer]]"),
+        "must contain match: {snip}"
+    );
+    // Snippet must be shorter than the full line for long inputs (default radius ~80).
+    assert!(snip.len() < line.len() + 8, "should be trimmed: {snip}");
+}
+
+#[test]
+fn snippet_for_empty_line_returns_empty_string() {
+    assert!(snippet_for("", "foo").is_empty());
+}
+
+#[test]
+fn slug_from_wiki_path_strips_ext_and_dirs() {
+    assert_eq!(
+        slug_from_wiki_path(Path::new("architecture/transformer.md")),
+        Some("transformer".to_string())
+    );
+    assert_eq!(
+        slug_from_wiki_path(Path::new("foo.md")),
+        Some("foo".to_string())
+    );
+    assert_eq!(slug_from_wiki_path(Path::new("")), None);
+}
+
+// ─── Index build + query ─────────────────────────────────────────────────────
+
+#[test]
+fn build_index_picks_up_wikilinks_and_related() {
+    let wiki = TestWiki::new();
+
+    // target page: tools/bar
+    let bar = make_page("Bar", &["tools"], "normal", "I am bar.");
+    wiki.write_page("tools/bar.md", &bar);
+
+    // source via body wikilink
+    let foo = make_page("Foo", &["tools"], "normal", "Use [[bar]] for parsing.");
+    wiki.write_page("tools/foo.md", &foo);
+
+    // source via related: frontmatter
+    let mut baz = make_page("Baz", &["tools"], "normal", "No body link here.");
+    baz.related = Some(vec!["tools/bar.md".to_string()]);
+    wiki.write_page("tools/baz.md", &baz);
+
+    let map = build_index(wiki.root()).expect("index must build");
+    let sources = map.get("bar").expect("bar must be indexed");
+    assert_eq!(
+        sources.len(),
+        2,
+        "two sources: wikilink + related: {sources:?}"
+    );
+
+    let kinds: Vec<&BacklinkKind> = sources.iter().map(|s| &s.kind).collect();
+    assert!(kinds.contains(&&BacklinkKind::Wikilink));
+    assert!(kinds.contains(&&BacklinkKind::Related));
+
+    // Source paths use `wiki/` prefix per spec.
+    let paths: Vec<&str> = sources.iter().map(|s| s.path.as_str()).collect();
+    assert!(paths.contains(&"wiki/tools/foo.md"));
+    assert!(paths.contains(&"wiki/tools/baz.md"));
+}
+
+#[test]
+fn build_index_pipe_wikilinks_match_by_slug() {
+    let wiki = TestWiki::new();
+    let target = make_page("Target", &["tools"], "normal", "target body");
+    wiki.write_page("tools/target.md", &target);
+
+    let src = make_page(
+        "Src",
+        &["tools"],
+        "normal",
+        "Read [[target|the awesome target]] now",
+    );
+    wiki.write_page("tools/src.md", &src);
+
+    let map = build_index(wiki.root()).expect("build");
+    let sources = map.get("target").expect("target must be indexed");
+    assert_eq!(sources.len(), 1);
+    assert_eq!(sources[0].path, "wiki/tools/src.md");
+    let ctx = sources[0].context.as_deref().unwrap_or("");
+    assert!(
+        ctx.contains("[[target"),
+        "context should include wikilink: {ctx}"
+    );
+}
+
+#[test]
+fn rebuild_index_writes_sidecar_files() {
+    let wiki = TestWiki::new();
+    let target = make_page("T", &["tools"], "normal", "");
+    wiki.write_page("tools/t.md", &target);
+    let src = make_page("S", &["tools"], "normal", "See [[t]].");
+    wiki.write_page("tools/s.md", &src);
+
+    rebuild_index(wiki.root()).expect("rebuild");
+    let path = sidecar_path(wiki.root(), "t");
+    assert!(path.exists(), "sidecar must be written: {path:?}");
+
+    let raw = std::fs::read_to_string(&path).unwrap();
+    let record: BacklinkRecord = serde_json::from_str(&raw).unwrap();
+    assert_eq!(record.target, "t");
+    assert_eq!(record.sources.len(), 1);
+    assert_eq!(record.sources[0].path, "wiki/tools/s.md");
+}
+
+#[test]
+fn query_returns_none_when_no_inbound_links() {
+    let wiki = TestWiki::new();
+    let res = query(wiki.root(), "nonexistent").expect("query ok");
+    assert!(res.is_none(), "no sidecar => None: {res:?}");
+}
+
+#[test]
+fn query_returns_record_after_rebuild() {
+    let wiki = TestWiki::new();
+    let target = make_page("Target", &["tools"], "normal", "");
+    wiki.write_page("tools/target.md", &target);
+    let src = make_page("Src", &["tools"], "normal", "Use [[target]].");
+    wiki.write_page("tools/src.md", &src);
+
+    rebuild_index(wiki.root()).expect("rebuild");
+    let record = query(wiki.root(), "target")
+        .expect("query ok")
+        .expect("Some record");
+    assert_eq!(record.target, "target");
+    assert_eq!(record.sources.len(), 1);
+    let snippet = record.sources[0]
+        .context
+        .as_deref()
+        .expect("wikilink source carries snippet");
+    assert!(
+        snippet.contains("[[target]]"),
+        "snippet should center on the link: {snippet}"
+    );
+}
+
+// ─── Incremental updates ─────────────────────────────────────────────────────
+
+#[test]
+fn update_for_page_creates_sidecar_for_new_links() {
+    let wiki = TestWiki::new();
+    let target = make_page("T", &["tools"], "normal", "t");
+    wiki.write_page("tools/t.md", &target);
+    let src = make_page("S", &["tools"], "normal", "See [[t]] here.");
+    wiki.write_page("tools/s.md", &src);
+
+    update_for_page(wiki.root(), Path::new("tools/s.md")).expect("update");
+    let record = query(wiki.root(), "t")
+        .expect("query ok")
+        .expect("sidecar created");
+    assert_eq!(record.sources[0].path, "wiki/tools/s.md");
+}
+
+#[test]
+fn update_for_page_removes_dropped_links() {
+    let wiki = TestWiki::new();
+    let target = make_page("T", &["tools"], "normal", "t");
+    wiki.write_page("tools/t.md", &target);
+
+    // Initial: source links to T
+    let src_v1 = make_page("S", &["tools"], "normal", "Use [[t]] often.");
+    wiki.write_page("tools/s.md", &src_v1);
+    update_for_page(wiki.root(), Path::new("tools/s.md")).expect("v1 update");
+    assert!(query(wiki.root(), "t").unwrap().is_some());
+
+    // Updated: source no longer mentions T
+    let src_v2 = make_page("S", &["tools"], "normal", "All references removed.");
+    wiki.write_page("tools/s.md", &src_v2);
+    update_for_page(wiki.root(), Path::new("tools/s.md")).expect("v2 update");
+
+    let after = query(wiki.root(), "t").expect("query ok");
+    assert!(
+        after.is_none(),
+        "sidecar should be removed when the only source drops the link: {after:?}"
+    );
+}
+
+#[test]
+fn update_for_page_preserves_other_sources() {
+    let wiki = TestWiki::new();
+    let target = make_page("T", &["tools"], "normal", "t");
+    wiki.write_page("tools/t.md", &target);
+    let a = make_page("A", &["tools"], "normal", "From A: [[t]].");
+    wiki.write_page("tools/a.md", &a);
+    let b = make_page("B", &["tools"], "normal", "From B: [[t]] also.");
+    wiki.write_page("tools/b.md", &b);
+
+    rebuild_index(wiki.root()).expect("rebuild");
+    let before = query(wiki.root(), "t").unwrap().unwrap();
+    assert_eq!(before.sources.len(), 2);
+
+    // Drop B's link only.
+    let b_v2 = make_page("B", &["tools"], "normal", "B no longer references it.");
+    wiki.write_page("tools/b.md", &b_v2);
+    update_for_page(wiki.root(), Path::new("tools/b.md")).expect("update b");
+
+    let after = query(wiki.root(), "t").unwrap().unwrap();
+    let paths: Vec<&str> = after.sources.iter().map(|s| s.path.as_str()).collect();
+    assert_eq!(paths, vec!["wiki/tools/a.md"], "only A remains: {paths:?}");
+}
+
+#[test]
+fn ensure_index_builds_when_missing() {
+    let wiki = TestWiki::new();
+    let t = make_page("T", &["tools"], "normal", "t");
+    wiki.write_page("tools/t.md", &t);
+    let s = make_page("S", &["tools"], "normal", "See [[t]].");
+    wiki.write_page("tools/s.md", &s);
+
+    let dir = wiki.root().join(BACKLINKS_DIR);
+    assert!(!dir.exists(), "precondition: dir absent");
+    ensure_index(wiki.root()).expect("ensure ok");
+    assert!(dir.exists(), "ensure_index must create dir");
+    assert!(query(wiki.root(), "t").unwrap().is_some());
+}

--- a/crates/lw-core/tests/backlinks_test.rs
+++ b/crates/lw-core/tests/backlinks_test.rs
@@ -271,3 +271,44 @@ fn ensure_index_builds_when_missing() {
     assert!(dir.exists(), "ensure_index must create dir");
     assert!(query(wiki.root(), "t").unwrap().is_some());
 }
+
+/// Regression: review feedback on PR #94. A wiki with no inter-page
+/// `[[wikilinks]]` writes no sidecar files, so the old "directory
+/// non-empty?" heuristic always considered the index unbuilt and
+/// triggered a full O(n_pages) rebuild on every call. The fix adds a
+/// `.built` sentinel file that `rebuild_index` writes on completion,
+/// so subsequent `ensure_index` calls early-return.
+///
+/// Detection strategy: after the first `ensure_index` builds (or no-ops)
+/// the index, add a brand-new page with a `[[wikilink]]`. Then call
+/// `ensure_index` again. If it rebuilds, the new link will produce a
+/// sidecar; if it correctly short-circuits, no sidecar should appear.
+#[test]
+fn ensure_index_skips_rebuild_when_already_built() {
+    let wiki = TestWiki::new();
+    // Phase 1: a single orphan page with NO outbound wikilinks. After
+    // ensure_index, the index is "built" but no sidecars exist.
+    let orphan = make_page("Orphan", &["tools"], "normal", "no links here");
+    wiki.write_page("tools/orphan.md", &orphan);
+
+    ensure_index(wiki.root()).expect("first ensure ok");
+    let dir = wiki.root().join(BACKLINKS_DIR);
+    assert!(dir.exists(), "ensure_index must create the directory");
+
+    // Phase 2: add a new page that links to the orphan AFTER the index
+    // was built. A correct ensure_index implementation must NOT pick
+    // this up — only an incremental update_for_page (or an explicit
+    // rebuild_index) should add this link to the sidecars. If
+    // ensure_index re-walks the tree on every call, the new sidecar
+    // will be created, exposing the regression.
+    let linker = make_page("Linker", &["tools"], "normal", "See [[orphan]] above.");
+    wiki.write_page("tools/linker.md", &linker);
+
+    ensure_index(wiki.root()).expect("second ensure ok");
+
+    let sidecar = sidecar_path(wiki.root(), "orphan");
+    assert!(
+        !sidecar.exists(),
+        "ensure_index must short-circuit when already built — found unexpected sidecar at {sidecar:?}; this means a full rebuild ran"
+    );
+}

--- a/crates/lw-core/tests/common/mod.rs
+++ b/crates/lw-core/tests/common/mod.rs
@@ -63,6 +63,7 @@ impl TestWiki {
     }
 
     /// Write the canonical 5-page sample set. Returns the (rel_path, Page) pairs.
+    #[allow(dead_code)]
     pub fn with_sample_pages(&self) -> Vec<(String, Page)> {
         let pages = sample_pages();
         for (rel, page) in &pages {
@@ -107,6 +108,7 @@ pub fn make_page(title: &str, tags: &[&str], decay: &str, body: &str) -> Page {
 }
 
 /// The canonical 5-page sample set for integration tests.
+#[allow(dead_code)]
 pub fn sample_pages() -> Vec<(String, Page)> {
     vec![
         (

--- a/crates/lw-core/tests/lint_test.rs
+++ b/crates/lw-core/tests/lint_test.rs
@@ -1,6 +1,6 @@
 mod common;
 
-use common::{TestWiki, make_page};
+use common::{make_page, TestWiki};
 use lw_core::lint::run_lint;
 
 #[test]
@@ -333,5 +333,39 @@ fn lint_reports_stale_journal_entries_older_than_threshold() {
         finding.detail.contains("days") || finding.detail.contains("stale"),
         "stale_journal detail should mention age/stale: {:?}",
         finding.detail
+    );
+}
+
+// ─── Issue #39: orphan rule must exclude `_journal/*` ─────────────────────────
+
+#[test]
+fn lint_excludes_journal_pages_from_orphans() {
+    let wiki = TestWiki::new();
+
+    // A non-journal orphan and a journal page (which is intentionally
+    // captured-not-linked).
+    let orphan = make_page("Orphan", &["tools"], "normal", "Body");
+    wiki.write_page("tools/orphan-page.md", &orphan);
+
+    let journal = make_page(
+        "Daily 2026-04-25",
+        &["journal"],
+        "normal",
+        "Notes for today",
+    );
+    wiki.write_page("_journal/2026-04-25.md", &journal);
+
+    let report = run_lint(wiki.root(), None).expect("lint should succeed");
+
+    let orphan_paths: Vec<String> = report.orphan_pages.iter().map(|f| f.path.clone()).collect();
+    assert!(
+        orphan_paths.iter().any(|p| p.contains("orphan-page.md")),
+        "regular page must still be flagged: {orphan_paths:?}"
+    );
+    assert!(
+        !orphan_paths
+            .iter()
+            .any(|p| p.contains("2026-04-25.md") || p.starts_with("_journal/")),
+        "_journal/* pages must be excluded: {orphan_paths:?}"
     );
 }

--- a/crates/lw-core/tests/lint_test.rs
+++ b/crates/lw-core/tests/lint_test.rs
@@ -1,6 +1,6 @@
 mod common;
 
-use common::{make_page, TestWiki};
+use common::{TestWiki, make_page};
 use lw_core::lint::run_lint;
 
 #[test]

--- a/crates/lw-mcp/src/lib.rs
+++ b/crates/lw-mcp/src/lib.rs
@@ -1910,4 +1910,158 @@ mod tests {
             "unknown target should error: {resp}"
         );
     }
+
+    /// Regression: review feedback on PR #94. The `append_section` /
+    /// `upsert_section` paths in `wiki_write` previously skipped
+    /// `backlinks::update_for_page`, so adding a `[[wikilink]]` via a
+    /// section write left the backlink index stale. To avoid masking the
+    /// bug behind a full `ensure_index` rebuild on the subsequent
+    /// `wiki_backlinks` call, we pre-seed an unrelated sidecar so
+    /// `.lw/backlinks/` is non-empty (and thus `ensure_index` skips the
+    /// rebuild — see also the `.built` sentinel test in lw-core).
+    #[tokio::test]
+    async fn wiki_write_append_section_updates_backlinks() {
+        let (tmp, server) = spawn_server();
+
+        // Two pages: target (has no inbound links yet) and source (will
+        // gain a [[target]] link via append_section).
+        let target = WikiWriteArgs {
+            path: "tools/append-target.md".to_string(),
+            content: "---\ntitle: Append Target\ntags: [t]\n---\n\nbody\n".to_string(),
+            mode: "overwrite".to_string(),
+            section: None,
+            commit: Some(false),
+            push: None,
+            author: None,
+            source: None,
+        };
+        let _ = server.wiki_write(Parameters(target));
+
+        let source = WikiWriteArgs {
+            path: "tools/append-source.md".to_string(),
+            content: "---\ntitle: Append Source\ntags: [t]\n---\n\nIntro paragraph.\n\n## Notes\n\nSome notes.\n".to_string(),
+            mode: "overwrite".to_string(),
+            section: None,
+            commit: Some(false),
+            push: None,
+            author: None,
+            source: None,
+        };
+        let _ = server.wiki_write(Parameters(source));
+
+        // Pre-seed an unrelated sidecar to keep .lw/backlinks/ non-empty.
+        // Without this, `ensure_index` on the wiki_backlinks call would
+        // run a full rebuild and mask the bug because the rebuild walk
+        // would re-discover the new wikilink anyway.
+        let backlinks_dir = tmp.path().join(lw_core::backlinks::BACKLINKS_DIR);
+        std::fs::create_dir_all(&backlinks_dir).unwrap();
+        std::fs::write(
+            backlinks_dir.join("__sentinel__.json"),
+            br#"{"target":"__sentinel__","sources":[]}"#,
+        )
+        .unwrap();
+
+        // Now append a [[append-target]] reference via append_section.
+        let append = WikiWriteArgs {
+            path: "tools/append-source.md".to_string(),
+            content: "Cross-reference [[append-target]] for context.".to_string(),
+            mode: "append_section".to_string(),
+            section: Some("Notes".to_string()),
+            commit: Some(false),
+            push: None,
+            author: None,
+            source: None,
+        };
+        let resp = server.wiki_write(Parameters(append));
+        let v = parse(&resp);
+        assert!(v.get("error").is_none(), "append failed: {resp}");
+
+        // Query the backlinks for the target — it should now include the source.
+        let q = WikiBacklinksArgs {
+            path: "append-target".to_string(),
+        };
+        let resp = server.wiki_backlinks(Parameters(q));
+        let v = parse(&resp);
+        let backlinks = v["backlinks"]
+            .as_array()
+            .unwrap_or_else(|| panic!("expected backlinks array, got: {resp}"));
+        assert_eq!(
+            backlinks.len(),
+            1,
+            "append_section must update backlinks index; got: {resp}"
+        );
+        assert_eq!(
+            backlinks[0]["source"].as_str(),
+            Some("wiki/tools/append-source.md"),
+            "wrong source path: {resp}"
+        );
+    }
+
+    /// Regression: same review feedback as above, but for `upsert_section`.
+    #[tokio::test]
+    async fn wiki_write_upsert_section_updates_backlinks() {
+        let (tmp, server) = spawn_server();
+
+        let target = WikiWriteArgs {
+            path: "tools/upsert-target.md".to_string(),
+            content: "---\ntitle: Upsert Target\ntags: [t]\n---\n\nbody\n".to_string(),
+            mode: "overwrite".to_string(),
+            section: None,
+            commit: Some(false),
+            push: None,
+            author: None,
+            source: None,
+        };
+        let _ = server.wiki_write(Parameters(target));
+
+        let source = WikiWriteArgs {
+            path: "tools/upsert-source.md".to_string(),
+            content: "---\ntitle: Upsert Source\ntags: [t]\n---\n\nIntro.\n".to_string(),
+            mode: "overwrite".to_string(),
+            section: None,
+            commit: Some(false),
+            push: None,
+            author: None,
+            source: None,
+        };
+        let _ = server.wiki_write(Parameters(source));
+
+        // Pre-seed an unrelated sidecar so ensure_index doesn't rebuild.
+        let backlinks_dir = tmp.path().join(lw_core::backlinks::BACKLINKS_DIR);
+        std::fs::create_dir_all(&backlinks_dir).unwrap();
+        std::fs::write(
+            backlinks_dir.join("__sentinel__.json"),
+            br#"{"target":"__sentinel__","sources":[]}"#,
+        )
+        .unwrap();
+
+        // upsert a Related section that adds a [[upsert-target]] link.
+        let upsert = WikiWriteArgs {
+            path: "tools/upsert-source.md".to_string(),
+            content: "See [[upsert-target]] for details.".to_string(),
+            mode: "upsert_section".to_string(),
+            section: Some("Related".to_string()),
+            commit: Some(false),
+            push: None,
+            author: None,
+            source: None,
+        };
+        let resp = server.wiki_write(Parameters(upsert));
+        let v = parse(&resp);
+        assert!(v.get("error").is_none(), "upsert failed: {resp}");
+
+        let q = WikiBacklinksArgs {
+            path: "upsert-target".to_string(),
+        };
+        let resp = server.wiki_backlinks(Parameters(q));
+        let v = parse(&resp);
+        let backlinks = v["backlinks"]
+            .as_array()
+            .unwrap_or_else(|| panic!("expected backlinks array, got: {resp}"));
+        assert_eq!(
+            backlinks.len(),
+            1,
+            "upsert_section must update backlinks index; got: {resp}"
+        );
+    }
 }

--- a/crates/lw-mcp/src/lib.rs
+++ b/crates/lw-mcp/src/lib.rs
@@ -1,6 +1,7 @@
 //! MCP server for LLM Wiki.
 //! Provides wiki_query, wiki_read, wiki_browse, wiki_tags, wiki_write, wiki_ingest, wiki_lint, wiki_stats tools.
 
+use lw_core::backlinks;
 use lw_core::fs::{
     NewPageRequest, atomic_write, category_from_path, list_pages, new_page, read_page,
     validate_wiki_path, write_page,
@@ -298,6 +299,14 @@ pub struct WikiNewArgs {
     pub source: Option<String>,
 }
 
+#[derive(Debug, Deserialize, schemars::JsonSchema)]
+pub struct WikiBacklinksArgs {
+    /// Target page to look up inbound links for. Accepts a bare slug (e.g.
+    /// `"bar"`), a category-relative path (`"tools/bar.md"`), or a
+    /// vault-relative path with wiki/ prefix (`"wiki/tools/bar.md"`).
+    pub path: String,
+}
+
 // === Server ===
 
 #[derive(Clone)]
@@ -528,6 +537,13 @@ impl WikiMcpServer {
                 if let Err(e) = write_page(&abs_path, &page) {
                     return serde_json::json!({"error": format!("Failed to write page: {e}")})
                         .to_string();
+                }
+
+                // Incrementally update the backlink index for this source page.
+                if let Ok(rel) = abs_path.strip_prefix(self.wiki_root.join("wiki"))
+                    && let Err(e) = backlinks::update_for_page(&self.wiki_root, rel)
+                {
+                    tracing::warn!("backlink update failed for {}: {e}", args.path);
                 }
 
                 if let Err(e) = self.searcher.index_page(&args.path, &page) {
@@ -837,6 +853,13 @@ impl WikiMcpServer {
                     .to_string_lossy()
                     .to_string();
 
+                // Incrementally update the backlink index for this new source page.
+                if let Ok(rel) = abs_path.strip_prefix(self.wiki_root.join("wiki"))
+                    && let Err(e) = backlinks::update_for_page(&self.wiki_root, rel)
+                {
+                    tracing::warn!("backlink update failed for new page {}: {e}", index_path);
+                }
+
                 if let Err(e) = self.searcher.index_page(&index_path, &page) {
                     tracing::warn!("Failed to index new page {}: {}", index_path, e);
                 }
@@ -926,6 +949,81 @@ impl WikiMcpServer {
         });
         attach_warnings(&mut response, dirty_warning);
         response.to_string()
+    }
+
+    /// Find all pages that link to a given page (backlinks / inbound links).
+    #[tool(
+        name = "wiki_backlinks",
+        description = "Return all pages that link to a given page via [[wikilinks]] or frontmatter related: entries. \
+                       Accepts a bare slug, category-relative path, or wiki/-prefixed vault path. \
+                       Returns a JSON object with a `backlinks` array. \
+                       Each entry has `source` (vault-relative path), `kind` (wikilink|related), and `context` (snippet)."
+    )]
+    fn wiki_backlinks(&self, Parameters(args): Parameters<WikiBacklinksArgs>) -> String {
+        // Normalise input to a slug: strip "wiki/" prefix, strip leading
+        // category/, strip ".md" extension.
+        let raw = args.path.trim_start_matches("wiki/");
+        let slug = std::path::Path::new(raw)
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or(raw)
+            .to_string();
+
+        // Ensure the index exists (lazy build on first call).
+        if let Err(e) = backlinks::ensure_index(&self.wiki_root) {
+            tracing::warn!("backlink index build failed: {e}");
+        }
+
+        // Verify the target page actually exists in the wiki.
+        let wiki_dir = self.wiki_root.join("wiki");
+        let target_exists = if wiki_dir.exists() {
+            // Walk categories to find <slug>.md
+            std::fs::read_dir(&wiki_dir)
+                .ok()
+                .map(|entries| {
+                    entries
+                        .flatten()
+                        .filter(|e| e.file_type().is_ok_and(|t| t.is_dir()))
+                        .any(|cat| cat.path().join(format!("{slug}.md")).exists())
+                })
+                .unwrap_or(false)
+        } else {
+            false
+        };
+
+        if !target_exists {
+            return serde_json::json!({
+                "error": format!("page not found: {slug}")
+            })
+            .to_string();
+        }
+
+        match backlinks::query(&self.wiki_root, &slug) {
+            Ok(Some(record)) => {
+                let entries: Vec<serde_json::Value> = record
+                    .sources
+                    .iter()
+                    .map(|s| {
+                        serde_json::json!({
+                            "source": s.path,
+                            "kind": serde_json::to_value(&s.kind).unwrap_or_default(),
+                            "context": s.context,
+                        })
+                    })
+                    .collect();
+                serde_json::json!({
+                    "target": slug,
+                    "backlinks": entries,
+                })
+                .to_string()
+            }
+            Ok(None) => serde_json::json!({
+                "target": slug,
+                "backlinks": [],
+            })
+            .to_string(),
+            Err(e) => serde_json::json!({"error": e.to_string()}).to_string(),
+        }
     }
 
     /// Get wiki health statistics: page count, category breakdown, freshness distribution.
@@ -1718,6 +1816,98 @@ mod tests {
         assert!(
             subj.starts_with("docs(wiki): capture"),
             "subject must be 'docs(wiki): capture <slug>'; got: {subj}"
+        );
+    }
+
+    // ─── wiki_backlinks tests (issue #39) ────────────────────────────────────
+
+    /// Stage two pages — `tools/bar.md` (target) and `tools/foo.md`
+    /// (source linking to bar) — using the MCP wiki_write tool so the
+    /// backlink index update path is exercised end-to-end.
+    fn seed_wiki_with_link(server: &WikiMcpServer) {
+        let target = WikiWriteArgs {
+            path: "tools/bar.md".to_string(),
+            content: "---\ntitle: Bar\ntags: [t]\n---\n\nbar body\n".to_string(),
+            mode: "overwrite".to_string(),
+            section: None,
+            commit: Some(false),
+            push: None,
+            author: None,
+            source: None,
+        };
+        let _ = server.wiki_write(Parameters(target));
+
+        let source = WikiWriteArgs {
+            path: "tools/foo.md".to_string(),
+            content: "---\ntitle: Foo\ntags: [t]\n---\n\nUse [[bar]] for parsing.\n".to_string(),
+            mode: "overwrite".to_string(),
+            section: None,
+            commit: Some(false),
+            push: None,
+            author: None,
+            source: None,
+        };
+        let _ = server.wiki_write(Parameters(source));
+    }
+
+    #[tokio::test]
+    async fn wiki_backlinks_returns_inbound_pages() {
+        let (_tmp, server) = spawn_server();
+        seed_wiki_with_link(&server);
+
+        let args = WikiBacklinksArgs {
+            path: "wiki/tools/bar.md".to_string(),
+        };
+        let resp = server.wiki_backlinks(Parameters(args));
+        let v = parse(&resp);
+
+        let backlinks = v["backlinks"]
+            .as_array()
+            .unwrap_or_else(|| panic!("expected backlinks array, got: {resp}"));
+        assert_eq!(backlinks.len(), 1, "one inbound link: {resp}");
+        assert_eq!(
+            backlinks[0]["source"].as_str(),
+            Some("wiki/tools/foo.md"),
+            "source path must be vault-relative with wiki/ prefix: {resp}"
+        );
+        let context = backlinks[0]["context"]
+            .as_str()
+            .expect("wikilink source carries context");
+        assert!(
+            context.contains("[[bar]]"),
+            "context should center on the wikilink: {context}"
+        );
+    }
+
+    #[tokio::test]
+    async fn wiki_backlinks_accepts_slug_input() {
+        let (_tmp, server) = spawn_server();
+        seed_wiki_with_link(&server);
+
+        // Bare slug instead of full wiki/... path.
+        let args = WikiBacklinksArgs {
+            path: "bar".to_string(),
+        };
+        let resp = server.wiki_backlinks(Parameters(args));
+        let v = parse(&resp);
+        assert!(v["backlinks"].is_array(), "got: {resp}");
+        assert_eq!(v["backlinks"].as_array().unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn wiki_backlinks_unknown_page_returns_empty_list() {
+        let (_tmp, server) = spawn_server();
+        seed_wiki_with_link(&server);
+
+        let args = WikiBacklinksArgs {
+            path: "not-a-real-page".to_string(),
+        };
+        let resp = server.wiki_backlinks(Parameters(args));
+        let v = parse(&resp);
+        // Per spec: missing-page returns an `error` field so the agent can react.
+        assert!(
+            v.get("error").is_some(),
+            "unknown target should error: {resp}"
         );
     }
 }

--- a/crates/lw-mcp/src/lib.rs
+++ b/crates/lw-mcp/src/lib.rs
@@ -629,6 +629,16 @@ impl WikiMcpServer {
                     .to_string();
                 }
 
+                // Incrementally update the backlink index — section-write
+                // paths can introduce or drop `[[wikilinks]]` just like
+                // overwrite. Without this call, append_section /
+                // upsert_section silently leave the index stale.
+                if let Ok(rel) = abs_path.strip_prefix(self.wiki_root.join("wiki"))
+                    && let Err(e) = backlinks::update_for_page(&self.wiki_root, rel)
+                {
+                    tracing::warn!("backlink update failed for {}: {e}", args.path);
+                }
+
                 let action = if args.mode == "append_section" {
                     CommitAction::Append
                 } else {

--- a/crates/lw-mcp/src/lib.rs
+++ b/crates/lw-mcp/src/lib.rs
@@ -1924,11 +1924,11 @@ mod tests {
     /// Regression: review feedback on PR #94. The `append_section` /
     /// `upsert_section` paths in `wiki_write` previously skipped
     /// `backlinks::update_for_page`, so adding a `[[wikilink]]` via a
-    /// section write left the backlink index stale. To avoid masking the
-    /// bug behind a full `ensure_index` rebuild on the subsequent
-    /// `wiki_backlinks` call, we pre-seed an unrelated sidecar so
-    /// `.lw/backlinks/` is non-empty (and thus `ensure_index` skips the
-    /// rebuild — see also the `.built` sentinel test in lw-core).
+    /// section write left the backlink index stale. We call
+    /// `rebuild_index` after the initial overwrite seed so the `.built`
+    /// sentinel exists and the subsequent `wiki_backlinks` call
+    /// short-circuits — otherwise a full rebuild on the query side
+    /// would re-discover the new wikilink and mask the bug.
     #[tokio::test]
     async fn wiki_write_append_section_updates_backlinks() {
         let (tmp, server) = spawn_server();
@@ -1959,17 +1959,10 @@ mod tests {
         };
         let _ = server.wiki_write(Parameters(source));
 
-        // Pre-seed an unrelated sidecar to keep .lw/backlinks/ non-empty.
-        // Without this, `ensure_index` on the wiki_backlinks call would
-        // run a full rebuild and mask the bug because the rebuild walk
-        // would re-discover the new wikilink anyway.
-        let backlinks_dir = tmp.path().join(lw_core::backlinks::BACKLINKS_DIR);
-        std::fs::create_dir_all(&backlinks_dir).unwrap();
-        std::fs::write(
-            backlinks_dir.join("__sentinel__.json"),
-            br#"{"target":"__sentinel__","sources":[]}"#,
-        )
-        .unwrap();
+        // Mark the index as built so wiki_backlinks short-circuits
+        // ensure_index. Without this, ensure_index would walk the wiki
+        // and discover the new wikilink, masking the bug.
+        lw_core::backlinks::rebuild_index(tmp.path()).expect("rebuild ok");
 
         // Now append a [[append-target]] reference via append_section.
         let append = WikiWriteArgs {
@@ -2036,14 +2029,8 @@ mod tests {
         };
         let _ = server.wiki_write(Parameters(source));
 
-        // Pre-seed an unrelated sidecar so ensure_index doesn't rebuild.
-        let backlinks_dir = tmp.path().join(lw_core::backlinks::BACKLINKS_DIR);
-        std::fs::create_dir_all(&backlinks_dir).unwrap();
-        std::fs::write(
-            backlinks_dir.join("__sentinel__.json"),
-            br#"{"target":"__sentinel__","sources":[]}"#,
-        )
-        .unwrap();
+        // Same masking-prevention as the append test.
+        lw_core::backlinks::rebuild_index(tmp.path()).expect("rebuild ok");
 
         // upsert a Related section that adds a [[upsert-target]] link.
         let upsert = WikiWriteArgs {


### PR DESCRIPTION
## Summary
- Implements a sidecar JSON backlink index at `.lw/backlinks/<slug>.json` — one file per target page, rebuilt lazily on first query and updated incrementally on every write
- Adds `wiki_backlinks` MCP tool: accepts bare slug, category-relative path, or `wiki/`-prefixed vault path; returns `backlinks[]` with `source`, `kind`, `context`
- Adds `lw backlinks <target>` CLI command with `--format json` and exit-2 on no results
- Fixes `lw lint` to exclude `_journal/*` pages from orphan detection (spec requirement from issue #39)
- Wires incremental `update_for_page` into `wiki_write`, `wiki_new` (MCP) and `lw write`, `lw new` (CLI)

## Index design

Sidecar JSON at `.lw/backlinks/<target-slug>.json`. Each file is a `BacklinkRecord`:

```json
{
  "target": "bar",
  "sources": [
    { "path": "wiki/tools/foo.md", "kind": "wikilink", "context": "See [[bar]] for details." }
  ]
}
```

Tracks `[[wikilinks]]` (with optional `|display` pipe) and frontmatter `related:` entries. Lazy-built by `ensure_index` on first `lw backlinks` / `wiki_backlinks` call; updated incrementally by `update_for_page` on every page write. Code-fenced links count (Obsidian convention).

## Acceptance Criteria Evidence

- [x] **Index built on first query** — `ensure_index` calls `rebuild_index` when `.lw/backlinks/` is absent or empty: `test::ensure_index_builds_when_missing` (backlinks_test.rs:261)
- [x] **Incremental update on wiki_write / wiki_new / lw write / lw new** — `update_for_page` wired in all four paths; tested by `test::update_for_page_creates_sidecar_for_new_links` (line 198), `test::update_for_page_removes_dropped_links` (line 213), `test::update_for_page_preserves_other_sources` (line 237); MCP path tested by `wiki_backlinks_returns_inbound_pages` (lw-mcp lib.rs test line 1571)
- [x] **wiki_backlinks MCP tool** returns linking pages with context snippets: `wiki_backlinks_returns_inbound_pages`, `wiki_backlinks_accepts_slug_input`, `wiki_backlinks_unknown_page_returns_empty_list` (lw-mcp lib.rs tests)
- [x] **lw backlinks CLI command** — `backlinks_happy_path_lists_inbound_links`, `backlinks_accepts_full_path_arg`, `backlinks_format_json_emits_structured_payload`, `backlinks_missing_page_exits_with_error`, `backlinks_help_shows_examples` (lw-cli/tests/backlinks_test.rs)
- [x] **lw lint excludes _journal/*** from orphan detection: `lint_excludes_journal_pages_from_orphans` (lint_test.rs:243)

## Test Plan
- [x] Tests added (TDD — tests commit `75177e2` precedes impl commit `ff409a2`)
- [x] `cargo test` green (405 tests, 32 suites)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --all --check` clean
- [x] Local smoke (isolated to `/tmp` via `--root`): `lw backlinks bar` returns `wiki/tools/foo.md` with context snippet; `lw lint` reports orphan correctly, excludes journal entries
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)