### PR TITLE
fix(core,cli,mcp): silence .lw/ dirty-warning noise (closes #97)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -199,6 +199,20 @@ Switching workspaces requires restarting the agent tool — MCP processes bind t
 - `RUST_LOG=debug lw query "test"` for debug output
 - Logs to stderr, never stdout
 
+## Migration Notes
+
+### 0.x → dirty-warning fix (issue #97)
+
+New vaults get `.lw/search/` and `.lw/backlinks/.built` excluded via the starter-template `.gitignore` files. Existing vaults whose git history already tracked these paths should un-track them once:
+
+```bash
+git rm -r --cached .lw/search/ 2>/dev/null || true
+git rm --cached .lw/backlinks/.built 2>/dev/null || true
+git commit -m "chore(vault): untrack ephemeral lw tooling artifacts"
+```
+
+Advisory only — `dirty_elsewhere_warning` defensively filters these paths regardless of gitignore state, so the warning is silenced even without the `git rm` step. The `git rm` just keeps `git status` clean for humans.
+
 ## Project Conventions
 
 - Edition 2024 (requires Rust 1.85+)

--- a/crates/lw-cli/src/backlinks.rs
+++ b/crates/lw-cli/src/backlinks.rs
@@ -95,8 +95,17 @@ pub fn run(root: &Path, target: &str, format: &Format) -> Result<()> {
 
 /// Wire `update_for_page` after a successful CLI write, so the backlink index
 /// stays up to date when the CLI modifies a page directly.
-pub fn update_after_write(root: &Path, rel_path: &Path) {
-    if let Err(e) = backlinks::update_for_page(root, rel_path) {
-        tracing::warn!("backlink update failed for {}: {e}", rel_path.display());
+///
+/// Returns the absolute paths of sidecar files written (created or updated) by
+/// the incremental update. The caller should pass these alongside the page path
+/// to `run_auto_commit` so the sidecars land in the same commit (Option A,
+/// issue #97). Returns an empty Vec on failure (already logged as a warning).
+pub fn update_after_write(root: &Path, rel_path: &Path) -> Vec<std::path::PathBuf> {
+    match backlinks::update_for_page(root, rel_path) {
+        Ok(written) => written,
+        Err(e) => {
+            tracing::warn!("backlink update failed for {}: {e}", rel_path.display());
+            vec![]
+        }
     }
 }

--- a/crates/lw-cli/src/new.rs
+++ b/crates/lw-cli/src/new.rs
@@ -70,9 +70,13 @@ pub fn run(
     let (abs_path, _page) = new_page(root, &schema, req)?;
 
     // Update the backlink index for the new page (issue #39).
-    if let Ok(rel) = abs_path.strip_prefix(root.join("wiki")) {
-        update_after_write(root, rel);
-    }
+    // Collect any sidecar paths written so we can include them in the
+    // same auto-commit as the page (Option A, issue #97).
+    let sidecar_paths = if let Ok(rel) = abs_path.strip_prefix(root.join("wiki")) {
+        update_after_write(root, rel)
+    } else {
+        vec![]
+    };
 
     // Compute a wiki-relative display path: strip the wiki_root prefix
     let display_path = abs_path
@@ -80,12 +84,16 @@ pub fn run(
         .map(|p| p.to_string_lossy().into_owned())
         .unwrap_or_else(|_| abs_path.to_string_lossy().into_owned());
 
-    // Auto-commit (issue #38). Hand `commit_paths` the *absolute* page
-    // path so it can re-resolve against the actual git toplevel — the
-    // wiki root is allowed to be a subdir of a larger repo.
+    // Auto-commit (issue #38). Pass the page path plus any backlink sidecar
+    // paths written by update_after_write so they land in the same commit
+    // (Option A, issue #97). Hand `commit_paths` absolute paths so it can
+    // re-resolve against the actual git toplevel — the wiki root is allowed
+    // to be a subdir of a larger repo.
+    let mut commit_paths_vec = vec![abs_path.clone()];
+    commit_paths_vec.extend(sidecar_paths);
     run_auto_commit(
         root,
-        std::slice::from_ref(&abs_path),
+        &commit_paths_vec,
         CommitAction::Create,
         &display_path,
         AutoCommitFlags {

--- a/crates/lw-cli/src/write.rs
+++ b/crates/lw-cli/src/write.rs
@@ -96,9 +96,13 @@ pub fn run(
     // is a no-op for both the file and git.
     if wrote_anything {
         // Update the backlink index for the modified page (issue #39).
-        if let Ok(rel) = abs_path.strip_prefix(root.join("wiki")) {
-            update_after_write(root, rel);
-        }
+        // Collect any sidecar paths written so we can include them in the
+        // same auto-commit as the page (Option A, issue #97).
+        let sidecar_paths = if let Ok(rel) = abs_path.strip_prefix(root.join("wiki")) {
+            update_after_write(root, rel)
+        } else {
+            vec![]
+        };
 
         // Display path stays wiki-relative for the commit subject; the
         // path handed to `commit_paths` is *absolute* so it works when
@@ -107,9 +111,11 @@ pub fn run(
             .strip_prefix(root)
             .map(|p| p.to_string_lossy().into_owned())
             .unwrap_or_else(|_| abs_path.to_string_lossy().into_owned());
+        let mut commit_paths_vec = vec![abs_path.clone()];
+        commit_paths_vec.extend(sidecar_paths);
         run_auto_commit(
             root,
-            std::slice::from_ref(&abs_path),
+            &commit_paths_vec,
             action,
             &display_path,
             AutoCommitFlags {

--- a/crates/lw-core/src/backlinks.rs
+++ b/crates/lw-core/src/backlinks.rs
@@ -254,7 +254,13 @@ pub fn ensure_index(wiki_root: &Path) -> Result<()> {
 /// 2. For every target whose sidecar may be affected by this source, reload the
 ///    sidecar, remove the old source entry, and either write the updated sidecar
 ///    or delete the file if no sources remain.
-pub fn update_for_page(wiki_root: &Path, source_rel: &Path) -> Result<()> {
+///
+/// Returns the list of sidecar paths that were written (created or updated).
+/// Deleted sidecars are NOT included — callers should only commit files that exist
+/// on disk. The caller (CLI/MCP auto-commit, Option A per issue #97) should
+/// include these paths in the same commit as the page so the link-evolution audit
+/// trail is preserved in `git log` / `git blame`.
+pub fn update_for_page(wiki_root: &Path, source_rel: &Path) -> Result<Vec<PathBuf>> {
     let abs_path = wiki_root.join("wiki").join(source_rel);
     let source_path_str = format!("wiki/{}", source_rel.to_string_lossy().replace('\\', "/"));
 
@@ -262,7 +268,7 @@ pub fn update_for_page(wiki_root: &Path, source_rel: &Path) -> Result<()> {
     let new_slugs: Vec<String> = if abs_path.exists() {
         let page = match read_page(&abs_path) {
             Ok(p) => p,
-            Err(_) => return Ok(()),
+            Err(_) => return Ok(vec![]),
         };
         let mut slugs: Vec<String> = extract_link_lines(&page.body)
             .into_iter()
@@ -333,6 +339,10 @@ pub fn update_for_page(wiki_root: &Path, source_rel: &Path) -> Result<()> {
         None
     };
 
+    // Collect paths of sidecar files written (created or updated) so callers
+    // can include them in the same auto-commit as the page (Option A, issue #97).
+    let mut written_sidecars: Vec<PathBuf> = Vec::new();
+
     for slug in all_slugs {
         let sidecar = sidecar_path(wiki_root, &slug);
 
@@ -387,6 +397,8 @@ pub fn update_for_page(wiki_root: &Path, source_rel: &Path) -> Result<()> {
                 std::fs::remove_file(&sidecar)
                     .map_err(|e| crate::WikiError::Io(std::io::Error::other(e.to_string())))?;
             }
+            // Deleted sidecars are not added to written_sidecars — can't commit a
+            // file that no longer exists. Stale-sidecar GC is out of scope (#97).
         } else {
             let record = BacklinkRecord {
                 target: slug,
@@ -395,10 +407,11 @@ pub fn update_for_page(wiki_root: &Path, source_rel: &Path) -> Result<()> {
             let json = serde_json::to_vec_pretty(&record)
                 .map_err(|e| crate::WikiError::Io(std::io::Error::other(e.to_string())))?;
             atomic_write(&sidecar, &json)?;
+            written_sidecars.push(sidecar);
         }
     }
 
-    Ok(())
+    Ok(written_sidecars)
 }
 
 /// Query the backlink index for a given target slug.

--- a/crates/lw-core/src/git.rs
+++ b/crates/lw-core/src/git.rs
@@ -1161,4 +1161,138 @@ mod tests {
             "warning must mention the other dirty file; got: {w}"
         );
     }
+
+    // ─── Issue #97: .lw/ ephemeral paths must not contribute to dirty-warning ──
+    //
+    // `.lw/search/*` (Tantivy index) and `.lw/backlinks/.built` (sentinel) are
+    // regenerable artifacts of the wiki tooling itself, not user content.  The
+    // dirty-elsewhere warning must silently skip them regardless of git-ignore
+    // state — this covers existing vaults that may already have these tracked.
+
+    #[test]
+    fn dirty_warning_ignores_lw_search_files() {
+        // Set up a repo where `.lw/search/segment.idx` appears as untracked
+        // alongside the wiki page being committed. The warning must be None
+        // because the ONLY other dirty entry is an ephemeral .lw/search/ file.
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        init_repo(root);
+
+        // Seed a baseline commit so HEAD exists.
+        fs::write(root.join("README.md"), "x").unwrap();
+        Command::new("git")
+            .args(["add", "README.md"])
+            .current_dir(root)
+            .output()
+            .unwrap();
+        Command::new("git")
+            .args(["commit", "-m", "init"])
+            .current_dir(root)
+            .output()
+            .unwrap();
+
+        // Simulate the Tantivy index artifacts under .lw/search/
+        fs::create_dir_all(root.join(".lw/search")).unwrap();
+        fs::write(root.join(".lw/search/segment.idx"), "tantivy").unwrap();
+        fs::write(root.join(".lw/search/meta.json"), "{}").unwrap();
+
+        // Also create the wiki page being committed.
+        fs::create_dir_all(root.join("wiki/tools")).unwrap();
+        fs::write(root.join("wiki/tools/bar.md"), "page").unwrap();
+
+        let warning =
+            dirty_elsewhere_warning(root, &[PathBuf::from("wiki/tools/bar.md")]);
+        assert!(
+            warning.is_none(),
+            ".lw/search/* must not trigger dirty-warning; got: {warning:?}"
+        );
+    }
+
+    #[test]
+    fn dirty_warning_ignores_lw_backlinks_built_sentinel() {
+        // `.lw/backlinks/.built` is the sentinel for the backlink index.
+        // It must be silently ignored in the dirty-warning.
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        init_repo(root);
+
+        fs::write(root.join("README.md"), "x").unwrap();
+        Command::new("git")
+            .args(["add", "README.md"])
+            .current_dir(root)
+            .output()
+            .unwrap();
+        Command::new("git")
+            .args(["commit", "-m", "init"])
+            .current_dir(root)
+            .output()
+            .unwrap();
+
+        // Simulate the backlinks built sentinel.
+        fs::create_dir_all(root.join(".lw/backlinks")).unwrap();
+        fs::write(root.join(".lw/backlinks/.built"), "").unwrap();
+
+        // Wiki page being committed.
+        fs::create_dir_all(root.join("wiki/tools")).unwrap();
+        fs::write(root.join("wiki/tools/baz.md"), "page").unwrap();
+
+        let warning =
+            dirty_elsewhere_warning(root, &[PathBuf::from("wiki/tools/baz.md")]);
+        assert!(
+            warning.is_none(),
+            ".lw/backlinks/.built must not trigger dirty-warning; got: {warning:?}"
+        );
+    }
+
+    #[test]
+    fn dirty_warning_fires_for_non_lw_dirty_file_positive_control() {
+        // Positive control: even when .lw/ ephemeral paths are present, an
+        // unrelated dirty file outside .lw/ must STILL trigger the warning.
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        init_repo(root);
+
+        fs::write(root.join("README.md"), "x").unwrap();
+        Command::new("git")
+            .args(["add", "README.md"])
+            .current_dir(root)
+            .output()
+            .unwrap();
+        Command::new("git")
+            .args(["commit", "-m", "init"])
+            .current_dir(root)
+            .output()
+            .unwrap();
+
+        // Ephemeral .lw/ paths — these must be ignored.
+        fs::create_dir_all(root.join(".lw/search")).unwrap();
+        fs::write(root.join(".lw/search/segment.idx"), "tantivy").unwrap();
+        fs::create_dir_all(root.join(".lw/backlinks")).unwrap();
+        fs::write(root.join(".lw/backlinks/.built"), "").unwrap();
+
+        // The unrelated dirty file that SHOULD trigger the warning.
+        fs::create_dir_all(root.join("wiki")).unwrap();
+        fs::write(root.join("wiki/other-page.md"), "draft").unwrap();
+
+        // Wiki page being committed.
+        fs::create_dir_all(root.join("wiki/tools")).unwrap();
+        fs::write(root.join("wiki/tools/qux.md"), "page").unwrap();
+
+        let warning =
+            dirty_elsewhere_warning(root, &[PathBuf::from("wiki/tools/qux.md")]);
+        let w = warning.expect("warning expected for wiki/other-page.md");
+        assert!(
+            w.contains("other-page.md"),
+            "warning must mention the non-.lw dirty file; got: {w}"
+        );
+        // The ephemeral .lw/ paths must NOT appear in the warning.
+        assert!(
+            !w.contains(".lw/search"),
+            "warning must NOT mention .lw/search; got: {w}"
+        );
+        assert!(
+            !w.contains(".built"),
+            "warning must NOT mention .lw/backlinks/.built; got: {w}"
+        );
+    }
 }

--- a/crates/lw-core/src/git.rs
+++ b/crates/lw-core/src/git.rs
@@ -553,9 +553,43 @@ pub fn auto_commit(
     Ok(outcome)
 }
 
+/// Returns true if `path_part` (a porcelain-output path fragment) is an
+/// ephemeral `.lw/` artifact that should be silently excluded from the
+/// dirty-elsewhere warning.
+///
+/// Ephemeral paths (issue #97):
+/// - `.lw/search/*`   — Tantivy index files; fully regenerable, never user content.
+/// - `.lw/backlinks/.built` — sentinel written by `rebuild_index`; local-only.
+///
+/// Note: `.lw/backlinks/*.json` sidecar files are NOT ephemeral — they carry
+/// the link-evolution audit trail and are auto-committed alongside the page
+/// (Option A per issue #97). They are intentionally NOT filtered here.
+fn is_lw_ephemeral(path_part: &str) -> bool {
+    // Tantivy index files: anything under .lw/search/
+    // The constant crate::INDEX_DIR == ".lw/search".
+    let index_prefix = format!("{}/", crate::INDEX_DIR);
+    if path_part.starts_with(&index_prefix) || path_part.contains(&format!("/{index_prefix}")) {
+        return true;
+    }
+    // Backlinks built sentinel: .lw/backlinks/.built
+    // Matches regardless of leading directory, to handle wiki-root-in-subdir.
+    // crate::backlinks::BACKLINKS_DIR == ".lw/backlinks"
+    let sentinel_suffix = format!("{}/{}", crate::backlinks::BACKLINKS_DIR, ".built");
+    if path_part == sentinel_suffix || path_part.ends_with(&format!("/{sentinel_suffix}")) {
+        return true;
+    }
+    false
+}
+
 /// Compose the dirty-elsewhere warning, if any. Compares
 /// `git status --porcelain` against the supplied paths and returns
 /// `Some(message)` when there are dirty files that aren't being committed.
+///
+/// Ephemeral `.lw/` artifacts (Tantivy index files under `.lw/search/` and
+/// the backlinks built sentinel `.lw/backlinks/.built`) are silently excluded
+/// from the warning — see `is_lw_ephemeral`. This covers both fresh vaults
+/// (where `.gitignore` excludes them) and existing vaults that may have
+/// accidentally tracked these paths before the fix.
 fn dirty_elsewhere_warning(repo_root: &Path, paths: &[PathBuf]) -> Option<String> {
     let toplevel = resolve_toplevel(repo_root).ok()?;
     // `--untracked-files=all` forces individual file listings; without it
@@ -588,6 +622,10 @@ fn dirty_elsewhere_warning(repo_root: &Path, paths: &[PathBuf]) -> Option<String
         // `XY <old> -> <new>`). Strip the 2 status chars + 1 space.
         let path_part = line.get(3..).unwrap_or("").trim();
         if path_part.is_empty() {
+            continue;
+        }
+        // Silently skip ephemeral .lw/ artifacts (Tantivy index, built sentinel).
+        if is_lw_ephemeral(path_part) {
             continue;
         }
         // Naive check: skip if any of our supplied paths matches the trailing
@@ -1200,8 +1238,7 @@ mod tests {
         fs::create_dir_all(root.join("wiki/tools")).unwrap();
         fs::write(root.join("wiki/tools/bar.md"), "page").unwrap();
 
-        let warning =
-            dirty_elsewhere_warning(root, &[PathBuf::from("wiki/tools/bar.md")]);
+        let warning = dirty_elsewhere_warning(root, &[PathBuf::from("wiki/tools/bar.md")]);
         assert!(
             warning.is_none(),
             ".lw/search/* must not trigger dirty-warning; got: {warning:?}"
@@ -1236,8 +1273,7 @@ mod tests {
         fs::create_dir_all(root.join("wiki/tools")).unwrap();
         fs::write(root.join("wiki/tools/baz.md"), "page").unwrap();
 
-        let warning =
-            dirty_elsewhere_warning(root, &[PathBuf::from("wiki/tools/baz.md")]);
+        let warning = dirty_elsewhere_warning(root, &[PathBuf::from("wiki/tools/baz.md")]);
         assert!(
             warning.is_none(),
             ".lw/backlinks/.built must not trigger dirty-warning; got: {warning:?}"
@@ -1278,8 +1314,7 @@ mod tests {
         fs::create_dir_all(root.join("wiki/tools")).unwrap();
         fs::write(root.join("wiki/tools/qux.md"), "page").unwrap();
 
-        let warning =
-            dirty_elsewhere_warning(root, &[PathBuf::from("wiki/tools/qux.md")]);
+        let warning = dirty_elsewhere_warning(root, &[PathBuf::from("wiki/tools/qux.md")]);
         let w = warning.expect("warning expected for wiki/other-page.md");
         assert!(
             w.contains("other-page.md"),

--- a/crates/lw-mcp/src/lib.rs
+++ b/crates/lw-mcp/src/lib.rs
@@ -593,11 +593,20 @@ impl WikiMcpServer {
                 }
 
                 // Incrementally update the backlink index for this source page.
-                if let Ok(rel) = abs_path.strip_prefix(self.wiki_root.join("wiki"))
-                    && let Err(e) = backlinks::update_for_page(&self.wiki_root, rel)
-                {
-                    tracing::warn!("backlink update failed for {}: {e}", args.path);
-                }
+                // Collect sidecar paths written so they land in the same commit
+                // as the page (Option A, issue #97).
+                let sidecar_paths =
+                    if let Ok(rel) = abs_path.strip_prefix(self.wiki_root.join("wiki")) {
+                        match backlinks::update_for_page(&self.wiki_root, rel) {
+                            Ok(paths) => paths,
+                            Err(e) => {
+                                tracing::warn!("backlink update failed for {}: {e}", args.path);
+                                vec![]
+                            }
+                        }
+                    } else {
+                        vec![]
+                    };
 
                 if let Err(e) = self.searcher.index_page(&args.path, &page) {
                     tracing::warn!("Failed to index page {}: {}", args.path, e);
@@ -606,9 +615,11 @@ impl WikiMcpServer {
                     tracing::warn!("Failed to commit index: {}", e);
                 }
 
+                let mut commit_paths = vec![abs_path.clone()];
+                commit_paths.extend(sidecar_paths);
                 let dirty_warning = match mcp_auto_commit(
                     &self.wiki_root,
-                    std::slice::from_ref(&abs_path),
+                    &commit_paths,
                     CommitAction::Update,
                     &display_path,
                     McpCommitArgs {
@@ -686,20 +697,31 @@ impl WikiMcpServer {
                 // paths can introduce or drop `[[wikilinks]]` just like
                 // overwrite. Without this call, append_section /
                 // upsert_section silently leave the index stale.
-                if let Ok(rel) = abs_path.strip_prefix(self.wiki_root.join("wiki"))
-                    && let Err(e) = backlinks::update_for_page(&self.wiki_root, rel)
-                {
-                    tracing::warn!("backlink update failed for {}: {e}", args.path);
-                }
+                // Collect sidecar paths written so they land in the same
+                // commit as the page (Option A, issue #97).
+                let sidecar_paths_sec =
+                    if let Ok(rel) = abs_path.strip_prefix(self.wiki_root.join("wiki")) {
+                        match backlinks::update_for_page(&self.wiki_root, rel) {
+                            Ok(paths) => paths,
+                            Err(e) => {
+                                tracing::warn!("backlink update failed for {}: {e}", args.path);
+                                vec![]
+                            }
+                        }
+                    } else {
+                        vec![]
+                    };
 
                 let action = if args.mode == "append_section" {
                     CommitAction::Append
                 } else {
                     CommitAction::Upsert
                 };
+                let mut commit_paths_sec = vec![abs_path.clone()];
+                commit_paths_sec.extend(sidecar_paths_sec);
                 let dirty_warning = match mcp_auto_commit(
                     &self.wiki_root,
-                    std::slice::from_ref(&abs_path),
+                    &commit_paths_sec,
                     action,
                     &display_path,
                     McpCommitArgs {
@@ -917,11 +939,23 @@ impl WikiMcpServer {
                     .to_string();
 
                 // Incrementally update the backlink index for this new source page.
-                if let Ok(rel) = abs_path.strip_prefix(self.wiki_root.join("wiki"))
-                    && let Err(e) = backlinks::update_for_page(&self.wiki_root, rel)
-                {
-                    tracing::warn!("backlink update failed for new page {}: {e}", index_path);
-                }
+                // Collect sidecar paths written so they land in the same commit
+                // as the page (Option A, issue #97).
+                let sidecar_paths_new =
+                    if let Ok(rel) = abs_path.strip_prefix(self.wiki_root.join("wiki")) {
+                        match backlinks::update_for_page(&self.wiki_root, rel) {
+                            Ok(paths) => paths,
+                            Err(e) => {
+                                tracing::warn!(
+                                    "backlink update failed for new page {}: {e}",
+                                    index_path
+                                );
+                                vec![]
+                            }
+                        }
+                    } else {
+                        vec![]
+                    };
 
                 if let Err(e) = self.searcher.index_page(&index_path, &page) {
                     tracing::warn!("Failed to index new page {}: {}", index_path, e);
@@ -930,13 +964,16 @@ impl WikiMcpServer {
                     tracing::warn!("Failed to commit index after wiki_new: {}", e);
                 }
 
-                // Auto-commit the new page (issue #38). Pass the
-                // *absolute* page path so `commit_paths` can re-resolve
-                // it against the actual git toplevel — wiki_root is
-                // allowed to be a subdir of a larger repo.
+                // Auto-commit the new page (issue #38). Pass the page path
+                // plus any backlink sidecar paths so they land in the same
+                // commit (Option A, issue #97). Absolute paths so
+                // `commit_paths` can re-resolve against the actual git toplevel
+                // — wiki_root is allowed to be a subdir of a larger repo.
+                let mut commit_paths_new = vec![abs_path.clone()];
+                commit_paths_new.extend(sidecar_paths_new);
                 let dirty_warning = match mcp_auto_commit(
                     &self.wiki_root,
-                    std::slice::from_ref(&abs_path),
+                    &commit_paths_new,
                     CommitAction::Create,
                     &json_path,
                     McpCommitArgs {

--- a/templates/engineering-notes/.gitignore
+++ b/templates/engineering-notes/.gitignore
@@ -1,0 +1,4 @@
+# lw tooling — regenerable artifacts (issue #97)
+# These are local-only; re-generated automatically on demand.
+.lw/search/
+.lw/backlinks/.built

--- a/templates/general/.gitignore
+++ b/templates/general/.gitignore
@@ -1,0 +1,4 @@
+# lw tooling — regenerable artifacts (issue #97)
+# These are local-only; re-generated automatically on demand.
+.lw/search/
+.lw/backlinks/.built

--- a/templates/research-papers/.gitignore
+++ b/templates/research-papers/.gitignore
@@ -1,0 +1,4 @@
+# lw tooling — regenerable artifacts (issue #97)
+# These are local-only; re-generated automatically on demand.
+.lw/search/
+.lw/backlinks/.built


### PR DESCRIPTION
## Summary

- Fixes #97
- Three coordinated changes:
  - **Template gitignore**: `.lw/search/` and `.lw/backlinks/.built` now ignored in all three starter vault templates (`general`, `research-papers`, `engineering-notes`).
  - **Auto-commit (Option A)**: `update_for_page` now returns `Vec<PathBuf>` of written sidecar paths. CLI (`lw new`, `lw write`) and MCP (`wiki_new`, `wiki_write`) auto-commit handlers include these paths in the same commit as the page — so sidecar evolution is preserved in `git log`.
  - **Defensive filter**: `dirty_elsewhere_warning` (in `git.rs`) skips porcelain entries under `.lw/search/` and the `.lw/backlinks/.built` sentinel regardless of gitignore state, covering existing vaults that may already have these tracked.

## Acceptance Criteria Evidence

- [x] **`templates/*/.gitignore`** includes `.lw/search/` and `.lw/backlinks/.built`
  - `templates/general/.gitignore:3-4`
  - `templates/research-papers/.gitignore:3-4`
  - `templates/engineering-notes/.gitignore:3-4`

- [x] **No dirty-warning after fresh `lw init` + `lw new`** — Smoke output:
  ```
  Added workspace 'smoke4' at .../vault4   initialized from template 'general'
  === git status BEFORE lw new ===
  (empty — .lw/search/ and .lw/backlinks/.built are gitignored)
  === Running lw new ===
  Committed wiki/notes/foo.md (create)
  wrote wiki/notes/foo.md
  === git status AFTER lw new ===
  (empty — completely clean)
  ```

- [x] **`git status --porcelain` clean under `.lw/` after auto-commit** — smoke vault shows empty porcelain output after `lw new`. Sidecar paths (when any wikilinks exist) are included in the same commit as the page.

- [x] **Unit tests assert `.lw/*` entries filtered** — `crates/lw-core/src/git.rs::tests`:
  - `dirty_warning_ignores_lw_search_files` — `?? .lw/search/segment.idx` must NOT trigger warning
  - `dirty_warning_ignores_lw_backlinks_built_sentinel` — `?? .lw/backlinks/.built` must NOT trigger warning
  - `dirty_warning_fires_for_non_lw_dirty_file_positive_control` — `?? wiki/other-page.md` DOES trigger (positive control); `.lw/` entries in same test are confirmed absent from warning message

- [x] **Migration note** — `CLAUDE.md` section "Migration Notes" (line ~196): `git rm -r --cached .lw/search/ && git rm --cached .lw/backlinks/.built` with explanation

## Smoke Output (verbatim, no dirty-warning)

```
SMOKE dir: /var/folders/cs/h8hgrbpj2tgb4x4jhjhm54h00000gn/T/tmp.6H3mtlo8Nn/vault4
Added workspace 'smoke4' at ...   initialized from template 'general'
=== Simulate Tantivy index + sentinel (gitignore should exclude them) ===
=== git status --porcelain BEFORE lw new (should NOT show .lw/ artifacts) ===
(no output)
=== Running lw new (must produce NO dirty-warning) ===
Committed wiki/notes/foo.md (create)
wrote wiki/notes/foo.md
=== git status --porcelain AFTER lw new (must be clean) ===
(no output)
=== git log --oneline ===
c0ff57e docs(wiki): create wiki/notes/foo.md
ca5faff scaffold
=== DONE ===
```

## Test Plan

- [x] 3 new unit tests added (Red→Green TDD): `dirty_warning_ignores_lw_search_files`, `dirty_warning_ignores_lw_backlinks_built_sentinel`, `dirty_warning_fires_for_non_lw_dirty_file_positive_control`
- [x] Full workspace test suite green: 474 passed (0 failed)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Hand-run smoke against throwaway vault (`--template general`) — completely clean
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)