### PR TITLE
fix(ci): switch release-please to release-type=simple for workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.2.6"
+version = "0.2.6" # x-release-please-version
 edition = "2024"
 license = "MIT"
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
-  "release-type": "rust",
+  "release-type": "simple",
   "include-v-in-tag": true,
   "include-component-in-tag": false,
   "packages": {


### PR DESCRIPTION
## Summary

The first release-please run after #104 merged failed with:

```
##[error]release-please failed: value at path package.version is not tagged
```

despite correctly computing the next version as `v0.3.0`:

```
versions map: Map(3) { 'lw-core' => 0.3.0, 'lw-cli' => 0.3.0, 'lw-mcp' => 0.3.0 }
```

**Root cause.** `release-type: rust` expects each member crate's `Cargo.toml` to have an explicit `[package].version = "..."` line to write the bump back to. This workspace uses `version.workspace = true` in every member, with the canonical version in root `[workspace.package].version`. release-please's rust strategy doesn't support that inheritance pattern.

## Fix

Two-line change:

1. `release-please-config.json`: `release-type: rust` → `release-type: simple`
2. `Cargo.toml`: annotate the canonical version line with ` # x-release-please-version`

`simple` does regex replacement on annotated lines. The bump computation (conventional commits → semver) is unchanged — the failed run already produced the correct v0.3.0 result.

## Caveat

`simple` does not auto-update `Cargo.lock`. The release-please PR will have a stale lockfile; the maintainer runs `cargo update --workspace` once on the PR branch before merging. One manual step per release — acceptable tradeoff to avoid restructuring the workspace.

## Verification

After this PR merges, the release-please workflow will fire on the merge commit and (assuming this fix is correct) open a v0.3.0 Release PR.

## Test Plan

- [ ] CI passes
- [ ] After merge, release-please workflow run succeeds
- [ ] Release PR opened titled e.g. `chore(main): release 0.3.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)