### PR TITLE
fix(ci): release-please should scan Cargo.toml for version annotation

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,7 +6,10 @@
   "packages": {
     ".": {
       "package-name": "llm-wiki",
-      "changelog-path": "CHANGELOG.md"
+      "changelog-path": "CHANGELOG.md",
+      "extra-files": [
+        "Cargo.toml"
+      ]
     }
   }
 }


### PR DESCRIPTION
## Summary

Follow-up to #105. PR #106 (release-please's first successful Release PR) only updates `.release-please-manifest.json` and `CHANGELOG.md` — but **NOT** `Cargo.toml`. Reason: `release-type: simple` only scans files listed under `extra-files` for `# x-release-please-version` annotations.

The annotation we placed in `Cargo.toml` (`[workspace.package].version = \"0.2.6\" # x-release-please-version` from #105) is currently being ignored.

## Fix

Add `"extra-files": ["Cargo.toml"]` to the package config in `release-please-config.json`. release-please will re-process PR #106 on the next push to main and add the Cargo.toml bump to the existing release PR.

## Test Plan

- [ ] CI passes
- [ ] After merge, release-please re-runs and PR #106's diff also includes the `Cargo.toml` version bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)