### PR TITLE
chore(ci): add workflow_dispatch fallback to release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,12 +3,19 @@ name: Release
 on:
   push:
     tags: ["v*"]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to release (e.g. v0.3.0). Must already exist on origin."
+        required: true
+        type: string
 
 permissions:
   contents: write
 
 env:
   CARGO_TERM_COLOR: always
+  RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
 
 jobs:
   build:
@@ -31,6 +38,8 @@ jobs:
             asset: lw-aarch64-darwin.tar.gz
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ env.RELEASE_TAG }}
 
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -64,8 +73,7 @@ jobs:
           cp installer/install.sh "$STAGE/installer/"
           cp installer/uninstall.sh "$STAGE/installer/"
           chmod +x "$STAGE/installer/install.sh" "$STAGE/installer/uninstall.sh"
-          # VERSION = tag without leading 'v'
-          echo "${GITHUB_REF_NAME#v}" > "$STAGE/VERSION"
+          echo "${RELEASE_TAG#v}" > "$STAGE/VERSION"
 
       - name: Package tarball
         run: |
@@ -83,6 +91,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ env.RELEASE_TAG }}
       - name: Stage installer + sha256
         run: |
           mkdir -p dist
@@ -101,6 +111,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ env.RELEASE_TAG }}
 
       - uses: actions/download-artifact@v8
         with:
@@ -110,5 +122,6 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ env.RELEASE_TAG }}
           generate_release_notes: true
           files: artifacts/*


### PR DESCRIPTION
## Why

release-please's first cut of v0.3.0 (#106 merge) succeeded — the **tag** was created at `a75c7cb` — but `release.yml` did **not** fire on that tag push. Known GitHub Actions policy: workflows triggered by the default `GITHUB_TOKEN` (which release-please-action uses) do not trigger other workflows.

## Fix

Add `workflow_dispatch` with a `tag` input. A workflow-level `RELEASE_TAG` env (`inputs.tag || github.ref_name`) normalizes manual-dispatch and tag-push into one variable. All three jobs check out that ref and pass it as `tag_name` to `softprops/action-gh-release`. Existing tag-push behavior preserved.

## After merging

`gh workflow run release.yml -f tag=v0.3.0` fires the build for the existing v0.3.0 tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)