### PR TITLE
chore(ci): use RELEASE_PLEASE_TOKEN PAT for tag-triggered downstream workflows

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,3 +14,5 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: googleapis/release-please-action@v4
+        with:
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}


### PR DESCRIPTION
Wires release-please-action to use the RELEASE_PLEASE_TOKEN repo secret. Tags pushed via the PAT count as regular user pushes and trigger `release.yml` automatically — no more manual `gh workflow run` for normal releases.