### PR TITLE
feat(core): alias index foundation (#100)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1055,7 +1055,7 @@ dependencies = [
 
 [[package]]
 name = "lw-cli"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1078,7 +1078,7 @@ dependencies = [
 
 [[package]]
 name = "lw-core"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "comrak",
  "gray_matter",
@@ -1094,11 +1094,12 @@ dependencies = [
  "tokio",
  "toml",
  "tracing",
+ "unicode-normalization",
 ]
 
 [[package]]
 name = "lw-mcp"
-version = "0.2.6"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "lw-core",

--- a/crates/lw-core/Cargo.toml
+++ b/crates/lw-core/Cargo.toml
@@ -17,6 +17,7 @@ tracing = { workspace = true }
 comrak = { version = "0.36", default-features = false }
 tempfile = "3"
 time = { version = "0.3", features = ["formatting", "macros", "local-offset"] }
+unicode-normalization = "0.1"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/lw-core/src/aliases.rs
+++ b/crates/lw-core/src/aliases.rs
@@ -5,16 +5,34 @@
 //! `.lw/aliases/index.json`. Foundation for #42 unlinked-mention detection
 //! (#101 matcher → #102 lint rule + #103 MCP suggestions).
 //!
-//! Stub — implementation lands as part of issue #100. The signatures here are
-//! the public contract that tests pin down.
+//! Storage shape mirrors `backlinks` in spirit but inverts the layout: a
+//! single index file per vault rather than per-target sidecars, because the
+//! lookup direction is `term → pages` (one-to-many flat) rather than
+//! `target → sources` (many-to-one). The sentinel + `.built` short-circuit
+//! pattern, the `update_for_page` returning `Vec<PathBuf>` for Option A
+//! auto-commit (issue #97 / #99), and the `ensure_index` lazy-build behavior
+//! all match `backlinks` so callers downstream can treat the two indexes
+//! symmetrically.
 
 use crate::Result;
+use crate::backlinks::slug_from_wiki_path;
+use crate::fs::{atomic_write, read_page};
+use crate::page::Page;
 use serde::{Deserialize, Serialize};
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
+use unicode_normalization::UnicodeNormalization;
 
 /// Relative path (from wiki root) to the alias-index sidecar directory.
 pub const ALIASES_DIR: &str = ".lw/aliases";
+
+/// Filename of the persisted index inside `ALIASES_DIR`.
+const INDEX_FILE: &str = "index.json";
+
+/// Sentinel written by `rebuild_index`/`save_index` so `ensure_index` can
+/// short-circuit without re-walking the wiki — same role as the backlinks
+/// `.built` marker (see `backlinks::ensure_index`).
+const BUILT_SENTINEL: &str = ".built";
 
 /// One page that a normalized term resolves to.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
@@ -38,37 +56,193 @@ pub struct AliasIndex {
 impl AliasIndex {
     /// Look up pages that match the given term. The argument is normalized
     /// internally so callers can pass raw text without preprocessing.
-    pub fn lookup(&self, _term: &str) -> &[PageRef] {
-        unimplemented!("issue #100")
+    pub fn lookup(&self, term: &str) -> &[PageRef] {
+        let normalized = normalize(term);
+        self.terms
+            .get(&normalized)
+            .map(Vec::as_slice)
+            .unwrap_or(&[])
     }
 }
 
-/// Normalize a term for indexing/lookup: lowercase + Unicode NFC.
-pub fn normalize(_term: &str) -> String {
-    unimplemented!("issue #100")
+/// Normalize a term for indexing/lookup: Unicode NFC + lowercase. Applied to
+/// every string before it enters the term map and every lookup query.
+pub fn normalize(term: &str) -> String {
+    // NFC first so combining sequences collapse before case folding.
+    term.nfc().collect::<String>().to_lowercase()
 }
 
 /// Walk `wiki_root/wiki/` and build the in-memory alias index.
-pub fn build_index(_wiki_root: &Path) -> Result<AliasIndex> {
-    unimplemented!("issue #100")
+pub fn build_index(wiki_root: &Path) -> Result<AliasIndex> {
+    let mut index = AliasIndex::default();
+    let wiki_dir = wiki_root.join("wiki");
+    if !wiki_dir.exists() {
+        return Ok(index);
+    }
+    for abs_path in collect_md_files(&wiki_dir)? {
+        let rel = abs_path
+            .strip_prefix(&wiki_dir)
+            .map_err(|e| crate::WikiError::Io(std::io::Error::other(e.to_string())))?;
+        let page = match read_page(&abs_path) {
+            Ok(p) => p,
+            // Skip unreadable / malformed pages — they show up via lint, not
+            // here. Same forgiving behavior as backlinks::build_index.
+            Err(_) => continue,
+        };
+        let (page_ref, terms) = page_terms(rel, &page);
+        for term in terms {
+            index.terms.entry(term).or_default().push(page_ref.clone());
+        }
+    }
+    Ok(index)
 }
 
 /// Rebuild the full index from scratch and persist it to
 /// `.lw/aliases/index.json`. Writes the `.built` sentinel on success.
-pub fn rebuild_index(_wiki_root: &Path) -> Result<()> {
-    unimplemented!("issue #100")
+pub fn rebuild_index(wiki_root: &Path) -> Result<()> {
+    let index = build_index(wiki_root)?;
+    save_index(wiki_root, &index)?;
+    Ok(())
 }
 
 /// Ensure the alias index has been built. Checks the `.built` sentinel and
 /// runs `rebuild_index` only when missing — mirrors `backlinks::ensure_index`.
-pub fn ensure_index(_wiki_root: &Path) -> Result<()> {
-    unimplemented!("issue #100")
+pub fn ensure_index(wiki_root: &Path) -> Result<()> {
+    let sentinel = wiki_root.join(ALIASES_DIR).join(BUILT_SENTINEL);
+    if !sentinel.exists() {
+        rebuild_index(wiki_root)?;
+    }
+    Ok(())
 }
 
 /// Incrementally update the alias index for a single source page.
-/// Returns the sidecar paths written so callers can include them in the same
-/// auto-commit as the page (Option A pattern from #97; mirrors the
-/// `update_after_write` plumbing established by #99).
-pub fn update_for_page(_wiki_root: &Path, _source_rel: &Path) -> Result<Vec<PathBuf>> {
-    unimplemented!("issue #100")
+///
+/// Algorithm:
+/// 1. Load the persisted index (or start empty).
+/// 2. Strip every existing `PageRef` whose slug matches the source page —
+///    this clears stale entries from prior titles/aliases regardless of what
+///    they were.
+/// 3. If the source file still exists, recompute its current terms and
+///    re-insert them.
+/// 4. Persist the updated index.
+///
+/// Returns the absolute paths written so callers can include them in the
+/// same auto-commit as the page (Option A pattern from #97; mirrors the
+/// `update_after_write` plumbing established by #99). The `.built` sentinel
+/// is intentionally NOT included — `is_lw_ephemeral` filters it out of
+/// dirty-warnings and it must not be committed.
+pub fn update_for_page(wiki_root: &Path, source_rel: &Path) -> Result<Vec<PathBuf>> {
+    let mut index = load_index(wiki_root)?.unwrap_or_default();
+    let source_slug = slug_from_wiki_path(source_rel).unwrap_or_default();
+
+    // Strip stale entries for this page. Done unconditionally so a rename
+    // or alias-drop in the new version cleanly leaves the old terms behind.
+    if !source_slug.is_empty() {
+        for entries in index.terms.values_mut() {
+            entries.retain(|p| p.slug != source_slug);
+        }
+        index.terms.retain(|_, v| !v.is_empty());
+    }
+
+    // Re-insert if the page still exists on disk.
+    let abs_path = wiki_root.join("wiki").join(source_rel);
+    if abs_path.exists()
+        && let Ok(page) = read_page(&abs_path)
+    {
+        let (page_ref, terms) = page_terms(source_rel, &page);
+        for term in terms {
+            index.terms.entry(term).or_default().push(page_ref.clone());
+        }
+    }
+
+    let written = save_index(wiki_root, &index)?;
+    Ok(vec![written])
+}
+
+// ─── Internal helpers ────────────────────────────────────────────────────────
+
+/// Compute the `PageRef` and the deduped, normalized term list for a single
+/// page given its path relative to `wiki/`.
+fn page_terms(rel_path: &Path, page: &Page) -> (PageRef, Vec<String>) {
+    let slug = slug_from_wiki_path(rel_path).unwrap_or_default();
+    let path = format!("wiki/{}", rel_path.to_string_lossy().replace('\\', "/"));
+    let page_ref = PageRef {
+        slug: slug.clone(),
+        title: page.title.clone(),
+        path,
+    };
+
+    let mut terms = Vec::new();
+    if !slug.is_empty() {
+        terms.push(normalize(&slug));
+    }
+    if !page.title.is_empty() {
+        terms.push(normalize(&page.title));
+    }
+    for alias in &page.aliases {
+        if !alias.is_empty() {
+            terms.push(normalize(alias));
+        }
+    }
+    // Dedup so a page whose normalized title equals its slug doesn't
+    // double-count itself in any single term bucket.
+    terms.sort();
+    terms.dedup();
+    (page_ref, terms)
+}
+
+/// Persist the index to `.lw/aliases/index.json` and write the `.built`
+/// sentinel. Returns the index file path so callers (auto-commit) can pin it.
+fn save_index(wiki_root: &Path, index: &AliasIndex) -> Result<PathBuf> {
+    let dir = wiki_root.join(ALIASES_DIR);
+    std::fs::create_dir_all(&dir)
+        .map_err(|e| crate::WikiError::Io(std::io::Error::other(e.to_string())))?;
+    let json = serde_json::to_vec_pretty(index)
+        .map_err(|e| crate::WikiError::Io(std::io::Error::other(e.to_string())))?;
+    let index_path = dir.join(INDEX_FILE);
+    atomic_write(&index_path, &json)?;
+
+    // Sentinel is written AFTER the index file so a partial save cannot
+    // falsely advertise itself as built. Empty body — only existence matters.
+    let sentinel = dir.join(BUILT_SENTINEL);
+    atomic_write(&sentinel, b"")?;
+    Ok(index_path)
+}
+
+/// Load the persisted index, returning `None` when the file is absent.
+fn load_index(wiki_root: &Path) -> Result<Option<AliasIndex>> {
+    let path = wiki_root.join(ALIASES_DIR).join(INDEX_FILE);
+    if !path.exists() {
+        return Ok(None);
+    }
+    let raw = std::fs::read_to_string(&path)
+        .map_err(|e| crate::WikiError::Io(std::io::Error::other(e.to_string())))?;
+    let index: AliasIndex = serde_json::from_str(&raw)
+        .map_err(|e| crate::WikiError::Io(std::io::Error::other(e.to_string())))?;
+    Ok(Some(index))
+}
+
+fn collect_md_files(dir: &Path) -> Result<Vec<PathBuf>> {
+    let mut out = Vec::new();
+    walk(dir, &mut out)?;
+    Ok(out)
+}
+
+fn walk(dir: &Path, out: &mut Vec<PathBuf>) -> Result<()> {
+    let read_dir = std::fs::read_dir(dir)
+        .map_err(|e| crate::WikiError::Io(std::io::Error::other(e.to_string())))?;
+    for entry in read_dir {
+        let entry =
+            entry.map_err(|e| crate::WikiError::Io(std::io::Error::other(e.to_string())))?;
+        let path = entry.path();
+        let file_type = entry
+            .file_type()
+            .map_err(|e| crate::WikiError::Io(std::io::Error::other(e.to_string())))?;
+        if file_type.is_dir() {
+            walk(&path, out)?;
+        } else if file_type.is_file() && path.extension().and_then(|e| e.to_str()) == Some("md") {
+            out.push(path);
+        }
+    }
+    Ok(())
 }

--- a/crates/lw-core/src/aliases.rs
+++ b/crates/lw-core/src/aliases.rs
@@ -54,6 +54,13 @@ pub struct AliasIndex {
 }
 
 impl AliasIndex {
+    /// Build an in-memory index by walking `wiki_root/wiki/`. Equivalent to
+    /// the free `build_index` function — provided as an associated function
+    /// so callers can use `AliasIndex::build(...)` per the issue #100 spec.
+    pub fn build(wiki_root: &Path) -> Result<Self> {
+        build_index(wiki_root)
+    }
+
     /// Look up pages that match the given term. The argument is normalized
     /// internally so callers can pass raw text without preprocessing.
     pub fn lookup(&self, term: &str) -> &[PageRef] {

--- a/crates/lw-core/src/aliases.rs
+++ b/crates/lw-core/src/aliases.rs
@@ -105,10 +105,14 @@ pub fn build_index(wiki_root: &Path) -> Result<AliasIndex> {
 }
 
 /// Rebuild the full index from scratch and persist it to
-/// `.lw/aliases/index.json`. Writes the `.built` sentinel on success.
+/// `.lw/aliases/index.json`. Writes the `.built` sentinel on success — only
+/// `rebuild_index` writes the sentinel; incremental updates do not, so a
+/// partial `update_for_page` against a fresh vault cannot fool a later
+/// `ensure_index` into short-circuiting.
 pub fn rebuild_index(wiki_root: &Path) -> Result<()> {
     let index = build_index(wiki_root)?;
     save_index(wiki_root, &index)?;
+    write_built_sentinel(wiki_root)?;
     Ok(())
 }
 
@@ -140,13 +144,16 @@ pub fn ensure_index(wiki_root: &Path) -> Result<()> {
 /// dirty-warnings and it must not be committed.
 pub fn update_for_page(wiki_root: &Path, source_rel: &Path) -> Result<Vec<PathBuf>> {
     let mut index = load_index(wiki_root)?.unwrap_or_default();
-    let source_slug = slug_from_wiki_path(source_rel).unwrap_or_default();
+    // Identity in the index is the full `wiki/<cat>/<file>.md` path, NOT the
+    // filename slug — `lw new` permits two pages with the same filename in
+    // different categories. Stripping by slug would wipe sibling entries.
+    let source_path = wiki_path(source_rel);
 
     // Strip stale entries for this page. Done unconditionally so a rename
     // or alias-drop in the new version cleanly leaves the old terms behind.
-    if !source_slug.is_empty() {
+    if !source_path.is_empty() {
         for entries in index.terms.values_mut() {
-            entries.retain(|p| p.slug != source_slug);
+            entries.retain(|p| p.path != source_path);
         }
         index.terms.retain(|_, v| !v.is_empty());
     }
@@ -162,21 +169,30 @@ pub fn update_for_page(wiki_root: &Path, source_rel: &Path) -> Result<Vec<PathBu
         }
     }
 
+    // Note: do NOT write `.built` here. Incremental updates may run before
+    // any full build (e.g. on a fresh vault that just had its first page
+    // edited via MCP), and a sentinel from a partial save would cause a
+    // later `ensure_index` to skip the rebuild and miss every other page.
     let written = save_index(wiki_root, &index)?;
     Ok(vec![written])
 }
 
 // ─── Internal helpers ────────────────────────────────────────────────────────
 
+/// Convert a wiki-relative path (e.g. `tools/foo.md`) to its canonical
+/// `wiki/...` form used throughout the index for page identity.
+fn wiki_path(rel_path: &Path) -> String {
+    format!("wiki/{}", rel_path.to_string_lossy().replace('\\', "/"))
+}
+
 /// Compute the `PageRef` and the deduped, normalized term list for a single
 /// page given its path relative to `wiki/`.
 fn page_terms(rel_path: &Path, page: &Page) -> (PageRef, Vec<String>) {
     let slug = slug_from_wiki_path(rel_path).unwrap_or_default();
-    let path = format!("wiki/{}", rel_path.to_string_lossy().replace('\\', "/"));
     let page_ref = PageRef {
         slug: slug.clone(),
         title: page.title.clone(),
-        path,
+        path: wiki_path(rel_path),
     };
 
     let mut terms = Vec::new();
@@ -198,8 +214,11 @@ fn page_terms(rel_path: &Path, page: &Page) -> (PageRef, Vec<String>) {
     (page_ref, terms)
 }
 
-/// Persist the index to `.lw/aliases/index.json` and write the `.built`
-/// sentinel. Returns the index file path so callers (auto-commit) can pin it.
+/// Persist the index to `.lw/aliases/index.json`. Does NOT write the
+/// `.built` sentinel — that is `rebuild_index`'s exclusive responsibility,
+/// so an incremental `update_for_page` against a fresh vault does not
+/// produce a partial-but-marked-built index. Returns the index file path so
+/// callers (auto-commit) can pin it.
 fn save_index(wiki_root: &Path, index: &AliasIndex) -> Result<PathBuf> {
     let dir = wiki_root.join(ALIASES_DIR);
     std::fs::create_dir_all(&dir)
@@ -208,12 +227,19 @@ fn save_index(wiki_root: &Path, index: &AliasIndex) -> Result<PathBuf> {
         .map_err(|e| crate::WikiError::Io(std::io::Error::other(e.to_string())))?;
     let index_path = dir.join(INDEX_FILE);
     atomic_write(&index_path, &json)?;
-
-    // Sentinel is written AFTER the index file so a partial save cannot
-    // falsely advertise itself as built. Empty body — only existence matters.
-    let sentinel = dir.join(BUILT_SENTINEL);
-    atomic_write(&sentinel, b"")?;
     Ok(index_path)
+}
+
+/// Write the `.built` sentinel inside `ALIASES_DIR`. Called only by
+/// `rebuild_index` after a successful full save — its existence signals
+/// "the index reflects every page in the vault, ensure_index can
+/// short-circuit". Body is intentionally empty; existence is the signal.
+fn write_built_sentinel(wiki_root: &Path) -> Result<()> {
+    let dir = wiki_root.join(ALIASES_DIR);
+    std::fs::create_dir_all(&dir)
+        .map_err(|e| crate::WikiError::Io(std::io::Error::other(e.to_string())))?;
+    atomic_write(&dir.join(BUILT_SENTINEL), b"")?;
+    Ok(())
 }
 
 /// Load the persisted index, returning `None` when the file is absent.

--- a/crates/lw-core/src/aliases.rs
+++ b/crates/lw-core/src/aliases.rs
@@ -1,0 +1,74 @@
+//! Title/alias index — answers "which page does this term refer to?"
+//!
+//! Walks `wiki/`, indexes each page's `title` + `aliases:` frontmatter list +
+//! slugified filename under a normalized term, and persists the result to
+//! `.lw/aliases/index.json`. Foundation for #42 unlinked-mention detection
+//! (#101 matcher → #102 lint rule + #103 MCP suggestions).
+//!
+//! Stub — implementation lands as part of issue #100. The signatures here are
+//! the public contract that tests pin down.
+
+use crate::Result;
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+
+/// Relative path (from wiki root) to the alias-index sidecar directory.
+pub const ALIASES_DIR: &str = ".lw/aliases";
+
+/// One page that a normalized term resolves to.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PageRef {
+    /// Filename stem (e.g. `transformer-architecture`).
+    pub slug: String,
+    /// Original page title with casing preserved.
+    pub title: String,
+    /// Path with `wiki/` prefix (e.g. `wiki/architecture/transformer-architecture.md`).
+    pub path: String,
+}
+
+/// In-memory `term → pages` map. Terms are normalized via [`normalize`].
+/// Multiple pages may map to the same term; the consumer (lint, matcher, MCP)
+/// decides how to handle ambiguity.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AliasIndex {
+    pub terms: BTreeMap<String, Vec<PageRef>>,
+}
+
+impl AliasIndex {
+    /// Look up pages that match the given term. The argument is normalized
+    /// internally so callers can pass raw text without preprocessing.
+    pub fn lookup(&self, _term: &str) -> &[PageRef] {
+        unimplemented!("issue #100")
+    }
+}
+
+/// Normalize a term for indexing/lookup: lowercase + Unicode NFC.
+pub fn normalize(_term: &str) -> String {
+    unimplemented!("issue #100")
+}
+
+/// Walk `wiki_root/wiki/` and build the in-memory alias index.
+pub fn build_index(_wiki_root: &Path) -> Result<AliasIndex> {
+    unimplemented!("issue #100")
+}
+
+/// Rebuild the full index from scratch and persist it to
+/// `.lw/aliases/index.json`. Writes the `.built` sentinel on success.
+pub fn rebuild_index(_wiki_root: &Path) -> Result<()> {
+    unimplemented!("issue #100")
+}
+
+/// Ensure the alias index has been built. Checks the `.built` sentinel and
+/// runs `rebuild_index` only when missing — mirrors `backlinks::ensure_index`.
+pub fn ensure_index(_wiki_root: &Path) -> Result<()> {
+    unimplemented!("issue #100")
+}
+
+/// Incrementally update the alias index for a single source page.
+/// Returns the sidecar paths written so callers can include them in the same
+/// auto-commit as the page (Option A pattern from #97; mirrors the
+/// `update_after_write` plumbing established by #99).
+pub fn update_for_page(_wiki_root: &Path, _source_rel: &Path) -> Result<Vec<PathBuf>> {
+    unimplemented!("issue #100")
+}

--- a/crates/lw-core/src/fs.rs
+++ b/crates/lw-core/src/fs.rs
@@ -303,6 +303,7 @@ pub fn new_page(
         generator: None,
         related: None,
         status: None,
+        aliases: vec![],
         body: template,
     };
 

--- a/crates/lw-core/src/git.rs
+++ b/crates/lw-core/src/git.rs
@@ -558,12 +558,14 @@ pub fn auto_commit(
 /// dirty-elsewhere warning.
 ///
 /// Ephemeral paths (issue #97):
-/// - `.lw/search/*`   — Tantivy index files; fully regenerable, never user content.
+/// - `.lw/search/*`         — Tantivy index files; fully regenerable, never user content.
 /// - `.lw/backlinks/.built` — sentinel written by `rebuild_index`; local-only.
+/// - `.lw/aliases/.built`   — sentinel written by `aliases::rebuild_index`; local-only (#100).
 ///
-/// Note: `.lw/backlinks/*.json` sidecar files are NOT ephemeral — they carry
-/// the link-evolution audit trail and are auto-committed alongside the page
-/// (Option A per issue #97). They are intentionally NOT filtered here.
+/// Note: `.lw/backlinks/*.json` and `.lw/aliases/index.json` are NOT ephemeral
+/// — they carry the link-evolution audit trail and are auto-committed
+/// alongside the page (Option A per issue #97). They are intentionally NOT
+/// filtered here.
 fn is_lw_ephemeral(path_part: &str) -> bool {
     // Tantivy index files: anything under .lw/search/
     // The constant crate::INDEX_DIR == ".lw/search".
@@ -571,12 +573,13 @@ fn is_lw_ephemeral(path_part: &str) -> bool {
     if path_part.starts_with(&index_prefix) || path_part.contains(&format!("/{index_prefix}")) {
         return true;
     }
-    // Backlinks built sentinel: .lw/backlinks/.built
-    // Matches regardless of leading directory, to handle wiki-root-in-subdir.
-    // crate::backlinks::BACKLINKS_DIR == ".lw/backlinks"
-    let sentinel_suffix = format!("{}/{}", crate::backlinks::BACKLINKS_DIR, ".built");
-    if path_part == sentinel_suffix || path_part.ends_with(&format!("/{sentinel_suffix}")) {
-        return true;
+    // Built sentinels for the ephemeral-marker pattern, matched regardless
+    // of leading directory to handle wiki-root-in-subdir.
+    for dir in [crate::backlinks::BACKLINKS_DIR, crate::aliases::ALIASES_DIR] {
+        let suffix = format!("{dir}/.built");
+        if path_part == suffix || path_part.ends_with(&format!("/{suffix}")) {
+            return true;
+        }
     }
     false
 }

--- a/crates/lw-core/src/git.rs
+++ b/crates/lw-core/src/git.rs
@@ -1281,6 +1281,42 @@ mod tests {
     }
 
     #[test]
+    fn dirty_warning_ignores_lw_aliases_built_sentinel() {
+        // `.lw/aliases/.built` is the sentinel for the alias index (#100).
+        // It must be silently ignored in the dirty-warning, mirroring the
+        // backlinks treatment.
+        let tmp = TempDir::new().unwrap();
+        let root = tmp.path();
+        init_repo(root);
+
+        fs::write(root.join("README.md"), "x").unwrap();
+        Command::new("git")
+            .args(["add", "README.md"])
+            .current_dir(root)
+            .output()
+            .unwrap();
+        Command::new("git")
+            .args(["commit", "-m", "init"])
+            .current_dir(root)
+            .output()
+            .unwrap();
+
+        // Simulate the aliases built sentinel.
+        fs::create_dir_all(root.join(".lw/aliases")).unwrap();
+        fs::write(root.join(".lw/aliases/.built"), "").unwrap();
+
+        // Wiki page being committed.
+        fs::create_dir_all(root.join("wiki/tools")).unwrap();
+        fs::write(root.join("wiki/tools/quux.md"), "page").unwrap();
+
+        let warning = dirty_elsewhere_warning(root, &[PathBuf::from("wiki/tools/quux.md")]);
+        assert!(
+            warning.is_none(),
+            ".lw/aliases/.built must not trigger dirty-warning; got: {warning:?}"
+        );
+    }
+
+    #[test]
     fn dirty_warning_fires_for_non_lw_dirty_file_positive_control() {
         // Positive control: even when .lw/ ephemeral paths are present, an
         // unrelated dirty file outside .lw/ must STILL trigger the warning.

--- a/crates/lw-core/src/import.rs
+++ b/crates/lw-core/src/import.rs
@@ -75,6 +75,7 @@ pub fn parse_twitter_json(json_str: &str, limit: Option<usize>) -> Result<Vec<Im
             generator: Some("lw-import".to_string()),
             related: None,
             status: None,
+            aliases: vec![],
             body: body.clone(),
         };
 

--- a/crates/lw-core/src/lib.rs
+++ b/crates/lw-core/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod aliases;
 pub mod backlinks;
 pub mod error;
 pub mod fs;

--- a/crates/lw-core/src/page.rs
+++ b/crates/lw-core/src/page.rs
@@ -21,6 +21,12 @@ pub struct Frontmatter {
     /// `archived`. Stored verbatim and indexed for `lw query --status` filtering.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub status: Option<String>,
+    /// Alternate names for this page. Free-form list, no schema validation.
+    /// Consumed by the alias index (`lw_core::aliases`) so cross-page references
+    /// like `[[short-name]]` and unlinked-mention detection (#42) can resolve to
+    /// the canonical page.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub aliases: Vec<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -35,6 +41,8 @@ pub struct Page {
     /// Optional lifecycle status (`draft`/`published`/`archived`/etc.). See
     /// [`Frontmatter::status`].
     pub status: Option<String>,
+    /// Alternate names for this page. See [`Frontmatter::aliases`].
+    pub aliases: Vec<String>,
     pub body: String,
 }
 
@@ -49,6 +57,7 @@ impl Page {
             generator: None,
             related: None,
             status: None,
+            aliases: vec![],
             body: body.to_string(),
         }
     }
@@ -80,6 +89,7 @@ impl Page {
             generator: fm.generator,
             related: fm.related,
             status: fm.status,
+            aliases: fm.aliases,
             body: parsed.content,
         })
     }
@@ -94,6 +104,7 @@ impl Page {
             generator: self.generator.clone(),
             related: self.related.clone(),
             status: self.status.clone(),
+            aliases: self.aliases.clone(),
         }
     }
 

--- a/crates/lw-core/tests/aliases_test.rs
+++ b/crates/lw-core/tests/aliases_test.rs
@@ -1,0 +1,509 @@
+//! Integration tests for `lw_core::aliases` — see issue #100.
+//!
+//! Covers the acceptance bullets of #100 (term sources, normalization,
+//! persistence, sentinel short-circuit, incremental updates) and the unicode
+//! / multi-word edge cases called out in the implementation notes.
+
+mod common;
+
+use common::{TestWiki, make_page};
+use lw_core::aliases::{
+    ALIASES_DIR, AliasIndex, PageRef, build_index, ensure_index, normalize, rebuild_index,
+    update_for_page,
+};
+use std::path::Path;
+
+// ─── Normalization (lowercase + NFC) ─────────────────────────────────────────
+
+#[test]
+fn normalize_lowercases_ascii() {
+    assert_eq!(normalize("Flash Attention"), "flash attention");
+    assert_eq!(normalize("FOO"), "foo");
+    assert_eq!(normalize("MixedCase"), "mixedcase");
+}
+
+#[test]
+fn normalize_is_idempotent() {
+    let once = normalize("Tantivy");
+    let twice = normalize(&once);
+    assert_eq!(once, twice, "double normalization must be a no-op");
+}
+
+#[test]
+fn normalize_preserves_cjk_characters_unchanged() {
+    // CJK has no case; lowercasing must leave the characters intact.
+    let input = "创业指南";
+    assert_eq!(normalize(input), input);
+}
+
+#[test]
+fn normalize_collapses_decomposed_unicode_to_nfc() {
+    // 'é' can be one precomposed code point (U+00E9) OR 'e' + U+0301 (combining
+    // acute accent). NFC normalization collapses the second form to the first.
+    let decomposed = "Cafe\u{0301}"; // C-a-f-e-´ (4 chars + combining)
+    let nfc = "Café"; // C-a-f-é (precomposed)
+    assert_eq!(
+        normalize(decomposed),
+        normalize(nfc),
+        "decomposed and precomposed must normalize to the same string"
+    );
+    // The normalized output must be the precomposed (NFC) form.
+    assert_eq!(normalize(decomposed), nfc.to_lowercase());
+}
+
+// ─── Build: term sources (title + aliases + slug) ────────────────────────────
+
+#[test]
+fn build_index_uses_title_as_term() {
+    let wiki = TestWiki::new();
+    let page = make_page("Transformer Architecture", &["arch"], "normal", "body");
+    wiki.write_page("architecture/transformer-architecture.md", &page);
+
+    let index = build_index(wiki.root()).expect("build");
+    let hits = index.lookup("Transformer Architecture");
+    assert_eq!(hits.len(), 1, "title must index the page: {hits:?}");
+    assert_eq!(hits[0].slug, "transformer-architecture");
+}
+
+#[test]
+fn build_index_uses_slug_from_filename_as_term() {
+    let wiki = TestWiki::new();
+    let page = make_page("Some Long Title", &["arch"], "normal", "body");
+    wiki.write_page("architecture/short-slug.md", &page);
+
+    let index = build_index(wiki.root()).expect("build");
+    let hits = index.lookup("short-slug");
+    assert_eq!(
+        hits.len(),
+        1,
+        "slug derived from filename must be a term: {hits:?}"
+    );
+    assert_eq!(hits[0].title, "Some Long Title");
+}
+
+#[test]
+fn build_index_uses_aliases_list_as_terms() {
+    let wiki = TestWiki::new();
+    let mut page = make_page("Real Title", &["arch"], "normal", "body");
+    page.aliases = vec!["nickname".to_string(), "ALIAS-TWO".to_string()];
+    wiki.write_page("architecture/real.md", &page);
+
+    let index = build_index(wiki.root()).expect("build");
+    assert_eq!(index.lookup("nickname").len(), 1, "first alias indexed");
+    assert_eq!(
+        index.lookup("alias-two").len(),
+        1,
+        "second alias indexed (case-folded)"
+    );
+}
+
+#[test]
+fn build_index_alias_field_missing_is_treated_as_empty() {
+    // No `aliases:` key at all in frontmatter (the default for existing vaults).
+    let wiki = TestWiki::new();
+    let page = make_page("Plain Page", &["arch"], "normal", "body");
+    // page.aliases is empty by default — this mimics absence of the field.
+    wiki.write_page("architecture/plain.md", &page);
+
+    let index = build_index(wiki.root()).expect("build");
+    // Page is still indexed by title + slug.
+    assert_eq!(
+        index.lookup("Plain Page").len(),
+        1,
+        "title still indexed when aliases missing"
+    );
+    assert_eq!(
+        index.lookup("plain").len(),
+        1,
+        "slug still indexed when aliases missing"
+    );
+}
+
+#[test]
+fn build_index_alias_field_empty_list_adds_no_extra_terms() {
+    let wiki = TestWiki::new();
+    let mut page = make_page("Title Only", &["arch"], "normal", "body");
+    page.aliases = vec![]; // explicit empty list
+    wiki.write_page("architecture/title-only.md", &page);
+
+    let index = build_index(wiki.root()).expect("build");
+    // Only title + slug — no extras.
+    let total: usize = index.terms.values().map(|v| v.len()).sum();
+    assert_eq!(
+        total, 2,
+        "title + slug => exactly 2 PageRef entries: {:?}",
+        index.terms
+    );
+}
+
+// ─── Build: edge cases ──────────────────────────────────────────────────────
+
+#[test]
+fn build_index_multi_word_title_stored_verbatim_not_tokenized() {
+    // Per implementation notes: "Multi-word titles stored verbatim in the
+    // term index. Windowed scan happens in the matcher (next sub-issue)."
+    let wiki = TestWiki::new();
+    let page = make_page("Flash Attention 2", &["arch"], "normal", "body");
+    wiki.write_page("architecture/flash-attention-2.md", &page);
+
+    let index = build_index(wiki.root()).expect("build");
+    // Whole multi-word title is one term:
+    assert_eq!(index.lookup("flash attention 2").len(), 1);
+    // Individual tokens are NOT terms here (matcher's job, not index's):
+    assert!(
+        index.lookup("attention").is_empty(),
+        "individual tokens must not be split by the index: {:?}",
+        index.terms
+    );
+}
+
+#[test]
+fn build_index_preserves_original_title_casing_in_pageref() {
+    let wiki = TestWiki::new();
+    let page = make_page("CamelCase Page", &["arch"], "normal", "body");
+    wiki.write_page("architecture/camel.md", &page);
+
+    let index = build_index(wiki.root()).expect("build");
+    let hits = index.lookup("camelcase page");
+    assert_eq!(hits.len(), 1);
+    assert_eq!(
+        hits[0].title, "CamelCase Page",
+        "PageRef.title preserves original casing"
+    );
+}
+
+#[test]
+fn build_index_pageref_path_uses_wiki_prefix() {
+    let wiki = TestWiki::new();
+    let page = make_page("X", &["arch"], "normal", "body");
+    wiki.write_page("architecture/x.md", &page);
+
+    let index = build_index(wiki.root()).expect("build");
+    let hits = index.lookup("x");
+    assert_eq!(hits.len(), 1);
+    assert_eq!(
+        hits[0].path, "wiki/architecture/x.md",
+        "path must include the `wiki/` prefix per project convention"
+    );
+}
+
+#[test]
+fn build_index_unicode_cjk_title_indexed_intact() {
+    let wiki = TestWiki::new();
+    let page = make_page("创业指南", &["startup"], "normal", "body");
+    wiki.write_page("_uncategorized/startup-guide.md", &page);
+
+    let index = build_index(wiki.root()).expect("build");
+    let hits = index.lookup("创业指南");
+    assert_eq!(
+        hits.len(),
+        1,
+        "CJK title must be findable verbatim: {:?}",
+        index.terms
+    );
+}
+
+#[test]
+fn build_index_empty_wiki_returns_empty_index() {
+    let wiki = TestWiki::new();
+    let index = build_index(wiki.root()).expect("build");
+    assert!(index.terms.is_empty(), "empty wiki => empty index");
+    assert!(index.lookup("anything").is_empty());
+}
+
+#[test]
+fn build_index_ambiguous_term_lists_all_pages() {
+    let wiki = TestWiki::new();
+    let mut a = make_page("A", &["arch"], "normal", "body");
+    a.aliases = vec!["common".to_string()];
+    wiki.write_page("architecture/a.md", &a);
+    let mut b = make_page("B", &["arch"], "normal", "body");
+    b.aliases = vec!["common".to_string()];
+    wiki.write_page("architecture/b.md", &b);
+
+    let index = build_index(wiki.root()).expect("build");
+    let hits = index.lookup("common");
+    assert_eq!(
+        hits.len(),
+        2,
+        "ambiguous term must list both pages — consumer decides how to surface: {hits:?}"
+    );
+    let slugs: Vec<&str> = hits.iter().map(|p| p.slug.as_str()).collect();
+    assert!(slugs.contains(&"a"));
+    assert!(slugs.contains(&"b"));
+}
+
+// ─── Lookup ──────────────────────────────────────────────────────────────────
+
+#[test]
+fn lookup_normalizes_input_so_callers_pass_raw_text() {
+    let wiki = TestWiki::new();
+    let page = make_page("Tantivy", &["tools"], "normal", "body");
+    wiki.write_page("tools/tantivy.md", &page);
+
+    let index = build_index(wiki.root()).expect("build");
+    // Same page resolves whether caller passes uppercased, mixed, or lowercased.
+    assert_eq!(index.lookup("TANTIVY").len(), 1);
+    assert_eq!(index.lookup("Tantivy").len(), 1);
+    assert_eq!(index.lookup("tantivy").len(), 1);
+}
+
+#[test]
+fn lookup_returns_empty_for_unknown_term() {
+    let wiki = TestWiki::new();
+    let page = make_page("Real", &["tools"], "normal", "body");
+    wiki.write_page("tools/real.md", &page);
+
+    let index = build_index(wiki.root()).expect("build");
+    assert!(index.lookup("nonexistent").is_empty());
+}
+
+// ─── Persistence: rebuild + sentinel ─────────────────────────────────────────
+
+#[test]
+fn rebuild_writes_index_json_under_aliases_dir() {
+    let wiki = TestWiki::new();
+    let page = make_page("Foo", &["tools"], "normal", "body");
+    wiki.write_page("tools/foo.md", &page);
+
+    rebuild_index(wiki.root()).expect("rebuild");
+    let index_file = wiki.root().join(ALIASES_DIR).join("index.json");
+    assert!(
+        index_file.exists(),
+        "index.json must exist after rebuild: {index_file:?}"
+    );
+    // The serialized blob round-trips into an AliasIndex with at least one term.
+    let raw = std::fs::read_to_string(&index_file).unwrap();
+    let parsed: AliasIndex = serde_json::from_str(&raw).expect("valid JSON shape");
+    assert!(
+        !parsed.terms.is_empty(),
+        "persisted index must contain the page's terms"
+    );
+}
+
+#[test]
+fn rebuild_writes_built_sentinel() {
+    let wiki = TestWiki::new();
+    let page = make_page("Foo", &["tools"], "normal", "body");
+    wiki.write_page("tools/foo.md", &page);
+
+    rebuild_index(wiki.root()).expect("rebuild");
+    let sentinel = wiki.root().join(ALIASES_DIR).join(".built");
+    assert!(
+        sentinel.exists(),
+        "rebuild must write the .built sentinel: {sentinel:?}"
+    );
+}
+
+#[test]
+fn ensure_index_builds_when_missing() {
+    let wiki = TestWiki::new();
+    let page = make_page("Foo", &["tools"], "normal", "body");
+    wiki.write_page("tools/foo.md", &page);
+
+    let dir = wiki.root().join(ALIASES_DIR);
+    assert!(!dir.exists(), "precondition: aliases dir absent");
+    ensure_index(wiki.root()).expect("ensure ok");
+    assert!(
+        dir.exists(),
+        "ensure_index must create the aliases directory"
+    );
+    let index_file = dir.join("index.json");
+    assert!(index_file.exists(), "ensure_index must write index.json");
+}
+
+/// Mirrors the backlinks `ensure_index_skips_rebuild_when_already_built`
+/// regression: after the first `ensure_index` builds the index, subsequent
+/// calls must short-circuit on the `.built` sentinel rather than re-walking
+/// `wiki/`. Detection: add a brand-new page after the first call; the second
+/// `ensure_index` must NOT pick it up — only an explicit `rebuild_index` or
+/// `update_for_page` should.
+#[test]
+fn ensure_index_skips_rebuild_when_already_built() {
+    let wiki = TestWiki::new();
+    let first = make_page("First", &["tools"], "normal", "body");
+    wiki.write_page("tools/first.md", &first);
+
+    ensure_index(wiki.root()).expect("first ensure ok");
+
+    // Add a brand-new page without calling update_for_page.
+    let stealth = make_page("Stealth", &["tools"], "normal", "body");
+    wiki.write_page("tools/stealth.md", &stealth);
+
+    ensure_index(wiki.root()).expect("second ensure ok");
+
+    // Reload the persisted index and confirm Stealth is absent. The second
+    // `ensure_index` must short-circuit; if it re-walked, Stealth would now
+    // be in the persisted index.
+    let raw = std::fs::read_to_string(wiki.root().join(ALIASES_DIR).join("index.json")).unwrap();
+    let persisted: AliasIndex = serde_json::from_str(&raw).expect("parse");
+    assert!(
+        persisted.lookup("stealth").is_empty(),
+        "ensure_index must short-circuit on .built — found Stealth in persisted index: {:?}",
+        persisted.terms
+    );
+}
+
+// ─── Incremental updates ─────────────────────────────────────────────────────
+
+#[test]
+fn update_for_page_indexes_a_brand_new_page() {
+    let wiki = TestWiki::new();
+    let page = make_page("Brand New", &["tools"], "normal", "body");
+    wiki.write_page("tools/brand-new.md", &page);
+
+    update_for_page(wiki.root(), Path::new("tools/brand-new.md")).expect("update");
+
+    let raw = std::fs::read_to_string(wiki.root().join(ALIASES_DIR).join("index.json")).unwrap();
+    let persisted: AliasIndex = serde_json::from_str(&raw).expect("parse");
+    let hits = persisted.lookup("Brand New");
+    assert_eq!(
+        hits.len(),
+        1,
+        "update_for_page must persist the new page: {:?}",
+        persisted.terms
+    );
+    assert_eq!(hits[0].slug, "brand-new");
+}
+
+#[test]
+fn update_for_page_drops_aliases_removed_in_new_version() {
+    let wiki = TestWiki::new();
+    let mut v1 = make_page("Page", &["tools"], "normal", "body");
+    v1.aliases = vec!["alias-keep".to_string(), "alias-drop".to_string()];
+    wiki.write_page("tools/page.md", &v1);
+    update_for_page(wiki.root(), Path::new("tools/page.md")).expect("v1 update");
+
+    // Reload, verify v1 state.
+    let raw = std::fs::read_to_string(wiki.root().join(ALIASES_DIR).join("index.json")).unwrap();
+    let after_v1: AliasIndex = serde_json::from_str(&raw).unwrap();
+    assert_eq!(after_v1.lookup("alias-keep").len(), 1);
+    assert_eq!(after_v1.lookup("alias-drop").len(), 1);
+
+    // v2: drop one alias.
+    let mut v2 = make_page("Page", &["tools"], "normal", "body");
+    v2.aliases = vec!["alias-keep".to_string()];
+    wiki.write_page("tools/page.md", &v2);
+    update_for_page(wiki.root(), Path::new("tools/page.md")).expect("v2 update");
+
+    let raw = std::fs::read_to_string(wiki.root().join(ALIASES_DIR).join("index.json")).unwrap();
+    let after_v2: AliasIndex = serde_json::from_str(&raw).unwrap();
+    assert_eq!(
+        after_v2.lookup("alias-keep").len(),
+        1,
+        "kept alias still resolves"
+    );
+    assert!(
+        after_v2.lookup("alias-drop").is_empty(),
+        "dropped alias must be removed: {:?}",
+        after_v2.terms
+    );
+}
+
+#[test]
+fn update_for_page_handles_title_rename() {
+    let wiki = TestWiki::new();
+    let v1 = make_page("Old Title", &["tools"], "normal", "body");
+    wiki.write_page("tools/page.md", &v1);
+    update_for_page(wiki.root(), Path::new("tools/page.md")).expect("v1 update");
+
+    // Rename: same file, different title.
+    let v2 = make_page("New Title", &["tools"], "normal", "body");
+    wiki.write_page("tools/page.md", &v2);
+    update_for_page(wiki.root(), Path::new("tools/page.md")).expect("v2 update");
+
+    let raw = std::fs::read_to_string(wiki.root().join(ALIASES_DIR).join("index.json")).unwrap();
+    let after: AliasIndex = serde_json::from_str(&raw).unwrap();
+    assert!(
+        after.lookup("old title").is_empty(),
+        "old title must be dropped: {:?}",
+        after.terms
+    );
+    assert_eq!(
+        after.lookup("new title").len(),
+        1,
+        "new title must be present"
+    );
+    // Slug term stays (filename did not change).
+    assert_eq!(after.lookup("page").len(), 1, "slug term still resolves");
+}
+
+#[test]
+fn update_for_page_handles_deleted_page() {
+    let wiki = TestWiki::new();
+    let page = make_page("Doomed", &["tools"], "normal", "body");
+    wiki.write_page("tools/doomed.md", &page);
+    update_for_page(wiki.root(), Path::new("tools/doomed.md")).expect("create update");
+
+    // Delete the page.
+    std::fs::remove_file(wiki.root().join("wiki/tools/doomed.md")).unwrap();
+    update_for_page(wiki.root(), Path::new("tools/doomed.md")).expect("delete update");
+
+    let raw = std::fs::read_to_string(wiki.root().join(ALIASES_DIR).join("index.json")).unwrap();
+    let after: AliasIndex = serde_json::from_str(&raw).unwrap();
+    assert!(
+        after.lookup("doomed").is_empty(),
+        "deleted page must be stripped from the index: {:?}",
+        after.terms
+    );
+}
+
+#[test]
+fn update_for_page_preserves_other_pages_terms() {
+    let wiki = TestWiki::new();
+    let a = make_page("Alpha", &["tools"], "normal", "body");
+    wiki.write_page("tools/alpha.md", &a);
+    let b = make_page("Beta", &["tools"], "normal", "body");
+    wiki.write_page("tools/beta.md", &b);
+
+    rebuild_index(wiki.root()).expect("rebuild");
+
+    // Touch only Alpha.
+    let mut a_v2 = make_page("Alpha", &["tools"], "normal", "body");
+    a_v2.aliases = vec!["a-alias".to_string()];
+    wiki.write_page("tools/alpha.md", &a_v2);
+    update_for_page(wiki.root(), Path::new("tools/alpha.md")).expect("update alpha");
+
+    let raw = std::fs::read_to_string(wiki.root().join(ALIASES_DIR).join("index.json")).unwrap();
+    let after: AliasIndex = serde_json::from_str(&raw).unwrap();
+    assert_eq!(after.lookup("alpha").len(), 1, "alpha still indexed");
+    assert_eq!(after.lookup("a-alias").len(), 1, "alpha alias added");
+    assert_eq!(after.lookup("beta").len(), 1, "beta untouched");
+}
+
+#[test]
+fn update_for_page_returns_index_path_when_changed() {
+    // Auto-commit (Option A) needs the sidecar paths so they land in the same
+    // commit as the page. Mirrors backlinks::update_for_page's return shape.
+    let wiki = TestWiki::new();
+    let page = make_page("Foo", &["tools"], "normal", "body");
+    wiki.write_page("tools/foo.md", &page);
+
+    let written =
+        update_for_page(wiki.root(), Path::new("tools/foo.md")).expect("update returns paths");
+    assert!(
+        !written.is_empty(),
+        "writing a page must report at least one updated sidecar path"
+    );
+    let expected = wiki.root().join(ALIASES_DIR).join("index.json");
+    assert!(
+        written.iter().any(|p| p == &expected),
+        "returned paths must include {expected:?}; got {written:?}"
+    );
+}
+
+// ─── Public API surface check ────────────────────────────────────────────────
+
+/// Compile-time assertion: PageRef must be Clone + serde-serializable so it
+/// can be embedded into MCP responses and CLI JSON output downstream (#102/#103).
+#[test]
+fn pageref_is_serializable() {
+    let p = PageRef {
+        slug: "x".into(),
+        title: "X".into(),
+        path: "wiki/x.md".into(),
+    };
+    let json = serde_json::to_string(&p).expect("serialize");
+    let back: PageRef = serde_json::from_str(&json).expect("deserialize");
+    assert_eq!(p, back);
+}

--- a/crates/lw-core/tests/aliases_test.rs
+++ b/crates/lw-core/tests/aliases_test.rs
@@ -6,10 +6,10 @@
 
 mod common;
 
-use common::{TestWiki, make_page};
+use common::{make_page, TestWiki};
 use lw_core::aliases::{
-    ALIASES_DIR, AliasIndex, PageRef, build_index, ensure_index, normalize, rebuild_index,
-    update_for_page,
+    build_index, ensure_index, normalize, rebuild_index, update_for_page, AliasIndex, PageRef,
+    ALIASES_DIR,
 };
 use std::path::Path;
 
@@ -489,6 +489,109 @@ fn update_for_page_returns_index_path_when_changed() {
     assert!(
         written.iter().any(|p| p == &expected),
         "returned paths must include {expected:?}; got {written:?}"
+    );
+}
+
+// ─── Regressions: PR #113 review ─────────────────────────────────────────────
+
+/// Regression for PR #113 review item 1: `update_for_page` must not write the
+/// `.built` sentinel — a partial incremental update is not a substitute for
+/// a full rebuild. If the sentinel were written by an incremental update on
+/// a fresh vault, a later `ensure_index` would short-circuit and leave every
+/// untouched page absent from alias lookups.
+///
+/// Detection: in a vault with two pages, call `update_for_page` on one
+/// (skipping `ensure_index`) and then call `ensure_index`. If the sentinel
+/// was incorrectly written, `ensure_index` short-circuits and the untouched
+/// page never makes it into the index.
+#[test]
+fn update_for_page_does_not_mark_index_as_fully_built() {
+    let wiki = TestWiki::new();
+    let touched = make_page("Touched", &["tools"], "normal", "body");
+    wiki.write_page("tools/touched.md", &touched);
+    let untouched = make_page("Untouched", &["tools"], "normal", "body");
+    wiki.write_page("tools/untouched.md", &untouched);
+
+    // Incremental update on the first page only — no ensure_index beforehand.
+    update_for_page(wiki.root(), Path::new("tools/touched.md")).expect("update");
+
+    // The next ensure_index MUST do a full rebuild (since we never built the
+    // index from scratch). If the incremental update wrote `.built`, this
+    // call short-circuits and leaves the untouched page out forever.
+    ensure_index(wiki.root()).expect("ensure");
+
+    let raw = std::fs::read_to_string(wiki.root().join(ALIASES_DIR).join("index.json")).unwrap();
+    let persisted: AliasIndex = serde_json::from_str(&raw).unwrap();
+    assert_eq!(
+        persisted.lookup("untouched").len(),
+        1,
+        "ensure_index after a partial incremental update must still rebuild \
+         the full vault — Untouched is missing: {:?}",
+        persisted.terms
+    );
+}
+
+/// Regression for PR #113 review item 2: page identity in the index is the
+/// full `wiki/<category>/<file>.md` path, not the filename slug. `lw new`
+/// allows two pages with the same filename in different categories (only the
+/// exact path is uniqueness-checked), so `update_for_page` must strip stale
+/// entries by path — otherwise editing one of two same-slug pages wipes the
+/// other from the index until a full rebuild.
+#[test]
+fn update_for_page_does_not_strip_same_slug_pages_in_other_categories() {
+    let wiki = TestWiki::new();
+    let tools_foo = make_page("Tools Foo", &["tools"], "normal", "body");
+    wiki.write_page("tools/foo.md", &tools_foo);
+    let arch_foo = make_page("Arch Foo", &["architecture"], "normal", "body");
+    wiki.write_page("architecture/foo.md", &arch_foo);
+
+    rebuild_index(wiki.root()).expect("rebuild");
+
+    // Sanity: term "foo" (the shared slug) resolves to BOTH pages before any
+    // incremental update runs.
+    let raw = std::fs::read_to_string(wiki.root().join(ALIASES_DIR).join("index.json")).unwrap();
+    let before: AliasIndex = serde_json::from_str(&raw).unwrap();
+    assert_eq!(
+        before.lookup("foo").len(),
+        2,
+        "precondition: both same-slug pages indexed: {:?}",
+        before.terms
+    );
+
+    // Edit only tools/foo.md.
+    let tools_foo_v2 = make_page("Tools Foo v2", &["tools"], "normal", "body");
+    wiki.write_page("tools/foo.md", &tools_foo_v2);
+    update_for_page(wiki.root(), Path::new("tools/foo.md")).expect("update tools/foo");
+
+    let raw = std::fs::read_to_string(wiki.root().join(ALIASES_DIR).join("index.json")).unwrap();
+    let after: AliasIndex = serde_json::from_str(&raw).unwrap();
+
+    // The architecture page must still be in the index — its title and slug
+    // entries must survive an unrelated edit on a same-slug sibling.
+    let arch_paths: Vec<&str> = after
+        .lookup("foo")
+        .iter()
+        .filter(|p| p.path == "wiki/architecture/foo.md")
+        .map(|p| p.path.as_str())
+        .collect();
+    assert_eq!(
+        arch_paths.len(),
+        1,
+        "architecture/foo.md must survive an edit on tools/foo.md: {:?}",
+        after.terms
+    );
+    assert_eq!(
+        after.lookup("arch foo").len(),
+        1,
+        "architecture/foo.md's title term must still resolve: {:?}",
+        after.terms
+    );
+    // And the just-edited page is reflected with the new title.
+    assert_eq!(after.lookup("tools foo v2").len(), 1, "new title indexed");
+    assert!(
+        after.lookup("tools foo").is_empty(),
+        "old title dropped for the edited page: {:?}",
+        after.terms
     );
 }
 

--- a/crates/lw-core/tests/aliases_test.rs
+++ b/crates/lw-core/tests/aliases_test.rs
@@ -6,10 +6,10 @@
 
 mod common;
 
-use common::{make_page, TestWiki};
+use common::{TestWiki, make_page};
 use lw_core::aliases::{
-    build_index, ensure_index, normalize, rebuild_index, update_for_page, AliasIndex, PageRef,
-    ALIASES_DIR,
+    ALIASES_DIR, AliasIndex, PageRef, build_index, ensure_index, normalize, rebuild_index,
+    update_for_page,
 };
 use std::path::Path;
 

--- a/crates/lw-core/tests/common/mod.rs
+++ b/crates/lw-core/tests/common/mod.rs
@@ -104,6 +104,7 @@ pub fn make_page(title: &str, tags: &[&str], decay: &str, body: &str) -> Page {
         generator: None,
         related: None,
         status: None,
+        aliases: vec![],
         body: body.to_string(),
     }
 }

--- a/crates/lw-core/tests/frontmatter_query_test.rs
+++ b/crates/lw-core/tests/frontmatter_query_test.rs
@@ -27,6 +27,7 @@ fn page_with(
         generator: generator.map(|s| s.to_string()),
         related: None,
         status: status.map(|s| s.to_string()),
+        aliases: vec![],
         body: body.to_string(),
     }
 }

--- a/crates/lw-core/tests/fs_test.rs
+++ b/crates/lw-core/tests/fs_test.rs
@@ -36,6 +36,7 @@ fn write_and_read_page() {
         generator: None,
         related: None,
         status: None,
+        aliases: vec![],
         body: "Hello world.\n".to_string(),
     };
     let path = root.join("wiki/architecture/test-page.md");
@@ -60,6 +61,7 @@ fn list_pages_finds_markdown() {
         generator: None,
         related: None,
         status: None,
+        aliases: vec![],
         body: "A.\n".into(),
     };
     let p2 = Page {
@@ -71,6 +73,7 @@ fn list_pages_finds_markdown() {
         generator: None,
         related: None,
         status: None,
+        aliases: vec![],
         body: "B.\n".into(),
     };
     write_page(&root.join("wiki/architecture/a.md"), &p1).unwrap();
@@ -174,6 +177,7 @@ fn write_page_leaves_no_tmp_file() {
         generator: None,
         related: None,
         status: None,
+        aliases: vec![],
         body: "content\n".to_string(),
     };
     let path = root.join("wiki/architecture/atomic-test.md");
@@ -236,6 +240,7 @@ fn write_page_does_not_follow_victim_symlink() {
         generator: None,
         related: None,
         status: None,
+        aliases: vec![],
         body: "safe\n".to_string(),
     };
     write_page(&page_path, &page).unwrap();

--- a/crates/lw-core/tests/search_test.rs
+++ b/crates/lw-core/tests/search_test.rs
@@ -14,6 +14,7 @@ fn make_page(title: &str, tags: &[&str], body: &str) -> (String, Page) {
         generator: None,
         related: None,
         status: None,
+        aliases: vec![],
         body: body.to_string(),
     };
     (format!("architecture/{slug}.md"), page)
@@ -173,6 +174,7 @@ fn search_chinese_text() {
         generator: None,
         related: None,
         status: None,
+        aliases: vec![],
         body: "如果你在创业，陷入焦虑和负面情绪中无法自拔。".to_string(),
     };
     searcher
@@ -262,6 +264,7 @@ fn search_mixed_chinese_english() {
         generator: None,
         related: None,
         status: None,
+        aliases: vec![],
         body: "使用 Claude Code 进行 AI Agent 开发的最佳实践。".to_string(),
     };
     searcher.index_page("tools/ai-agent-dev.md", &page).unwrap();

--- a/crates/lw-core/tests/tag_test.rs
+++ b/crates/lw-core/tests/tag_test.rs
@@ -11,6 +11,7 @@ fn make_page(title: &str, tags: &[&str]) -> Page {
         generator: None,
         related: None,
         status: None,
+        aliases: vec![],
         body: String::new(),
     }
 }

--- a/templates/engineering-notes/.gitignore
+++ b/templates/engineering-notes/.gitignore
@@ -2,3 +2,4 @@
 # These are local-only; re-generated automatically on demand.
 .lw/search/
 .lw/backlinks/.built
+.lw/aliases/.built

--- a/templates/general/.gitignore
+++ b/templates/general/.gitignore
@@ -2,3 +2,4 @@
 # These are local-only; re-generated automatically on demand.
 .lw/search/
 .lw/backlinks/.built
+.lw/aliases/.built

--- a/templates/research-papers/.gitignore
+++ b/templates/research-papers/.gitignore
@@ -2,3 +2,4 @@
 # These are local-only; re-generated automatically on demand.
 .lw/search/
 .lw/backlinks/.built
+.lw/aliases/.built


### PR DESCRIPTION
## Summary

Lands the title/alias index foundation that issue #100 specs out — the first link in the chain that closes [issue #42 (auto-link mention detection)](https://github.com/Pawpaw-Technology/llm-wiki/issues/42).

- New `lw_core::aliases` module with `AliasIndex { terms: BTreeMap<String, Vec<PageRef>> }` and `PageRef { slug, title, path }`.
- Indexes each page under (a) slug from filename, (b) frontmatter `title`, (c) every entry in the new `aliases:` frontmatter list (free-form, optional). Terms are normalized via `lowercase(NFC(s))`.
- Persists to `.lw/aliases/index.json` via `atomic_write`; `.built` sentinel for short-circuit (mirrors `backlinks::ensure_index`).
- `update_for_page(root, rel)` strips every entry whose slug matches the source page, then re-inserts current terms — handles renames, alias drops, and deletions in one path. Returns `Vec<PathBuf>` of files written so callers can include the index in the same auto-commit as the page (Option A pattern from #97/#99).
- `git.rs::is_lw_ephemeral` extended to filter `.lw/aliases/.built` from dirty-warnings; the three starter-template `.gitignore` files gain the same line.
- New `Page.aliases: Vec<String>` field (with matching `Frontmatter.aliases`); existing `Page` literals across the codebase updated.

## Spec ↔ implementation map

| #100 acceptance bullet | Where |
|---|---|
| `AliasIndex` struct + `terms` map | `crates/lw-core/src/aliases.rs` |
| Indexes title + `aliases:` + slug | `page_terms()` |
| `AliasIndex::build` + `AliasIndex::lookup` | `impl AliasIndex` |
| Persist to `.lw/aliases/index.json` | `save_index()` |
| Lazy rebuild on missing | `ensure_index()` |
| `update_for_page` incremental | `update_for_page()` |
| Auto-commit returns `Vec<PathBuf>` | `update_for_page()` returns `vec![index.json]` |
| `.lw/aliases/.built` filtered | `git.rs::is_lw_ephemeral` + 3 template gitignores |

## Out of scope (per #100)

- Matcher / tokenization (covered by #101).
- Wiring `aliases::update_for_page` into MCP/CLI write paths — happens when #101+ adds a consumer.
- Public MCP tool to query the index — no consumer yet.

## Test plan

- [x] `cargo test --workspace` — 509 / 509 pass (480 baseline + 28 new aliases tests + 1 new sentinel-filter test).
- [x] `cargo clippy --workspace --all-targets --no-deps` — clean.
- [x] `cargo fmt --all -- --check` — clean.
- [x] RED phase verified: 28 new tests panicked on `unimplemented!` before the GREEN commit.

Closes #100.

🤖 Generated with [Claude Code](https://claude.com/claude-code)