### PR TITLE
feat(core): unlinked-mention matcher (closes #101)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1095,6 +1095,7 @@ dependencies = [
  "toml",
  "tracing",
  "unicode-normalization",
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -2408,6 +2409,12 @@ checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
 
 [[package]]
 name = "unicode-xid"

--- a/crates/lw-core/Cargo.toml
+++ b/crates/lw-core/Cargo.toml
@@ -18,6 +18,7 @@ comrak = { version = "0.36", default-features = false }
 tempfile = "3"
 time = { version = "0.3", features = ["formatting", "macros", "local-offset"] }
 unicode-normalization = "0.1"
+unicode-segmentation = "1.12"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/lw-core/src/lib.rs
+++ b/crates/lw-core/src/lib.rs
@@ -1,6 +1,5 @@
 pub mod aliases;
 pub mod backlinks;
-pub mod mentions;
 pub mod error;
 pub mod fs;
 pub mod git;
@@ -9,6 +8,7 @@ pub mod ingest;
 pub mod journal;
 pub mod link;
 pub mod lint;
+pub mod mentions;
 pub mod page;
 pub mod schema;
 pub mod search;

--- a/crates/lw-core/src/lib.rs
+++ b/crates/lw-core/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod aliases;
 pub mod backlinks;
+pub mod mentions;
 pub mod error;
 pub mod fs;
 pub mod git;

--- a/crates/lw-core/src/mentions.rs
+++ b/crates/lw-core/src/mentions.rs
@@ -1,0 +1,33 @@
+//! Unlinked-mention matcher — flag terms in body text that match an indexed
+//! page but are not already wrapped in `[[…]]`. Stub for issue #101.
+
+use crate::aliases::AliasIndex;
+use serde::{Deserialize, Serialize};
+
+/// Maximum number of tokens to consider for a multi-word title lookup.
+pub const MAX_WINDOW_TOKENS: usize = 4;
+
+/// One unlinked mention found in a body. Multiple are emitted for ambiguous
+/// matches (a term that resolves to several pages).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct UnlinkedMention {
+    /// The exact text in the body that matched (preserving original casing /
+    /// whitespace as a single normalized space between tokens).
+    pub term: String,
+    /// Slug of the page the term resolves to.
+    pub target_slug: String,
+    /// 1-based line number in `body` where the match occurs.
+    pub line: u32,
+    /// Snippet of the surrounding line (centred on the match, ~80 chars).
+    pub context: String,
+}
+
+/// Scan `body` for terms that resolve to entries in `index` but are not yet
+/// wrapped in `[[…]]` wikilinks. Honours the rules in the issue #101 spec.
+pub fn find_unlinked_mentions(
+    _body: &str,
+    _index: &AliasIndex,
+    _self_slug: &str,
+) -> Vec<UnlinkedMention> {
+    unimplemented!("issue #101")
+}

--- a/crates/lw-core/src/mentions.rs
+++ b/crates/lw-core/src/mentions.rs
@@ -133,13 +133,21 @@ fn strip_frontmatter(body: &str) -> (&str, u32) {
     let mut found_close = false;
 
     for (i, line) in body.lines().enumerate() {
-        // `lines()` strips line terminators; reconstruct the byte length by
-        // adding 1 (\n) when this is not the last line.
+        // `lines()` strips the line terminator entirely. Detect whether the
+        // original byte sequence uses CRLF (\r\n = 2 bytes) or LF (\n = 1
+        // byte) so `consumed_bytes` stays aligned with `body`.
         let line_bytes = line.len();
         consumed_bytes += line_bytes;
-        // Only add the newline byte if there's more text after this line.
+        // Peek at the next byte after the line content: if it is '\r' the
+        // terminator is \r\n (2 bytes), otherwise just \n (1 byte). Only add
+        // the terminator when there is more content after this line.
         if consumed_bytes < body.len() {
-            consumed_bytes += 1;
+            let next_byte = body.as_bytes()[consumed_bytes];
+            if next_byte == b'\r' {
+                consumed_bytes += 2; // \r\n
+            } else {
+                consumed_bytes += 1; // \n
+            }
         }
         consumed_lines += 1;
 
@@ -244,12 +252,21 @@ fn scan_line(
                 continue;
             }
 
-            // Self-reference guard: if any matched page is the current
-            // page, drop the *whole* mention (per issue spec — a page does
-            // not flag mentions of itself, full stop). If multiple pages
-            // resolve and only one is self, we still drop, because the
-            // intent is "don't surface self-noise".
-            if !self_slug.is_empty() && pages.iter().any(|p| p.slug == self_slug) {
+            // Self-reference guard: filter out any PageRef whose slug is
+            // the current page (spec criterion #6). If the term resolves
+            // ambiguously to [self, page_b], we keep page_b and emit one
+            // mention for it (spec criterion #7 — consumer decides how to
+            // surface ambiguous matches). Only when ALL resolved pages are
+            // self do we suppress entirely and advance past the window.
+            let non_self_pages: Vec<_> = if self_slug.is_empty() {
+                pages.iter().collect()
+            } else {
+                pages.iter().filter(|p| p.slug != self_slug).collect()
+            };
+
+            if non_self_pages.is_empty() {
+                // Every resolution was self — consume the window without
+                // emitting, same as the original single-self behaviour.
                 matched_end_token = Some(end);
                 break;
             }
@@ -259,7 +276,7 @@ fn scan_line(
             let verbatim_term = line[start_byte..end_byte].to_string();
             let context = snippet_centered(line, start_byte, end_byte);
 
-            for page in pages {
+            for page in non_self_pages {
                 out.push(UnlinkedMention {
                     term: verbatim_term.clone(),
                     target_slug: page.slug.clone(),

--- a/crates/lw-core/src/mentions.rs
+++ b/crates/lw-core/src/mentions.rs
@@ -1,33 +1,339 @@
-//! Unlinked-mention matcher — flag terms in body text that match an indexed
-//! page but are not already wrapped in `[[…]]`. Stub for issue #101.
+//! Unlinked-mention matcher — flag terms in a page body that match an indexed
+//! page but are not already wrapped in `[[…]]`. Foundation for issue #42:
+//! a `lw lint` rule and `wiki_write` response field that nudge authors toward
+//! denser cross-linking.
+//!
+//! Algorithm overview
+//! ──────────────────
+//! 1. Skip the leading YAML frontmatter (`---\n…\n---\n`) so its keys never
+//!    fire false matches and so reported line numbers stay aligned with the
+//!    raw input text the caller hands us.
+//! 2. Walk line-by-line, maintaining fenced-code state across lines (toggled
+//!    by triple-backtick).
+//! 3. Per line, compute byte ranges to *exclude* (inline code, URLs, existing
+//!    `[[…]]` wikilinks). The matcher walks token windows of 1..=N words and
+//!    skips any whose byte span overlaps an excluded range.
+//! 4. Lookups go through `aliases::normalize` so casing + Unicode NFC are
+//!    handled identically to the index side.
+//! 5. Greedy longest-match per starting token: try the 4-, 3-, 2-, 1-token
+//!    window in order and advance past the first hit so "Flash Attention 2"
+//!    consumes its inner "Attention" without double-counting.
+//!
+//! Performance
+//! ───────────
+//! All regexes are compiled once via `LazyLock`. The hot loop allocates a
+//! few `String`s per token window (the normalized lookup key); profiling on a
+//! 500-page wiki + ~40-line body runs comfortably under the 100ms budget
+//! lifted from parent issue #42.
 
-use crate::aliases::AliasIndex;
+use crate::aliases::{AliasIndex, normalize};
+use regex::Regex;
 use serde::{Deserialize, Serialize};
+use std::sync::LazyLock;
+use unicode_segmentation::UnicodeSegmentation;
 
-/// Maximum number of tokens to consider for a multi-word title lookup.
+/// Maximum number of tokens we will join when looking up multi-word titles.
+/// "Sensible cap; most page titles are well under this" — issue #101.
 pub const MAX_WINDOW_TOKENS: usize = 4;
 
-/// One unlinked mention found in a body. Multiple are emitted for ambiguous
-/// matches (a term that resolves to several pages).
+// ─── Regexes ────────────────────────────────────────────────────────────────
+
+/// `[[target]]` or `[[target|display]]`. Used to mask already-linked spans
+/// from the unlinked-mention scan. Same shape as `backlinks::WIKILINK_RE`.
+static WIKILINK_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"\[\[([^\]]+)\]\]").expect("WIKILINK_RE is a valid regex"));
+
+/// Inline-code spans: paired single backticks. Greedy-non-greedy `[^`]+`
+/// matches text up to the closing backtick. Unmatched single backticks (no
+/// closing pair) are left alone — same heuristic CommonMark uses.
+static INLINE_CODE_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"`[^`]+`").expect("INLINE_CODE_RE is a valid regex"));
+
+/// HTTP/HTTPS URLs. The pattern stops at the first whitespace, matching the
+/// issue note: "URL detection: regex `https?://\S+` is sufficient."
+static URL_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"https?://\S+").expect("URL_RE is a valid regex"));
+
+// ─── Public API ─────────────────────────────────────────────────────────────
+
+/// One unlinked mention found in a page body. Ambiguous lookups (a term that
+/// hits multiple pages) emit one `UnlinkedMention` per matched page — the
+/// consumer (`lw lint`, MCP) decides how to surface that to the user.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct UnlinkedMention {
-    /// The exact text in the body that matched (preserving original casing /
-    /// whitespace as a single normalized space between tokens).
+    /// The verbatim body text that matched (preserves original casing).
     pub term: String,
     /// Slug of the page the term resolves to.
     pub target_slug: String,
-    /// 1-based line number in `body` where the match occurs.
+    /// 1-based line number in the input `body` where the match occurs.
     pub line: u32,
-    /// Snippet of the surrounding line (centred on the match, ~80 chars).
+    /// A ~80-character snippet of the matched line, centred on the term.
     pub context: String,
 }
 
 /// Scan `body` for terms that resolve to entries in `index` but are not yet
-/// wrapped in `[[…]]` wikilinks. Honours the rules in the issue #101 spec.
+/// wrapped in `[[…]]` wikilinks.
+///
+/// The matcher is read-only: it returns suggestions; auto-fix is out of scope
+/// (issue #101). Excludes content inside fenced code blocks, inline code,
+/// URLs, the leading frontmatter block, and existing wikilinks. Self-mentions
+/// (`PageRef.slug == self_slug`) are dropped.
+#[tracing::instrument(level = "debug", skip(body, index))]
 pub fn find_unlinked_mentions(
-    _body: &str,
-    _index: &AliasIndex,
-    _self_slug: &str,
+    body: &str,
+    index: &AliasIndex,
+    self_slug: &str,
 ) -> Vec<UnlinkedMention> {
-    unimplemented!("issue #101")
+    if body.is_empty() || index.terms.is_empty() {
+        return Vec::new();
+    }
+
+    let (scan_text, line_offset) = strip_frontmatter(body);
+
+    let mut out: Vec<UnlinkedMention> = Vec::new();
+    let mut in_fence = false;
+
+    for (idx, line) in scan_text.lines().enumerate() {
+        let line_no = (idx as u32) + 1 + line_offset;
+
+        // Fenced-code state machine. A line whose trimmed-start prefix is
+        // ``` (with optional language tag) toggles the fence state. The
+        // toggle line itself is treated as part of the fence either way.
+        if line.trim_start().starts_with("```") {
+            in_fence = !in_fence;
+            continue;
+        }
+        if in_fence {
+            continue;
+        }
+
+        scan_line(line, line_no, index, self_slug, &mut out);
+    }
+
+    out
+}
+
+// ─── Internal helpers ───────────────────────────────────────────────────────
+
+/// Strip a leading YAML frontmatter block (`---\n…\n---\n`) from `body`.
+/// Returns the remaining text plus the number of lines consumed so the caller
+/// can keep reported line numbers aligned with the *original* input text.
+///
+/// If the body has no frontmatter the input is returned unchanged with a 0
+/// line offset.
+fn strip_frontmatter(body: &str) -> (&str, u32) {
+    // Frontmatter must begin at byte 0 — anything else is body content.
+    if !body.starts_with("---\n") && body != "---" && !body.starts_with("---\r\n") {
+        return (body, 0);
+    }
+
+    // Walk lines, counting bytes until we find the closing `---` line.
+    let mut consumed_bytes = 0usize;
+    let mut consumed_lines = 0u32;
+    let mut found_close = false;
+
+    for (i, line) in body.lines().enumerate() {
+        // `lines()` strips line terminators; reconstruct the byte length by
+        // adding 1 (\n) when this is not the last line.
+        let line_bytes = line.len();
+        consumed_bytes += line_bytes;
+        // Only add the newline byte if there's more text after this line.
+        if consumed_bytes < body.len() {
+            consumed_bytes += 1;
+        }
+        consumed_lines += 1;
+
+        if i > 0 && line.trim_end() == "---" {
+            found_close = true;
+            break;
+        }
+    }
+
+    if !found_close {
+        return (body, 0);
+    }
+
+    // `consumed_bytes` is now the byte index of the first body byte. Clamp to
+    // the body length to be defensive against pathological inputs.
+    let split = consumed_bytes.min(body.len());
+    (&body[split..], consumed_lines)
+}
+
+/// Compute byte ranges (start..end, half-open) on `line` that should be
+/// invisible to the matcher: inside `[[…]]`, inline `…`, or a URL.
+fn excluded_ranges(line: &str) -> Vec<(usize, usize)> {
+    let mut ranges: Vec<(usize, usize)> = Vec::new();
+    for cap in WIKILINK_RE.find_iter(line) {
+        ranges.push((cap.start(), cap.end()));
+    }
+    for cap in INLINE_CODE_RE.find_iter(line) {
+        ranges.push((cap.start(), cap.end()));
+    }
+    for cap in URL_RE.find_iter(line) {
+        ranges.push((cap.start(), cap.end()));
+    }
+    // Sort + leave overlaps in place — the overlap check downstream is O(N)
+    // anyway and ranges per line are tiny.
+    ranges.sort_by_key(|&(s, _)| s);
+    ranges
+}
+
+/// True if `[start, end)` overlaps any excluded range.
+fn span_excluded(start: usize, end: usize, ranges: &[(usize, usize)]) -> bool {
+    ranges.iter().any(|&(s, e)| start < e && s < end)
+}
+
+/// Walk `line` and append every unlinked mention into `out`.
+fn scan_line(
+    line: &str,
+    line_no: u32,
+    index: &AliasIndex,
+    self_slug: &str,
+    out: &mut Vec<UnlinkedMention>,
+) {
+    let exclusions = excluded_ranges(line);
+
+    // Tokenize with Unicode word boundaries. Each entry is (byte_start, word).
+    // For CJK text, where there are no whitespace boundaries, this still
+    // yields the contiguous CJK run as a single "word" — which is what we
+    // want for verbatim multi-character title matching.
+    let tokens: Vec<(usize, &str)> = line.unicode_word_indices().collect();
+    if tokens.is_empty() {
+        return;
+    }
+
+    // Greedy: at each starting token, try the longest window first.
+    let mut i = 0usize;
+    while i < tokens.len() {
+        let mut matched_end_token: Option<usize> = None;
+
+        for window in (1..=MAX_WINDOW_TOKENS).rev() {
+            let end = i + window;
+            if end > tokens.len() {
+                continue;
+            }
+            let (start_byte, _) = tokens[i];
+            let (last_start, last_word) = tokens[end - 1];
+            let end_byte = last_start + last_word.len();
+
+            // Skip windows that touch any excluded byte range.
+            if span_excluded(start_byte, end_byte, &exclusions) {
+                continue;
+            }
+
+            // Build the lookup key from the verbatim byte slice between the
+            // first and last tokens. This naturally handles two cases:
+            //
+            // - ASCII: "Flash Attention 2" — tokens separated by spaces in
+            //   the body text, which `normalize` collapses to lowercase NFC.
+            // - CJK: "创业指南" — `unicode_word_indices` splits each
+            //   character into its own token, but the byte slice between the
+            //   first and last tokens is the contiguous run, with no
+            //   spurious separators inserted.
+            //
+            // We also collapse internal whitespace runs to a single space so
+            // that "Flash  Attention" (double-space) still resolves.
+            let raw_slice = &line[start_byte..end_byte];
+            let normalized_key = normalize(&collapse_whitespace(raw_slice));
+            let pages = index.terms.get(&normalized_key);
+
+            let Some(pages) = pages else {
+                continue;
+            };
+            if pages.is_empty() {
+                continue;
+            }
+
+            // Self-reference guard: if any matched page is the current
+            // page, drop the *whole* mention (per issue spec — a page does
+            // not flag mentions of itself, full stop). If multiple pages
+            // resolve and only one is self, we still drop, because the
+            // intent is "don't surface self-noise".
+            if !self_slug.is_empty() && pages.iter().any(|p| p.slug == self_slug) {
+                matched_end_token = Some(end);
+                break;
+            }
+
+            // Use the verbatim body slice as the `term` so the user sees
+            // their own casing in lint output.
+            let verbatim_term = line[start_byte..end_byte].to_string();
+            let context = snippet_centered(line, start_byte, end_byte);
+
+            for page in pages {
+                out.push(UnlinkedMention {
+                    term: verbatim_term.clone(),
+                    target_slug: page.slug.clone(),
+                    line: line_no,
+                    context: context.clone(),
+                });
+            }
+
+            matched_end_token = Some(end);
+            break;
+        }
+
+        // Advance past the matched window (greedy) or by one token if
+        // nothing matched at this position.
+        i = matched_end_token.unwrap_or(i + 1);
+    }
+}
+
+/// Collapse runs of whitespace inside `s` to a single space and trim ends.
+/// Used so that double-space or tab-separated multi-word titles in body text
+/// still match the canonicalized index keys.
+fn collapse_whitespace(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut last_was_space = false;
+    for ch in s.chars() {
+        if ch.is_whitespace() {
+            if !last_was_space && !out.is_empty() {
+                out.push(' ');
+                last_was_space = true;
+            }
+        } else {
+            out.push(ch);
+            last_was_space = false;
+        }
+    }
+    if out.ends_with(' ') {
+        out.pop();
+    }
+    out
+}
+
+/// Build a context snippet of `line` centred on the byte range `[start, end)`.
+/// Mirrors `backlinks::snippet_for` but works on byte offsets so it can be
+/// reused without reconstructing the `[[slug]]` needle.
+fn snippet_centered(line: &str, start: usize, end: usize) -> String {
+    if line.is_empty() {
+        return String::new();
+    }
+    const RADIUS: usize = 80;
+    if line.len() <= RADIUS * 2 {
+        return line.to_string();
+    }
+
+    let want_start = start.saturating_sub(RADIUS / 2);
+    let want_end = (end + RADIUS / 2).min(line.len());
+
+    // Clamp to char boundaries so we never split a multi-byte UTF-8 sequence.
+    let char_start = line
+        .char_indices()
+        .map(|(i, _)| i)
+        .rfind(|&i| i <= want_start)
+        .unwrap_or(0);
+    let char_end = line
+        .char_indices()
+        .map(|(i, _)| i)
+        .find(|&i| i >= want_end)
+        .unwrap_or(line.len());
+
+    let mut snip = line[char_start..char_end].to_string();
+    if char_start > 0 {
+        snip = format!("…{snip}");
+    }
+    if char_end < line.len() {
+        snip = format!("{snip}…");
+    }
+    snip
 }

--- a/crates/lw-core/tests/mentions_test.rs
+++ b/crates/lw-core/tests/mentions_test.rs
@@ -5,9 +5,9 @@
 
 mod common;
 
-use common::{make_page, TestWiki};
-use lw_core::aliases::{build_index, AliasIndex};
-use lw_core::mentions::{find_unlinked_mentions, UnlinkedMention, MAX_WINDOW_TOKENS};
+use common::{TestWiki, make_page};
+use lw_core::aliases::{AliasIndex, build_index};
+use lw_core::mentions::{MAX_WINDOW_TOKENS, UnlinkedMention, find_unlinked_mentions};
 
 // ─── Tiny helpers (reduce per-test boilerplate) ─────────────────────────────
 

--- a/crates/lw-core/tests/mentions_test.rs
+++ b/crates/lw-core/tests/mentions_test.rs
@@ -5,9 +5,9 @@
 
 mod common;
 
-use common::{TestWiki, make_page};
-use lw_core::aliases::{AliasIndex, build_index};
-use lw_core::mentions::{MAX_WINDOW_TOKENS, UnlinkedMention, find_unlinked_mentions};
+use common::{make_page, TestWiki};
+use lw_core::aliases::{build_index, AliasIndex};
+use lw_core::mentions::{find_unlinked_mentions, UnlinkedMention, MAX_WINDOW_TOKENS};
 
 // ─── Tiny helpers (reduce per-test boilerplate) ─────────────────────────────
 
@@ -575,6 +575,108 @@ fn perf_under_100ms_on_500_page_wiki() {
     );
     // In debug mode just print the timing for human review.
     eprintln!("find_unlinked_mentions on 500-page wiki: {elapsed:?}");
+}
+
+// ─── PR #115 review regression: CRLF frontmatter ────────────────────────────
+
+/// Frontmatter delimited by `\r\n` line endings must be stripped correctly.
+/// The byte-counter inside `strip_frontmatter` must account for the extra `\r`
+/// byte that `body.lines()` discards, otherwise the split lands inside the
+/// `\r` byte of the closing `---\r\n` and line numbers are off by 1.
+#[test]
+fn frontmatter_with_crlf_line_endings_is_excluded_and_lines_after_it_count_correctly() {
+    let (_wiki, index) = index_with(&[(
+        "tools/tantivy.md",
+        make_page("Tantivy", &["tools"], "normal", "body"),
+    )]);
+
+    // Build a body whose frontmatter uses \r\n throughout.
+    // Line map (1-based within the raw string):
+    //   1: ---\r\n
+    //   2: title: x\r\n
+    //   3: ---\r\n
+    //   4: actual body line 1\r\n
+    //   5: [[tantivy]]\r\n   ← already linked, must NOT fire
+    //   6: tantivy\r\n        ← unlinked, MUST fire
+    let body = "---\r\ntitle: x\r\n---\r\nactual body line 1\r\n[[tantivy]]\r\ntantivy\r\n";
+    let hits = find_unlinked_mentions(body, &index, "");
+
+    // The "tantivy" inside the frontmatter key area must not fire.
+    // (None of the frontmatter lines contain the plain word "tantivy", but
+    // this assertion guards against the CRLF split going wrong and scanning
+    // frontmatter as body.)
+    assert!(
+        hits.iter().all(|h| h.line >= 4),
+        "no match may come from within the frontmatter (lines 1-3): {hits:?}"
+    );
+
+    // The already-linked [[tantivy]] on line 5 must not fire.
+    assert!(
+        !hits.iter().any(|h| h.line == 5),
+        "[[tantivy]] (already linked) must not fire: {hits:?}"
+    );
+
+    // The unlinked "tantivy" on line 6 of the raw body must fire exactly once.
+    let line6_hits: Vec<_> = hits.iter().filter(|h| h.line == 6).collect();
+    assert_eq!(
+        line6_hits.len(),
+        1,
+        "exactly one match expected on raw-input line 6 (unlinked tantivy): {hits:?}"
+    );
+    assert_eq!(line6_hits[0].target_slug, "tantivy");
+}
+
+// ─── PR #115 review regression: self-ref + ambiguous match interaction ───────
+
+/// When a term resolves ambiguously to BOTH self.md and other.md, the self
+/// entry must be filtered out and exactly one mention (for other.md) emitted.
+/// This tests spec criterion #7: the self-ref guard is a filter, not a drop.
+#[test]
+fn self_ref_drops_only_self_when_term_ambiguously_matches_other_pages() {
+    // Give both pages the same alias "foo" so the term is genuinely ambiguous.
+    let mut self_page = make_page("Self Page", &["arch"], "normal", "body");
+    self_page.aliases = vec!["foo".to_string()];
+    let mut other_page = make_page("Other Page", &["arch"], "normal", "body");
+    other_page.aliases = vec!["foo".to_string()];
+    let (_wiki, index) = index_with(&[
+        ("architecture/self.md", self_page),
+        ("architecture/other.md", other_page),
+    ]);
+
+    // Scan body that mentions "foo" with self_slug = "self".
+    let body = "foo is interesting.";
+    let hits = find_unlinked_mentions(body, &index, "self");
+
+    // Must produce exactly one mention — for "other", not "self".
+    assert_eq!(
+        hits.len(),
+        1,
+        "exactly one mention expected (self filtered, other kept): {hits:?}"
+    );
+    assert_eq!(
+        hits[0].target_slug, "other",
+        "surviving mention must point to the non-self page: {hits:?}"
+    );
+}
+
+/// When a term resolves ONLY to self.md, the self-ref guard must suppress all
+/// output (zero mentions). This is the original spec criterion #6 behaviour,
+/// preserved after the filter-not-drop refactor.
+#[test]
+fn self_ref_yields_no_mentions_when_term_only_matches_self() {
+    let (_wiki, index) = index_with(&[(
+        "tools/tantivy.md",
+        make_page("Tantivy", &["tools"], "normal", "body"),
+    )]);
+
+    // "tantivy" resolves only to itself — scanning its own body must yield nothing.
+    let body = "Tantivy is great.";
+    let hits = find_unlinked_mentions(body, &index, "tantivy");
+
+    assert!(
+        hits.is_empty(),
+        "self-only match must produce zero mentions: {hits:?}"
+    );
 }
 
 // ─── Compile-time API surface ───────────────────────────────────────────────

--- a/crates/lw-core/tests/mentions_test.rs
+++ b/crates/lw-core/tests/mentions_test.rs
@@ -1,0 +1,593 @@
+//! Integration tests for `lw_core::mentions::find_unlinked_mentions` — issue #101.
+//!
+//! Covers every acceptance bullet of #101 plus the performance contract lifted
+//! from parent #42 (< 100ms for a 500-page wiki).
+
+mod common;
+
+use common::{make_page, TestWiki};
+use lw_core::aliases::{build_index, AliasIndex};
+use lw_core::mentions::{find_unlinked_mentions, UnlinkedMention, MAX_WINDOW_TOKENS};
+
+// ─── Tiny helpers (reduce per-test boilerplate) ─────────────────────────────
+
+/// Build an alias index containing exactly the given (rel_path, page) pairs.
+fn index_with(pages: &[(&str, lw_core::page::Page)]) -> (TestWiki, AliasIndex) {
+    let wiki = TestWiki::new();
+    for (rel, page) in pages {
+        wiki.write_page(rel, page);
+    }
+    let index = build_index(wiki.root()).expect("build index");
+    (wiki, index)
+}
+
+/// Convenience: find mentions on an empty self_slug ("") so no self-ref guard
+/// kicks in. Use the explicit API in tests that exercise the guard.
+fn mentions_for(body: &str, index: &AliasIndex) -> Vec<UnlinkedMention> {
+    find_unlinked_mentions(body, index, "")
+}
+
+// ─── Spec acceptance bullet: empty body ─────────────────────────────────────
+
+#[test]
+fn empty_body_returns_no_mentions() {
+    let (_wiki, index) = index_with(&[(
+        "tools/transformer.md",
+        make_page("Transformer", &["arch"], "normal", "body"),
+    )]);
+    let hits = mentions_for("", &index);
+    assert!(hits.is_empty(), "empty body must produce no mentions");
+}
+
+// ─── Spec acceptance bullet: empty index ────────────────────────────────────
+
+#[test]
+fn empty_index_returns_no_mentions() {
+    let index = AliasIndex::default();
+    let body = "Transformer architecture is widely used.";
+    let hits = mentions_for(body, &index);
+    assert!(
+        hits.is_empty(),
+        "empty index must produce no mentions: {hits:?}"
+    );
+}
+
+// ─── Spec acceptance bullet: single-token match (case-insensitive) ──────────
+
+#[test]
+fn case_insensitive_single_token_match() {
+    let (_wiki, index) = index_with(&[(
+        "tools/tantivy.md",
+        make_page("Tantivy", &["tools"], "normal", "body"),
+    )]);
+
+    // Body contains the page title with different casing.
+    let body = "We use TANTIVY for full-text search.";
+    let hits = mentions_for(body, &index);
+
+    assert_eq!(
+        hits.len(),
+        1,
+        "case-insensitive title hit expected: {hits:?}"
+    );
+    assert_eq!(hits[0].target_slug, "tantivy");
+    assert_eq!(hits[0].line, 1);
+    assert!(
+        hits[0].context.contains("TANTIVY"),
+        "context must include the matched text: {:?}",
+        hits[0].context
+    );
+}
+
+// ─── Spec acceptance bullet: multi-word title ───────────────────────────────
+
+#[test]
+fn multi_word_title_match_uses_token_window() {
+    let (_wiki, index) = index_with(&[(
+        "architecture/flash-attention-2.md",
+        make_page("Flash Attention 2", &["arch"], "normal", "body"),
+    )]);
+
+    let body = "We benchmarked flash attention 2 against the baseline.";
+    let hits = mentions_for(body, &index);
+
+    assert_eq!(hits.len(), 1, "multi-word title must match: {hits:?}");
+    assert_eq!(hits[0].target_slug, "flash-attention-2");
+    // The matched term should reflect the body casing (not the indexed casing).
+    assert!(
+        hits[0].term.to_lowercase().contains("flash attention 2"),
+        "matched term must reflect body text: {:?}",
+        hits[0].term
+    );
+}
+
+#[test]
+fn multi_word_match_is_greedy_longest_wins() {
+    // Both "Attention" and "Flash Attention 2" are pages. The body says
+    // "flash attention 2" — the matcher must surface the longest match
+    // (Flash Attention 2), not also "Attention" inside it.
+    let (_wiki, index) = index_with(&[
+        (
+            "architecture/attention.md",
+            make_page("Attention", &["arch"], "normal", "body"),
+        ),
+        (
+            "architecture/flash-attention-2.md",
+            make_page("Flash Attention 2", &["arch"], "normal", "body"),
+        ),
+    ]);
+
+    let body = "Read about flash attention 2 here.";
+    let hits = mentions_for(body, &index);
+
+    let slugs: Vec<&str> = hits.iter().map(|h| h.target_slug.as_str()).collect();
+    assert!(
+        slugs.contains(&"flash-attention-2"),
+        "longest greedy match (flash-attention-2) must be present: {hits:?}"
+    );
+    assert!(
+        !slugs.contains(&"attention"),
+        "shorter prefix (attention) must NOT also fire when consumed by the \
+         longer match: {hits:?}"
+    );
+}
+
+// ─── Spec acceptance bullet: alias match ────────────────────────────────────
+
+#[test]
+fn alias_match_resolves_via_index() {
+    let mut page = make_page("Tantivy", &["tools"], "normal", "body");
+    page.aliases = vec!["tantivy-search".to_string()];
+    let (_wiki, index) = index_with(&[("tools/tantivy.md", page)]);
+
+    let body = "We migrated from Lucene to tantivy-search last year.";
+    let hits = mentions_for(body, &index);
+
+    assert_eq!(hits.len(), 1, "alias must resolve to its page: {hits:?}");
+    assert_eq!(hits[0].target_slug, "tantivy");
+}
+
+// ─── Spec acceptance bullet: already-linked exclusion ───────────────────────
+
+#[test]
+fn already_linked_term_is_excluded() {
+    let (_wiki, index) = index_with(&[(
+        "tools/tantivy.md",
+        make_page("Tantivy", &["tools"], "normal", "body"),
+    )]);
+
+    let body = "We use [[tantivy]] for full-text search.";
+    let hits = mentions_for(body, &index);
+
+    assert!(
+        hits.is_empty(),
+        "term inside [[…]] must not be flagged: {hits:?}"
+    );
+}
+
+#[test]
+fn already_linked_with_pipe_alias_is_excluded() {
+    let (_wiki, index) = index_with(&[(
+        "tools/tantivy.md",
+        make_page("Tantivy", &["tools"], "normal", "body"),
+    )]);
+
+    let body = "We use [[tantivy|the search engine]] here.";
+    let hits = mentions_for(body, &index);
+
+    assert!(
+        hits.is_empty(),
+        "term inside [[a|b]] must not be flagged: {hits:?}"
+    );
+}
+
+#[test]
+fn unlinked_term_on_same_line_as_a_link_is_still_flagged() {
+    // "[[Foo]]" should not gate every other token on that line.
+    let (_wiki, index) = index_with(&[
+        (
+            "tools/foo.md",
+            make_page("Foo", &["tools"], "normal", "body"),
+        ),
+        (
+            "tools/bar.md",
+            make_page("Bar", &["tools"], "normal", "body"),
+        ),
+    ]);
+
+    let body = "See [[foo]] and also bar for details.";
+    let hits = mentions_for(body, &index);
+
+    let slugs: Vec<&str> = hits.iter().map(|h| h.target_slug.as_str()).collect();
+    assert!(slugs.contains(&"bar"), "bar (unlinked) must fire: {hits:?}");
+    assert!(
+        !slugs.contains(&"foo"),
+        "foo (already linked) must not fire: {hits:?}"
+    );
+}
+
+// ─── Spec acceptance bullet: code-block exclusion ───────────────────────────
+
+#[test]
+fn fenced_code_block_content_is_excluded() {
+    let (_wiki, index) = index_with(&[(
+        "tools/tantivy.md",
+        make_page("Tantivy", &["tools"], "normal", "body"),
+    )]);
+
+    let body = "Some prose.\n```rust\nlet x = tantivy::Index::create();\n```\nMore prose.";
+    let hits = mentions_for(body, &index);
+
+    assert!(
+        hits.is_empty(),
+        "tantivy inside ``` fence must be excluded: {hits:?}"
+    );
+}
+
+#[test]
+fn text_after_closing_fence_is_re_enabled() {
+    // Make sure the fence state machine flips back on the closing ```.
+    let (_wiki, index) = index_with(&[(
+        "tools/tantivy.md",
+        make_page("Tantivy", &["tools"], "normal", "body"),
+    )]);
+
+    let body = "Intro.\n```\nignored tantivy here\n```\nUse tantivy outside.";
+    let hits = mentions_for(body, &index);
+
+    assert_eq!(
+        hits.len(),
+        1,
+        "exactly one match (post-fence) expected: {hits:?}"
+    );
+    assert_eq!(hits[0].target_slug, "tantivy");
+    // Line 5 of the body (1-based).
+    assert_eq!(
+        hits[0].line, 5,
+        "match must come from the post-fence line, not inside the fence: {hits:?}"
+    );
+}
+
+// ─── Spec acceptance bullet: inline-code exclusion ──────────────────────────
+
+#[test]
+fn inline_code_content_is_excluded() {
+    let (_wiki, index) = index_with(&[(
+        "tools/tantivy.md",
+        make_page("Tantivy", &["tools"], "normal", "body"),
+    )]);
+
+    let body = "Look at the `tantivy` API for details.";
+    let hits = mentions_for(body, &index);
+
+    assert!(
+        hits.is_empty(),
+        "term inside `inline code` must be excluded: {hits:?}"
+    );
+}
+
+#[test]
+fn inline_code_does_not_swallow_rest_of_line() {
+    let (_wiki, index) = index_with(&[
+        (
+            "tools/tantivy.md",
+            make_page("Tantivy", &["tools"], "normal", "body"),
+        ),
+        (
+            "tools/lucene.md",
+            make_page("Lucene", &["tools"], "normal", "body"),
+        ),
+    ]);
+
+    let body = "Compare `tantivy` to lucene now.";
+    let hits = mentions_for(body, &index);
+
+    let slugs: Vec<&str> = hits.iter().map(|h| h.target_slug.as_str()).collect();
+    assert!(
+        slugs.contains(&"lucene"),
+        "lucene (outside backticks) must fire: {hits:?}"
+    );
+    assert!(
+        !slugs.contains(&"tantivy"),
+        "tantivy (inside backticks) must not fire: {hits:?}"
+    );
+}
+
+// ─── Spec acceptance bullet: URL exclusion ──────────────────────────────────
+
+#[test]
+fn url_content_is_excluded() {
+    let (_wiki, index) = index_with(&[(
+        "tools/tantivy.md",
+        make_page("Tantivy", &["tools"], "normal", "body"),
+    )]);
+
+    let body = "See https://example.com/tantivy/docs for the manual.";
+    let hits = mentions_for(body, &index);
+
+    assert!(
+        hits.is_empty(),
+        "term inside a URL must be excluded: {hits:?}"
+    );
+}
+
+#[test]
+fn http_url_is_also_excluded() {
+    let (_wiki, index) = index_with(&[(
+        "tools/tantivy.md",
+        make_page("Tantivy", &["tools"], "normal", "body"),
+    )]);
+
+    let body = "Mirror at http://example.org/tantivy/index.html for offline use.";
+    let hits = mentions_for(body, &index);
+
+    assert!(hits.is_empty(), "http:// URL exclusion: {hits:?}");
+}
+
+// ─── Spec acceptance bullet: frontmatter exclusion ──────────────────────────
+
+#[test]
+fn frontmatter_block_is_excluded_and_lines_after_it_count_correctly() {
+    let (_wiki, index) = index_with(&[(
+        "tools/tantivy.md",
+        make_page("Tantivy", &["tools"], "normal", "body"),
+    )]);
+
+    // The matcher must accept a raw markdown source (with its own frontmatter)
+    // and skip the leading `---\n…\n---\n` block. Line counting starts at the
+    // first body line after the closing `---`.
+    let body = "---\ntitle: Doc with frontmatter\naliases: [tantivy]\n---\n\nWe use tantivy here.";
+    let hits = mentions_for(body, &index);
+
+    assert_eq!(
+        hits.len(),
+        1,
+        "exactly one match (in body, not frontmatter): {hits:?}"
+    );
+    assert_eq!(
+        hits[0].target_slug, "tantivy",
+        "match must resolve to tantivy: {hits:?}"
+    );
+    // The body line is the 6th line of the raw input — but matchers may report
+    // either the raw-input line or the body-relative line. Whichever convention
+    // is chosen, the `tantivy` token alone must NOT show up on a frontmatter
+    // line (so a reported line number of 3 or 4 is wrong; 5 or 6 is fine).
+    assert!(
+        hits[0].line >= 5,
+        "matched line must be after the closing --- (>= 5): {hits:?}"
+    );
+}
+
+// ─── Spec acceptance bullet: self-reference guard ───────────────────────────
+
+#[test]
+fn self_reference_is_not_flagged() {
+    let (_wiki, index) = index_with(&[(
+        "tools/tantivy.md",
+        make_page("Tantivy", &["tools"], "normal", "body"),
+    )]);
+
+    // The body of tantivy.md mentions its own title. With self_slug = "tantivy"
+    // the matcher must drop that mention entirely.
+    let body = "Tantivy is a Rust search library.";
+    let hits = find_unlinked_mentions(body, &index, "tantivy");
+
+    assert!(
+        hits.is_empty(),
+        "page must not flag mentions of itself: {hits:?}"
+    );
+}
+
+#[test]
+fn other_pages_still_flag_when_self_slug_set() {
+    let (_wiki, index) = index_with(&[
+        (
+            "tools/tantivy.md",
+            make_page("Tantivy", &["tools"], "normal", "body"),
+        ),
+        (
+            "tools/lucene.md",
+            make_page("Lucene", &["tools"], "normal", "body"),
+        ),
+    ]);
+
+    let body = "Tantivy is faster than Lucene.";
+    let hits = find_unlinked_mentions(body, &index, "tantivy");
+
+    let slugs: Vec<&str> = hits.iter().map(|h| h.target_slug.as_str()).collect();
+    assert!(
+        !slugs.contains(&"tantivy"),
+        "self-mention must be guarded: {hits:?}"
+    );
+    assert!(
+        slugs.contains(&"lucene"),
+        "non-self mentions must still fire: {hits:?}"
+    );
+}
+
+// ─── Spec acceptance bullet: ambiguous matches surfaced ─────────────────────
+
+#[test]
+fn ambiguous_term_emits_one_mention_per_page() {
+    let mut a = make_page("A", &["arch"], "normal", "body");
+    a.aliases = vec!["common".to_string()];
+    let mut b = make_page("B", &["arch"], "normal", "body");
+    b.aliases = vec!["common".to_string()];
+    let (_wiki, index) = index_with(&[("architecture/a.md", a), ("architecture/b.md", b)]);
+
+    let body = "The common term shows up here.";
+    let hits = mentions_for(body, &index);
+
+    assert_eq!(
+        hits.len(),
+        2,
+        "ambiguous term must emit one mention per matched page: {hits:?}"
+    );
+    let slugs: Vec<&str> = hits.iter().map(|h| h.target_slug.as_str()).collect();
+    assert!(slugs.contains(&"a"));
+    assert!(slugs.contains(&"b"));
+    // Same line + same matched term, different target slug.
+    assert_eq!(hits[0].line, hits[1].line);
+    assert_eq!(hits[0].term, hits[1].term);
+}
+
+// ─── Spec acceptance bullet: unicode (CJK + accented) ───────────────────────
+
+#[test]
+fn unicode_cjk_title_match() {
+    let (_wiki, index) = index_with(&[(
+        "_uncategorized/startup-guide.md",
+        make_page("创业指南", &["startup"], "normal", "body"),
+    )]);
+
+    let body = "今天读了创业指南这本书。";
+    let hits = mentions_for(body, &index);
+
+    assert_eq!(hits.len(), 1, "CJK title match: {hits:?}");
+    assert_eq!(hits[0].target_slug, "startup-guide");
+}
+
+#[test]
+fn unicode_accented_title_match_with_decomposed_input() {
+    // Title indexed in NFC form, body uses decomposed form. The matcher
+    // normalizes both via aliases::normalize so these collide.
+    let (_wiki, index) = index_with(&[(
+        "_uncategorized/cafe.md",
+        make_page("Café", &["food"], "normal", "body"),
+    )]);
+
+    let decomposed_body = "Visited the Cafe\u{0301} downtown today.";
+    let hits = mentions_for(decomposed_body, &index);
+
+    assert_eq!(
+        hits.len(),
+        1,
+        "accented title (decomposed) must still match: {hits:?}"
+    );
+    assert_eq!(hits[0].target_slug, "cafe");
+}
+
+// ─── Window cap (N=4 tokens) ────────────────────────────────────────────────
+
+#[test]
+fn window_cap_n_equals_four_documented() {
+    // Just compile-time / public-API check on the constant.
+    assert_eq!(MAX_WINDOW_TOKENS, 4);
+}
+
+#[test]
+fn five_token_title_is_not_matched_by_window_scan() {
+    // Five-token title — beyond the N=4 cap. This isn't a hard requirement
+    // (the issue says "sensible cap; most page titles are well under this"),
+    // but the cap MUST exist; this regression catches accidental removal.
+    let (_wiki, index) = index_with(&[(
+        "_uncategorized/long.md",
+        make_page("alpha beta gamma delta epsilon", &["x"], "normal", "body"),
+    )]);
+
+    let body = "Discuss alpha beta gamma delta epsilon today.";
+    let hits = mentions_for(body, &index);
+
+    assert!(
+        hits.is_empty(),
+        "5-token title must not be matched (window cap = 4): {hits:?}"
+    );
+}
+
+// ─── Context snippet sanity check ───────────────────────────────────────────
+
+#[test]
+fn context_snippet_centered_on_match_for_long_lines() {
+    let (_wiki, index) = index_with(&[(
+        "tools/tantivy.md",
+        make_page("Tantivy", &["tools"], "normal", "body"),
+    )]);
+
+    // 200+ char line so the snippet helper truncates with ellipsis.
+    let prefix = "lorem ipsum dolor sit amet ".repeat(8);
+    let suffix = " consectetur adipiscing elit sed do eiusmod tempor".to_string();
+    let body = format!("{prefix}tantivy{suffix}");
+    let hits = mentions_for(&body, &index);
+
+    assert_eq!(hits.len(), 1, "single hit on a long line: {hits:?}");
+    let ctx = &hits[0].context;
+    assert!(
+        ctx.contains("tantivy"),
+        "context must include the match: {ctx:?}"
+    );
+    assert!(
+        ctx.len() < body.len(),
+        "context must be shorter than the full line: ctx_len={}, body_len={}",
+        ctx.len(),
+        body.len()
+    );
+}
+
+// ─── Performance contract: < 100ms on a 500-page wiki ───────────────────────
+
+/// The parent issue (#42) sets a 100ms budget for the matcher on a
+/// 500-page wiki. Run only in `--release` so debug-mode noise (regex
+/// compilation, no inlining, integer-overflow checks) doesn't make this
+/// flaky on slow CI runners. In debug mode the assertion is skipped.
+#[test]
+fn perf_under_100ms_on_500_page_wiki() {
+    use std::time::Instant;
+
+    let wiki = TestWiki::new();
+    for i in 0..500 {
+        let title = format!("Page Title {i}");
+        let page = make_page(&title, &["bench"], "normal", "body");
+        let rel = format!("bench/page-{i:03}.md");
+        wiki.write_page(&rel, &page);
+    }
+    let index = build_index(wiki.root()).expect("build index");
+
+    // Build a typical body with ~40 lines, lots of plain text, a few
+    // already-linked references, a code fence, and a URL — exercising every
+    // exclusion path on every line.
+    let mut body = String::new();
+    body.push_str("This page references [[page-001]] and discusses Page Title 7\n");
+    body.push_str("along with Page Title 13 and a fenced block:\n");
+    body.push_str("```\nlet x = page_title_99();\n```\n");
+    body.push_str("plus a URL https://example.com/page-200/index.html.\n");
+    for i in 0..30 {
+        body.push_str(&format!(
+            "Line {i}: discussing Page Title {} in some prose.\n",
+            (i + 50) % 500
+        ));
+    }
+
+    let start = Instant::now();
+    let hits = find_unlinked_mentions(&body, &index, "");
+    let elapsed = start.elapsed();
+
+    // Sanity: should have found a bunch of matches.
+    assert!(
+        !hits.is_empty(),
+        "expected at least one match in the perf body"
+    );
+
+    // Only enforce the budget in release builds (issue spec).
+    #[cfg(not(debug_assertions))]
+    assert!(
+        elapsed.as_millis() < 100,
+        "find_unlinked_mentions took {elapsed:?} on 500-page wiki — exceeds 100ms budget"
+    );
+    // In debug mode just print the timing for human review.
+    eprintln!("find_unlinked_mentions on 500-page wiki: {elapsed:?}");
+}
+
+// ─── Compile-time API surface ───────────────────────────────────────────────
+
+#[test]
+fn unlinked_mention_is_serializable() {
+    let m = UnlinkedMention {
+        term: "Tantivy".into(),
+        target_slug: "tantivy".into(),
+        line: 1,
+        context: "We use Tantivy.".into(),
+    };
+    let json = serde_json::to_string(&m).expect("serialize");
+    let back: UnlinkedMention = serde_json::from_str(&json).expect("deserialize");
+    assert_eq!(m, back);
+}


### PR DESCRIPTION
## Summary

Implements `lw_core::mentions::find_unlinked_mentions(body, index, self_slug)` — scans a page body and flags terms that resolve to entries in the alias index (#100) but are not yet wrapped in `[[…]]`. Foundation for `lw lint --rule unlinked-mentions` and the `wiki_write` MCP response field (next sub-issues of parent #42).

Public API:

```rust
pub const MAX_WINDOW_TOKENS: usize = 4;

pub struct UnlinkedMention {
    pub term: String,
    pub target_slug: String,
    pub line: u32,
    pub context: String,
}

pub fn find_unlinked_mentions(
    body: &str,
    index: &AliasIndex,
    self_slug: &str,
) -> Vec<UnlinkedMention>;
```

Adds the `unicode-segmentation = "1.12"` dep (used for `unicode_word_indices` to drive the multi-word window scan).

## Algorithm

1. Strip leading YAML frontmatter (`---\n…\n---\n`); track consumed lines so reported line numbers stay aligned with the original input.
2. Walk lines; maintain triple-backtick fence state across lines.
3. Per line: compute byte-range exclusions for inline code (`` `…` ``), URLs (`https?://\S+`), and existing wikilinks (`[[…]]`). Token windows that overlap any exclusion are skipped.
4. Token windowing via `unicode_word_indices`: 1..=4 token windows per starting position, greedy-longest-wins. The lookup key is the **verbatim byte slice** between the first and last token (`line[start_byte..end_byte]`), then `aliases::normalize`d. This handles ASCII (space-separated) and CJK (no separators) symmetrically — adjacent CJK chars naturally form a single key without spurious spaces.
5. Self-reference guard: if any matched page's slug equals `self_slug`, drop the entire mention.
6. Ambiguity: one `UnlinkedMention` per matched page (term/line/context shared).

## Performance

`perf_under_100ms_on_500_page_wiki` test, `--release`: **555.75µs** on a 500-page wiki with a typical ~40-line body that exercises every exclusion path. ~180x under the 100ms budget from parent #42. The assertion is gated on `cfg(not(debug_assertions))` so debug-mode noise doesn't make it flaky on slow CI; the timing is also printed for human review.

## Acceptance Criteria Evidence

| Acceptance bullet | Test path : line | Assertion |
|---|---|---|
| `find_unlinked_mentions(body, index, self_slug) -> Vec<UnlinkedMention>` API | `crates/lw-core/src/mentions.rs` : 82-86 | Public function signature |
| `UnlinkedMention { term, target_slug, line, context }` struct | `crates/lw-core/src/mentions.rs` : 62-72 | Public struct definition |
| Unicode word-boundary scan; window up to N=4 tokens | `crates/lw-core/tests/mentions_test.rs` : 84-102 (`multi_word_title_match_uses_token_window`), 104-133 (`multi_word_match_is_greedy_longest_wins`), 414-426 (`window_cap_n_equals_four_documented`), 428-444 (`five_token_title_is_not_matched_by_window_scan`) | Multi-word window match + N=4 cap |
| Excludes `[[term]]` and `[[term\|alias]]` | `crates/lw-core/tests/mentions_test.rs` : 152-166 (`already_linked_term_is_excluded`), 168-182 (`already_linked_with_pipe_alias_is_excluded`), 184-207 (`unlinked_term_on_same_line_as_a_link_is_still_flagged`) | Exclusion of bracketed terms |
| Excludes fenced code blocks | `crates/lw-core/tests/mentions_test.rs` : 211-225 (`fenced_code_block_content_is_excluded`), 227-249 (`text_after_closing_fence_is_re_enabled`) | Fenced ```` ``` ```` content excluded; state machine flips back |
| Excludes inline code | `crates/lw-core/tests/mentions_test.rs` : 253-267 (`inline_code_content_is_excluded`), 269-294 (`inline_code_does_not_swallow_rest_of_line`) | Backtick-wrapped tokens excluded |
| Excludes URLs | `crates/lw-core/tests/mentions_test.rs` : 298-312 (`url_content_is_excluded`), 314-328 (`http_url_is_also_excluded`) | https:// and http:// URL exclusion |
| Excludes frontmatter | `crates/lw-core/tests/mentions_test.rs` : 332-360 (`frontmatter_block_is_excluded_and_lines_after_it_count_correctly`) | Leading `---…---` block skipped, line numbers correct |
| Self-reference guard via `self_slug` | `crates/lw-core/tests/mentions_test.rs` : 364-379 (`self_reference_is_not_flagged`), 381-407 (`other_pages_still_flag_when_self_slug_set`) | Self-mention dropped; other mentions still fire |
| Ambiguous matches returned as-is | `crates/lw-core/tests/mentions_test.rs` : 364-388 (`ambiguous_term_emits_one_mention_per_page`) | One mention per matched page |
| Performance < 100ms for 500-page wiki | `crates/lw-core/tests/mentions_test.rs` : 480-528 (`perf_under_100ms_on_500_page_wiki`) | **Measured: 555.75µs in --release** (~180x headroom). Assertion gated on `cfg(not(debug_assertions))`; timing also printed via `eprintln!` |
| Test: code-block exclusion | `crates/lw-core/tests/mentions_test.rs` : 211-249 | covered |
| Test: inline-code exclusion | `crates/lw-core/tests/mentions_test.rs` : 253-294 | covered |
| Test: URL exclusion | `crates/lw-core/tests/mentions_test.rs` : 298-328 | covered |
| Test: frontmatter exclusion | `crates/lw-core/tests/mentions_test.rs` : 332-360 | covered |
| Test: multi-word title match | `crates/lw-core/tests/mentions_test.rs` : 84-133 | covered |
| Test: alias match | `crates/lw-core/tests/mentions_test.rs` : 137-148 (`alias_match_resolves_via_index`) | covered |
| Test: already-linked exclusion | `crates/lw-core/tests/mentions_test.rs` : 152-207 | covered |
| Test: self-reference guard | `crates/lw-core/tests/mentions_test.rs` : 364-407 | covered |
| Test: case-insensitive match | `crates/lw-core/tests/mentions_test.rs` : 57-80 (`case_insensitive_single_token_match`) | "TANTIVY" → tantivy.md |
| Test: unicode (CJK / accented) | `crates/lw-core/tests/mentions_test.rs` : 440-455 (`unicode_cjk_title_match`), 457-477 (`unicode_accented_title_match_with_decomposed_input`) | CJK title `创业指南` matched; decomposed `Café` matched |
| Test: empty body | `crates/lw-core/tests/mentions_test.rs` : 32-40 (`empty_body_returns_no_mentions`) | covered |
| Test: empty index | `crates/lw-core/tests/mentions_test.rs` : 44-53 (`empty_index_returns_no_mentions`) | covered |

(Test line ranges are approximate — see `gh pr diff` for exact line numbers after fmt.)

## Test plan

- [x] `cargo test -p lw-core --test mentions_test` — 26 / 26 pass
- [x] `cargo test --workspace --no-fail-fast` — 537 / 537 pass
- [x] `cargo clippy --workspace --all-targets --no-deps` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo test -p lw-core --release --test mentions_test perf_under_100ms_on_500_page_wiki -- --nocapture` — **555.75µs** measured

🤖 Generated with [Claude Code](https://claude.com/claude-code)