### PR TITLE
feat(lint): unlinked-mentions rule (closes #102)

### DIFF
--- a/crates/lw-cli/src/lint.rs
+++ b/crates/lw-cli/src/lint.rs
@@ -1,9 +1,32 @@
 use crate::output::Format;
 use lw_core::lint::{self, LintReport};
 use std::path::Path;
+use std::process;
 
-pub fn run(root: &Path, category: &Option<String>, output_format: &Format) -> anyhow::Result<()> {
-    let report = lint::run_lint(root, category.as_deref())?;
+/// Run the lint command.
+///
+/// `rule` — when `Some("unlinked-mentions")`, run only that rule and zero-out
+/// all other rule results so the report (human or JSON) is scoped to just the
+/// requested rule. Unknown rule names are silently treated as "all rules" to
+/// stay forward-compatible.
+///
+/// Exit codes (per issue #102 + existing lint contract):
+///   0 — clean (no findings from any enabled rule)
+///   1 — at least one finding
+pub fn run(
+    root: &Path,
+    category: &Option<String>,
+    output_format: &Format,
+    rule: Option<&str>,
+) -> anyhow::Result<()> {
+    let mut report = lint::run_lint(root, category.as_deref())?;
+
+    // Apply rule filter: suppress all findings except those from the named rule.
+    if let Some(rule_name) = rule {
+        apply_rule_filter(&mut report, rule_name);
+    }
+
+    let has_findings = report.has_findings();
 
     match output_format {
         Format::Json => {
@@ -13,7 +36,30 @@ pub fn run(root: &Path, category: &Option<String>, output_format: &Format) -> an
             print_human_report(&report);
         }
     }
+
+    if has_findings {
+        process::exit(1);
+    }
     Ok(())
+}
+
+/// Zero out every rule except `rule_name` so the report is scoped to that
+/// single rule. Unknown rule names leave the report unchanged.
+fn apply_rule_filter(report: &mut LintReport, rule_name: &str) {
+    match rule_name {
+        "unlinked-mentions" => {
+            report.todo_pages.clear();
+            report.broken_related.clear();
+            report.orphan_pages.clear();
+            report.missing_concepts.clear();
+            report.stale_journal_pages.clear();
+            report.freshness.stale = 0;
+            report.freshness.stale_pages.clear();
+        }
+        _ => {
+            // Unknown rule — run all rules (forward-compatible default).
+        }
+    }
 }
 
 fn print_human_report(report: &LintReport) {
@@ -22,7 +68,8 @@ fn print_human_report(report: &LintReport) {
         + report.orphan_pages.len()
         + report.missing_concepts.len()
         + report.stale_journal_pages.len()
-        + report.freshness.stale;
+        + report.freshness.stale
+        + report.unlinked_mentions.len();
 
     println!("Wiki Lint Report");
     println!("================");
@@ -67,6 +114,14 @@ fn print_human_report(report: &LintReport) {
         );
         for f in &report.stale_journal_pages {
             println!("  - {}: {}", f.path, f.detail);
+        }
+        println!();
+    }
+
+    if !report.unlinked_mentions.is_empty() {
+        println!("Unlinked Mentions ({}):", report.unlinked_mentions.len());
+        for f in &report.unlinked_mentions {
+            println!("  {}", f.to_text_line());
         }
         println!();
     }

--- a/crates/lw-cli/src/main.rs
+++ b/crates/lw-cli/src/main.rs
@@ -187,7 +187,7 @@ enum Commands {
 
     /// Check wiki health: stale pages, broken links, orphans, TODO stubs
     #[command(
-        after_help = "Examples:\n  lw lint\n  lw lint --format json\n  lw lint --category architecture"
+        after_help = "Examples:\n  lw lint\n  lw lint --format json\n  lw lint --category architecture\n  lw lint --rule unlinked-mentions"
     )]
     Lint {
         /// Filter by category
@@ -196,6 +196,9 @@ enum Commands {
         /// Output format (human or json)
         #[arg(short, long, default_value = "human")]
         format: Format,
+        /// Run only the named rule (e.g. unlinked-mentions). Default: all rules.
+        #[arg(long)]
+        rule: Option<String>,
     },
 
     /// Start MCP server (stdio)
@@ -566,8 +569,12 @@ fn main() {
                 process::exit(1);
             }
         },
-        Commands::Lint { category, format } => match resolve_root(cli.root) {
-            Ok(root) => lint::run(&root, &category, &format),
+        Commands::Lint {
+            category,
+            format,
+            rule,
+        } => match resolve_root(cli.root) {
+            Ok(root) => lint::run(&root, &category, &format, rule.as_deref()),
             Err(e) => {
                 eprintln!("Error: {e}");
                 process::exit(1);

--- a/crates/lw-cli/tests/lint_cli.rs
+++ b/crates/lw-cli/tests/lint_cli.rs
@@ -186,7 +186,7 @@ fn lint_rule_filter_unlinked_mentions_json() {
     );
     // Other rule sections must be empty (rule filter suppresses them).
     assert!(
-        json["todo_pages"].as_array().map_or(true, |a| a.is_empty()),
+        json["todo_pages"].as_array().is_none_or(|a| a.is_empty()),
         "todo_pages must be empty when filtering to unlinked-mentions"
     );
 }

--- a/crates/lw-cli/tests/lint_cli.rs
+++ b/crates/lw-cli/tests/lint_cli.rs
@@ -1,0 +1,209 @@
+//! CLI-level integration tests for `lw lint` with the unlinked-mentions rule.
+//! Issue #102: surfaces the mention matcher (#101) as a lint rule.
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use tempfile::TempDir;
+
+fn lw() -> Command {
+    Command::cargo_bin("lw").unwrap()
+}
+
+/// Create a minimal initialized wiki with two pages:
+/// - tools/tantivy.md  (the target page)
+/// - tools/comrak.md   (mentions "tantivy" without linking it)
+///
+/// Returns the TempDir so it stays alive for the duration of the test.
+fn wiki_with_unlinked_mention() -> TempDir {
+    let tmp = TempDir::new().unwrap();
+    lw().args(["init", "--root", tmp.path().to_str().unwrap()])
+        .assert()
+        .success();
+
+    std::fs::write(
+        tmp.path().join("wiki/tools/tantivy.md"),
+        "---\ntitle: Tantivy\ntags: [tools]\n---\n\nTantivy is a full-text search engine.\n",
+    )
+    .unwrap();
+
+    std::fs::write(
+        tmp.path().join("wiki/tools/comrak.md"),
+        "---\ntitle: Comrak\ntags: [tools]\n---\n\nComrak is a CommonMark parser. We also use tantivy for search.\n",
+    )
+    .unwrap();
+
+    tmp
+}
+
+/// Acceptance bullet 4 (CLI): text output format matches the spec.
+/// Format: `<path>:<line> — "<term>" could link to [[<target>]]`
+/// Uses em-dash (U+2014), quoted term, double-bracket target.
+#[test]
+fn lint_unlinked_mentions_text_format_cli() {
+    let tmp = wiki_with_unlinked_mention();
+
+    let output = lw()
+        .args(["lint", "--root", tmp.path().to_str().unwrap()])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    // Must contain the em-dash character (U+2014)
+    assert!(
+        stdout.contains('\u{2014}'),
+        "lint text output must contain em-dash (—): {stdout:?}"
+    );
+    // Must quote the term
+    assert!(
+        stdout.contains("\"tantivy\""),
+        "lint text output must quote the term: {stdout:?}"
+    );
+    // Must use [[slug]] for target
+    assert!(
+        stdout.contains("[[tantivy]]"),
+        "lint text output must use [[tantivy]] notation: {stdout:?}"
+    );
+    // Must contain a line number reference
+    assert!(
+        stdout.contains(":1") || stdout.contains(":2"),
+        "lint text output must include a line number: {stdout:?}"
+    );
+}
+
+/// Acceptance bullet 5 (CLI): exit code is 1 when there are findings.
+#[test]
+fn lint_exits_1_when_findings_present() {
+    let tmp = wiki_with_unlinked_mention();
+
+    let output = lw()
+        .args(["lint", "--root", tmp.path().to_str().unwrap()])
+        .output()
+        .unwrap();
+
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "lw lint must exit 1 when findings are present; stdout: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+}
+
+/// Acceptance bullet 5 (CLI): exit code is 0 on a clean wiki.
+#[test]
+fn lint_exits_0_on_clean_wiki() {
+    let tmp = TempDir::new().unwrap();
+    lw().args(["init", "--root", tmp.path().to_str().unwrap()])
+        .assert()
+        .success();
+
+    // No pages — nothing to find
+    let output = lw()
+        .args(["lint", "--root", tmp.path().to_str().unwrap()])
+        .output()
+        .unwrap();
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "lw lint must exit 0 on a clean wiki; stdout: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+}
+
+/// Acceptance bullet 3 (CLI): `--format json` output matches the spec exactly.
+/// Shape: `{"rule": "unlinked-mentions", "path": "...", "line": N, "term": "...", "target": "..."}`
+#[test]
+fn lint_json_format_unlinked_mentions_shape() {
+    let tmp = wiki_with_unlinked_mention();
+
+    let output = lw()
+        .args([
+            "lint",
+            "--format",
+            "json",
+            "--root",
+            tmp.path().to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let json: serde_json::Value =
+        serde_json::from_str(&stdout).expect("lint --format json must emit valid JSON");
+
+    // The top-level report must have an "unlinked_mentions" array.
+    let findings = json["unlinked_mentions"]
+        .as_array()
+        .expect("JSON report must contain unlinked_mentions array");
+
+    assert!(
+        !findings.is_empty(),
+        "unlinked_mentions array must be non-empty when findings exist"
+    );
+
+    let f = &findings[0];
+    assert_eq!(
+        f["rule"], "unlinked-mentions",
+        "rule field must be 'unlinked-mentions': {f}"
+    );
+    assert!(f["path"].is_string(), "path must be string: {f}");
+    assert!(f["line"].is_number(), "line must be number: {f}");
+    assert_eq!(f["term"], "tantivy", "term must match: {f}");
+    assert_eq!(f["target"], "tantivy", "target must be slug: {f}");
+}
+
+/// `--rule unlinked-mentions` filters output to only that rule's findings.
+/// With the flag, the report must contain unlinked-mentions findings and
+/// suppress other rule sections (the output must be scoped to this rule only).
+#[test]
+fn lint_rule_filter_unlinked_mentions_json() {
+    let tmp = wiki_with_unlinked_mention();
+
+    let output = lw()
+        .args([
+            "lint",
+            "--rule",
+            "unlinked-mentions",
+            "--format",
+            "json",
+            "--root",
+            tmp.path().to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let json: serde_json::Value =
+        serde_json::from_str(&stdout).expect("lint --rule json must emit valid JSON");
+
+    // When --rule is applied, must include unlinked-mentions findings.
+    let findings = json["unlinked_mentions"]
+        .as_array()
+        .expect("filtered report must contain unlinked_mentions array");
+    assert!(
+        !findings.is_empty(),
+        "filtered report must include the rule's findings"
+    );
+    // Other rule sections must be empty (rule filter suppresses them).
+    assert!(
+        json["todo_pages"].as_array().map_or(true, |a| a.is_empty()),
+        "todo_pages must be empty when filtering to unlinked-mentions"
+    );
+}
+
+/// `--rule unlinked-mentions` also works in text/human mode.
+#[test]
+fn lint_rule_filter_unlinked_mentions_human() {
+    let tmp = wiki_with_unlinked_mention();
+
+    lw().args([
+        "lint",
+        "--rule",
+        "unlinked-mentions",
+        "--root",
+        tmp.path().to_str().unwrap(),
+    ])
+    .assert()
+    .code(1)
+    .stdout(predicate::str::contains("could link to"));
+}

--- a/crates/lw-core/src/lint.rs
+++ b/crates/lw-core/src/lint.rs
@@ -1,6 +1,9 @@
+use crate::aliases::{AliasIndex, build_index};
+use crate::backlinks::slug_from_wiki_path;
 use crate::fs::{category_from_path, list_pages, load_schema, read_page};
 use crate::git::{FreshnessLevel, compute_freshness, page_age_days};
 use crate::link::{extract_wiki_links, resolve_link};
+use crate::mentions::find_unlinked_mentions;
 use regex::Regex;
 use serde::Serialize;
 use std::collections::HashSet;
@@ -247,6 +250,11 @@ pub fn run_lint(root: &Path, category: Option<&str>) -> crate::Result<LintReport
             })
             .collect();
 
+    // Check 7: Unlinked mentions — issue #102.
+    // Build the alias index once (in-memory; no sentinel required here since
+    // lint is a read-only pass and the index is ephemeral).
+    let unlinked_mentions = run_unlinked_mentions(root, category, &page_paths, &wiki_dir);
+
     Ok(LintReport {
         todo_pages,
         broken_related,
@@ -259,8 +267,80 @@ pub fn run_lint(root: &Path, category: Option<&str>) -> crate::Result<LintReport
             stale_pages,
         },
         stale_journal_pages,
-        // Stub: unlinked-mentions rule is not yet implemented.
-        // Issue #102 implementation fills this in the GREEN step.
-        unlinked_mentions: vec![],
+        unlinked_mentions,
     })
+}
+
+/// Build the alias index and scan every page in `page_paths` for unlinked
+/// mentions. Returns one `UnlinkedMentionFinding` per `(page, term, target)`
+/// triple — ambiguous matches produce multiple findings, one per matched page.
+///
+/// Pages in `_journal/` are excluded: journal entries are intentionally
+/// capture-not-linked (issue #39). The `category` filter is honoured the same
+/// way the other checks honour it.
+fn run_unlinked_mentions(
+    root: &Path,
+    category: Option<&str>,
+    page_paths: &[std::path::PathBuf],
+    wiki_dir: &Path,
+) -> Vec<UnlinkedMentionFinding> {
+    // Build an in-memory alias index from the vault. Errors (e.g. an
+    // unreadable vault) are silently ignored — lint degrades gracefully
+    // rather than aborting the entire report.
+    let index: AliasIndex = match build_index(root) {
+        Ok(idx) => idx,
+        Err(_) => return Vec::new(),
+    };
+
+    if index.terms.is_empty() {
+        return Vec::new();
+    }
+
+    let mut findings = Vec::new();
+
+    for rel_path in page_paths {
+        // Apply the same category filter as other checks.
+        let cat = category_from_path(rel_path).unwrap_or_default();
+        if let Some(filter) = category
+            && cat != filter
+        {
+            continue;
+        }
+
+        let rel_str = rel_path.to_string_lossy();
+
+        // Exclude journal pages — they are intentionally un-linked captures.
+        if rel_str.starts_with("_journal/") || rel_str.starts_with("_journal\\") {
+            continue;
+        }
+        // Exclude special files.
+        if matches!(rel_str.as_ref(), "index.md" | "log.md") {
+            continue;
+        }
+
+        let abs_path = wiki_dir.join(rel_path);
+        let page = match read_page(&abs_path) {
+            Ok(p) => p,
+            Err(_) => continue,
+        };
+
+        // The slug for this page (used to suppress self-mentions).
+        let self_slug = slug_from_wiki_path(rel_path).unwrap_or_default();
+
+        // The path stored in findings uses `wiki/<rel>` form so it matches
+        // what the CLI displays (e.g. `wiki/tools/comrak.md`).
+        let finding_path = format!("wiki/{}", rel_str.replace('\\', "/"));
+
+        for mention in find_unlinked_mentions(&page.body, &index, &self_slug) {
+            findings.push(UnlinkedMentionFinding {
+                rule: "unlinked-mentions".to_string(),
+                path: finding_path.clone(),
+                line: mention.line,
+                term: mention.term,
+                target: mention.target_slug,
+            });
+        }
+    }
+
+    findings
 }

--- a/crates/lw-core/src/lint.rs
+++ b/crates/lw-core/src/lint.rs
@@ -7,6 +7,38 @@ use std::collections::HashSet;
 use std::path::Path;
 use std::sync::LazyLock;
 
+/// A single unlinked-mention finding produced by the `unlinked-mentions` rule.
+/// JSON shape (per issue #102 spec):
+/// `{"rule": "unlinked-mentions", "path": "...", "line": N, "term": "...", "target": "..."}`
+#[derive(Debug, Clone, Serialize)]
+pub struct UnlinkedMentionFinding {
+    /// Always `"unlinked-mentions"` — present in every serialized record so
+    /// a flat list of heterogeneous findings remains self-describing.
+    pub rule: String,
+    /// Wiki-relative path to the page that contains the mention
+    /// (e.g. `wiki/tools/comrak.md`).
+    pub path: String,
+    /// 1-based line number in the page body where the mention occurs.
+    pub line: u32,
+    /// Verbatim text from the body that matched (preserves original casing).
+    pub term: String,
+    /// Slug of the page the term resolves to (not the full path).
+    pub target: String,
+}
+
+impl UnlinkedMentionFinding {
+    /// Format this finding as the canonical human-readable text line:
+    /// `wiki/tools/comrak.md:12 — "tantivy" could link to [[tantivy]]`
+    ///
+    /// Uses an em-dash (U+2014) per the issue #102 text-format spec.
+    pub fn to_text_line(&self) -> String {
+        format!(
+            "{}:{} \u{2014} \"{}\" could link to [[{}]]",
+            self.path, self.line, self.term, self.target
+        )
+    }
+}
+
 static INDEX_LINK_RE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"\]\(([^)]+\.md)\)").expect("INDEX_LINK_RE is a valid regex"));
 
@@ -39,6 +71,26 @@ pub struct LintReport {
     /// Issue #37: signals captures that haven't been triaged.
     #[serde(default)]
     pub stale_journal_pages: Vec<LintFinding>,
+    /// Unlinked mentions found across all vault pages — issue #102.
+    /// One entry per (page, term, target) triple; ambiguous matches produce
+    /// multiple entries (one per matched page), following the one-finding-
+    /// per-offense pattern used by the other rules above.
+    #[serde(default)]
+    pub unlinked_mentions: Vec<UnlinkedMentionFinding>,
+}
+
+impl LintReport {
+    /// Returns `true` if any rule produced at least one finding.
+    /// Used by the CLI to decide the exit code: 0 = clean, 1 = findings.
+    pub fn has_findings(&self) -> bool {
+        !self.todo_pages.is_empty()
+            || !self.broken_related.is_empty()
+            || !self.orphan_pages.is_empty()
+            || !self.missing_concepts.is_empty()
+            || !self.stale_journal_pages.is_empty()
+            || self.freshness.stale > 0
+            || !self.unlinked_mentions.is_empty()
+    }
 }
 
 /// Run all lint checks on the wiki at `root`.
@@ -207,5 +259,8 @@ pub fn run_lint(root: &Path, category: Option<&str>) -> crate::Result<LintReport
             stale_pages,
         },
         stale_journal_pages,
+        // Stub: unlinked-mentions rule is not yet implemented.
+        // Issue #102 implementation fills this in the GREEN step.
+        unlinked_mentions: vec![],
     })
 }

--- a/crates/lw-core/tests/lint_test.rs
+++ b/crates/lw-core/tests/lint_test.rs
@@ -1,7 +1,7 @@
 mod common;
 
-use common::{TestWiki, make_page};
-use lw_core::lint::run_lint;
+use common::{make_page, TestWiki};
+use lw_core::lint::{run_lint, UnlinkedMentionFinding};
 
 #[test]
 fn lint_empty_wiki_returns_clean_report() {
@@ -367,5 +367,273 @@ fn lint_excludes_journal_pages_from_orphans() {
             .iter()
             .any(|p| p.contains("2026-04-25.md") || p.starts_with("_journal/")),
         "_journal/* pages must be excluded: {orphan_paths:?}"
+    );
+}
+
+// ─── Issue #102: unlinked-mentions lint rule ──────────────────────────────────
+
+/// Acceptance bullet 1: rule fires on unlinked mention (positive case).
+/// A page whose body contains "tantivy" (an unlinked mention of tools/tantivy.md)
+/// must produce exactly one finding in `unlinked_mentions`.
+#[test]
+fn lint_unlinked_mentions_fires_on_unlinked_term() {
+    let wiki = TestWiki::new();
+
+    // The target page: tantivy
+    let tantivy = make_page(
+        "Tantivy",
+        &["tools"],
+        "normal",
+        "Tantivy is a full-text search engine library.",
+    );
+    wiki.write_page("tools/tantivy.md", &tantivy);
+
+    // A page that mentions tantivy but does NOT link it
+    let comrak = make_page(
+        "Comrak",
+        &["tools"],
+        "normal",
+        "Comrak is a CommonMark parser. We also use tantivy for search.",
+    );
+    wiki.write_page("tools/comrak.md", &comrak);
+
+    let report = run_lint(wiki.root(), None).expect("lint should succeed");
+    assert_eq!(
+        report.unlinked_mentions.len(),
+        1,
+        "expected 1 unlinked-mention finding, got: {:?}",
+        report.unlinked_mentions
+    );
+    let f = &report.unlinked_mentions[0];
+    assert!(
+        f.path.contains("comrak.md"),
+        "finding path must point to comrak.md, got: {:?}",
+        f.path
+    );
+    assert_eq!(f.term, "tantivy", "term must be verbatim: {:?}", f.term);
+    assert_eq!(
+        f.target, "tantivy",
+        "target must be slug of tantivy page: {:?}",
+        f.target
+    );
+    assert_eq!(
+        f.line, 1,
+        "line must be 1 (body has only one line): {:?}",
+        f.line
+    );
+}
+
+/// Acceptance bullet 2: silent on already-linked mention (negative case).
+/// A page that uses `[[tantivy]]` must produce no unlinked-mention findings.
+#[test]
+fn lint_unlinked_mentions_silent_when_already_linked() {
+    let wiki = TestWiki::new();
+
+    let tantivy = make_page("Tantivy", &["tools"], "normal", "Full-text search library.");
+    wiki.write_page("tools/tantivy.md", &tantivy);
+
+    // Already linked with [[tantivy]]
+    let comrak = make_page(
+        "Comrak",
+        &["tools"],
+        "normal",
+        "Comrak is a CommonMark parser. We also use [[tantivy]] for search.",
+    );
+    wiki.write_page("tools/comrak.md", &comrak);
+
+    let report = run_lint(wiki.root(), None).expect("lint should succeed");
+    assert!(
+        report.unlinked_mentions.is_empty(),
+        "already-linked term must not produce findings: {:?}",
+        report.unlinked_mentions
+    );
+}
+
+/// Acceptance bullet 3: JSON output shape exactly matches the spec.
+/// `{"rule": "unlinked-mentions", "path": "...", "line": N, "term": "...", "target": "..."}`
+#[test]
+fn lint_unlinked_mentions_json_shape() {
+    let wiki = TestWiki::new();
+
+    let tantivy = make_page("Tantivy", &["tools"], "normal", "Full-text search library.");
+    wiki.write_page("tools/tantivy.md", &tantivy);
+
+    let comrak = make_page(
+        "Comrak",
+        &["tools"],
+        "normal",
+        "We use tantivy for indexing.",
+    );
+    wiki.write_page("tools/comrak.md", &comrak);
+
+    let report = run_lint(wiki.root(), None).expect("lint should succeed");
+    assert_eq!(report.unlinked_mentions.len(), 1);
+
+    let f = &report.unlinked_mentions[0];
+    // Serialize to JSON and verify exact field names and types.
+    let json_val = serde_json::to_value(f).expect("must serialize");
+    assert_eq!(
+        json_val["rule"], "unlinked-mentions",
+        "rule field must be 'unlinked-mentions': {json_val}"
+    );
+    assert!(
+        json_val["path"].is_string(),
+        "path must be a string: {json_val}"
+    );
+    assert!(
+        json_val["line"].is_number(),
+        "line must be a number: {json_val}"
+    );
+    assert_eq!(json_val["term"], "tantivy", "term must match: {json_val}");
+    assert_eq!(
+        json_val["target"], "tantivy",
+        "target must be the slug: {json_val}"
+    );
+    // No extra fields not in the spec (path, rule, line, term, target only).
+    let obj = json_val.as_object().unwrap();
+    for key in obj.keys() {
+        assert!(
+            ["rule", "path", "line", "term", "target"].contains(&key.as_str()),
+            "unexpected JSON field: {key}"
+        );
+    }
+}
+
+/// Acceptance bullet 4: text output shape matches the spec exactly.
+/// Format: `wiki/tools/comrak.md:12 — "tantivy" could link to [[tantivy]]`
+/// (em-dash U+2014, double quotes around term, double brackets around target)
+#[test]
+fn lint_unlinked_mentions_text_format() {
+    let wiki = TestWiki::new();
+
+    let tantivy = make_page("Tantivy", &["tools"], "normal", "Full-text search library.");
+    wiki.write_page("tools/tantivy.md", &tantivy);
+
+    let comrak = make_page(
+        "Comrak",
+        &["tools"],
+        "normal",
+        "We use tantivy for indexing.",
+    );
+    wiki.write_page("tools/comrak.md", &comrak);
+
+    let report = run_lint(wiki.root(), None).expect("lint should succeed");
+    assert_eq!(report.unlinked_mentions.len(), 1);
+
+    let f = &report.unlinked_mentions[0];
+    let text = f.to_text_line();
+    // Must contain the em-dash (U+2014), quoted term, and [[slug]] brackets.
+    assert!(
+        text.contains('\u{2014}'),
+        "text line must contain em-dash (—): {text:?}"
+    );
+    assert!(
+        text.contains("\"tantivy\""),
+        "text line must quote the term: {text:?}"
+    );
+    assert!(
+        text.contains("[[tantivy]]"),
+        "text line must use [[slug]] for target: {text:?}"
+    );
+    assert!(
+        text.contains(":1"),
+        "text line must contain line number ':1': {text:?}"
+    );
+    // Path portion before the colon must contain the page path.
+    assert!(
+        text.starts_with("wiki/") || text.contains("comrak.md"),
+        "text line must start with wiki-relative path: {text:?}"
+    );
+}
+
+/// Acceptance bullet 5: aggregate exit code — `lw lint` exits 1 when
+/// unlinked-mentions findings exist. Tested at the library level by checking
+/// that `has_findings()` returns true when `unlinked_mentions` is non-empty.
+#[test]
+fn lint_report_has_findings_when_unlinked_mentions_present() {
+    let wiki = TestWiki::new();
+
+    let tantivy = make_page("Tantivy", &["tools"], "normal", "Full-text search library.");
+    wiki.write_page("tools/tantivy.md", &tantivy);
+
+    let comrak = make_page(
+        "Comrak",
+        &["tools"],
+        "normal",
+        "We use tantivy for indexing.",
+    );
+    wiki.write_page("tools/comrak.md", &comrak);
+
+    let report = run_lint(wiki.root(), None).expect("lint should succeed");
+    assert!(
+        report.has_findings(),
+        "has_findings() must return true when unlinked_mentions is non-empty: {:?}",
+        report
+    );
+
+    // Clean wiki (no pages) must not have findings.
+    let wiki2 = TestWiki::new();
+    let clean = run_lint(wiki2.root(), None).expect("lint should succeed");
+    assert!(
+        !clean.has_findings(),
+        "has_findings() must return false on a clean wiki: {:?}",
+        clean
+    );
+}
+
+/// Acceptance bullet 6: ambiguous match — a term that matches multiple pages
+/// produces one finding per matched page (one-finding-per-offense pattern).
+#[test]
+fn lint_unlinked_mentions_ambiguous_match_produces_one_finding_per_target() {
+    let wiki = TestWiki::new();
+
+    // Two pages with the same alias "search"
+    let tantivy = make_page("Tantivy", &["tools"], "normal", "Full-text search library.");
+    wiki.write_page("tools/tantivy.md", &tantivy);
+
+    // A second page that also uses "tantivy" as an alias
+    let mut meilisearch = make_page(
+        "Meilisearch",
+        &["tools"],
+        "normal",
+        "Another search engine.",
+    );
+    meilisearch.aliases = vec!["tantivy".to_string()];
+    wiki.write_page("tools/meilisearch.md", &meilisearch);
+
+    // A page that mentions "tantivy" without linking
+    let page = make_page(
+        "Comrak",
+        &["tools"],
+        "normal",
+        "We use tantivy for full-text search.",
+    );
+    wiki.write_page("tools/comrak.md", &page);
+
+    let report = run_lint(wiki.root(), None).expect("lint should succeed");
+    // The mention "tantivy" is ambiguous (resolves to tantivy + meilisearch),
+    // so we expect 2 findings — one per matched page.
+    let findings_for_comrak: Vec<&UnlinkedMentionFinding> = report
+        .unlinked_mentions
+        .iter()
+        .filter(|f| f.path.contains("comrak.md"))
+        .collect();
+    assert_eq!(
+        findings_for_comrak.len(),
+        2,
+        "ambiguous term must produce one finding per matched page: {:?}",
+        findings_for_comrak
+    );
+    let targets: Vec<&str> = findings_for_comrak
+        .iter()
+        .map(|f| f.target.as_str())
+        .collect();
+    assert!(
+        targets.contains(&"tantivy"),
+        "findings must include tantivy slug: {targets:?}"
+    );
+    assert!(
+        targets.contains(&"meilisearch"),
+        "findings must include meilisearch slug: {targets:?}"
     );
 }

--- a/crates/lw-core/tests/lint_test.rs
+++ b/crates/lw-core/tests/lint_test.rs
@@ -1,7 +1,7 @@
 mod common;
 
-use common::{make_page, TestWiki};
-use lw_core::lint::{run_lint, UnlinkedMentionFinding};
+use common::{TestWiki, make_page};
+use lw_core::lint::{UnlinkedMentionFinding, run_lint};
 
 #[test]
 fn lint_empty_wiki_returns_clean_report() {


### PR DESCRIPTION
## Summary

- Adds `unlinked-mentions` lint rule that calls the `find_unlinked_mentions` matcher from #101 across every vault page in a single pass
- New `UnlinkedMentionFinding` struct with `to_text_line()` and full JSON serialization matching the spec
- `--rule unlinked-mentions` CLI flag filters the report to just this rule; other rules are zeroed out
- Exit code 1 on any findings, 0 on clean (enforced via new `has_findings()` on `LintReport`)

## Acceptance Criteria Evidence

| Bullet | Test path : line range |
|--------|------------------------|
| 1. Rule fires on unlinked mention | `crates/lw-core/tests/lint_test.rs` `lint_unlinked_mentions_fires_on_unlinked_term` lines 382–431 |
| 2. Silent on already-linked | `crates/lw-core/tests/lint_test.rs` `lint_unlinked_mentions_silent_when_already_linked` lines 433–459 |
| 3. JSON output shape (`rule`, `path`, `line`, `term`, `target`) | `crates/lw-core/tests/lint_test.rs` `lint_unlinked_mentions_json_shape` lines 461–505; `crates/lw-cli/tests/lint_cli.rs` `lint_json_format_unlinked_mentions_shape` lines 100–138 |
| 4. Text format: `path:N — "term" could link to [[target]]` | `crates/lw-core/tests/lint_test.rs` `lint_unlinked_mentions_text_format` lines 507–541; `crates/lw-cli/tests/lint_cli.rs` `lint_unlinked_mentions_text_format_cli` lines 42–73 |
| 5. Exit code 0=clean / 1=findings | `crates/lw-core/tests/lint_test.rs` `lint_report_has_findings_when_unlinked_mentions_present` lines 543–573; `crates/lw-cli/tests/lint_cli.rs` `lint_exits_1_when_findings_present` lines 75–89; `lint_exits_0_on_clean_wiki` lines 91–109 |
| 6. Ambiguous match → one finding per matched page | `crates/lw-core/tests/lint_test.rs` `lint_unlinked_mentions_ambiguous_match_produces_one_finding_per_target` lines 575–634 |

## Test plan

- [x] `cargo test -p lw-core -- lint` — 19 tests, all pass
- [x] `cargo test -p lw-cli --test lint_cli` — 6 tests, all pass
- [x] `cargo test --workspace --no-fail-fast` — 552 tests, all pass
- [x] `cargo clippy --workspace --all-targets --no-deps` — no issues
- [x] `cargo fmt --all -- --check` — clean
- [ ] CI green (watch after PR creation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)