### PR TITLE
fix(search): cache writer in early-check to avoid LockFailure race

### DIFF
--- a/crates/lw-core/src/search.rs
+++ b/crates/lw-core/src/search.rs
@@ -407,16 +407,27 @@ impl TantivySearcher {
         op(guard.as_mut().expect("writer opened above"))
     }
 
-    fn check_writer_available(&self) -> Result<()> {
-        let guard = self
+    /// Eagerly acquire the writer if it isn't already cached, so callers
+    /// (currently `rebuild`) can fail fast on a lock conflict before doing
+    /// expensive work. The acquired writer is **stored** in the mutex; we
+    /// must not open-and-drop it here, because tantivy's `IndexWriter` drop
+    /// path is asynchronous (merging threads finish in the background) and
+    /// the lock file can outlive the drop. A subsequent `with_writer` call
+    /// would then race the still-releasing lock and surface a spurious
+    /// `IndexLocked` — the exact flake hit on Linux CI before this change.
+    fn ensure_writer(&self) -> Result<()> {
+        let mut guard = self
             .writer
             .lock()
             .map_err(|e| WikiError::Internal(e.to_string()))?;
         if guard.is_some() {
             return Ok(());
         }
-        match self.index.writer::<TantivyDocument>(50_000_000) {
-            Ok(_writer) => Ok(()),
+        match self.index.writer(50_000_000) {
+            Ok(writer) => {
+                *guard = Some(writer);
+                Ok(())
+            }
             Err(tantivy::TantivyError::LockFailure(..)) => Err(WikiError::IndexLocked {
                 path: self.index_dir.clone(),
             }),
@@ -643,7 +654,7 @@ impl Searcher for TantivySearcher {
 
     #[tracing::instrument(skip(self))]
     fn rebuild(&self, wiki_dir: &Path) -> Result<()> {
-        self.check_writer_available()?;
+        self.ensure_writer()?;
 
         let mut docs = Vec::new();
         let pages = crate::fs::list_pages(wiki_dir)?;


### PR DESCRIPTION
## Summary

`rebuild()` was racy on Linux CI: `check_writer_available()` opened a tantivy `IndexWriter`, dropped it, and immediately after `with_writer()` opened it again. Tantivy's `IndexWriter::drop` is asynchronous (merging threads finish in the background) so the lock file could outlive the drop, and the second acquisition would surface as `IndexLocked`.

Renamed to `ensure_writer` and now store the acquired writer in the mutex instead of dropping it. The follow-up `with_writer` reuses it — one tantivy acquisition per rebuild instead of two, no race.

## Symptom

Intermittent CI failures on Ubuntu only (~25% on `main` since the `lw-mcp` test crate grew):

```
thread 'tests::wiki_query_csv_tags_split_to_and' panicked at crates/lw-mcp/src/lib.rs:2364:59:
called `Result::unwrap()` on an `Err` value: IndexLocked { path: "/tmp/.tmpPwGQuI/.lw/search" }
```

The panicking test rotated (`wiki_query_csv_tags_split_to_and`, `wiki_query_sort_title`, …) but the failure mode was identical: each test's own tempdir, always at `server.searcher.rebuild(...)`. macOS never hit it (different drop timing). Recent failed runs on `main`: 24963595572, 24963518724.

## Test plan

- [x] `cargo build`
- [x] `cargo fmt --check`
- [x] `RUSTFLAGS=-Dwarnings cargo clippy --all-targets`
- [x] `RUSTFLAGS=-Dwarnings cargo test` — 558 passed
- [x] `cargo test -p lw-mcp --lib` ×5 — all passed (was the flaky suite)
- [ ] CI green on Ubuntu + macOS