### PR TITLE
chore: wire installer tests + drop stale dead_code allows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1055,7 +1055,7 @@ dependencies = [
 
 [[package]]
 name = "lw-cli"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -1078,7 +1078,7 @@ dependencies = [
 
 [[package]]
 name = "lw-core"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "comrak",
  "gray_matter",
@@ -1100,7 +1100,7 @@ dependencies = [
 
 [[package]]
 name = "lw-mcp"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "lw-core",

--- a/crates/lw-cli/src/integrations/mcp.rs
+++ b/crates/lw-cli/src/integrations/mcp.rs
@@ -170,7 +170,6 @@ pub fn remove_entry(config: &mut Value, key_path: &str) -> bool {
 
 /// Result of an ownership-checked removal attempt.
 #[derive(Debug, PartialEq)]
-#[allow(dead_code)]
 pub enum RemoveOutcome {
     /// Entry was present, matched the managed shape, and has been removed.
     Removed,
@@ -190,7 +189,6 @@ pub enum RemoveOutcome {
 /// * `Removed` — entry matched; caller should persist `config`.
 /// * `PreservedUserEdited` — entry exists but was user-modified; caller should warn.
 /// * `NotPresent` — key_path resolved to nothing; caller should report no-op.
-#[allow(dead_code)]
 pub fn remove_if_managed(config: &mut Value, key_path: &str, canonical: &Value) -> RemoveOutcome {
     let parts: Vec<&str> = key_path.split('.').collect();
     let (last, parents) = parts.split_last().unwrap();


### PR DESCRIPTION
## Summary

Two small leftover cleanups from the 2026-04-25 issue sweep.

- **Fix 1 (ci.yml) — needs manual application, see below:** Wire `installer/tests/swap_test.sh` and `installer/tests/integrate_gate_test.sh` into CI so regressions in `install.sh` are caught automatically. Tests existed on `main` but were never invoked by CI.
- **Fix 2 (mcp.rs — committed):** Drop `#[allow(dead_code)]` on `RemoveOutcome` and `remove_if_managed`. These suppressions were added in the RED commit (`25d51d8`) when neither item had non-test callers. Commit `aec24f7` wired them into `integrate.rs`; the suppression is now misleading.

## Status

| Fix | File | Status |
|-----|------|--------|
| Drop stale `dead_code` allows | `crates/lw-cli/src/integrations/mcp.rs` | ✅ Committed (`6ef396b`) |
| Wire installer shell tests | `.github/workflows/ci.yml` | ⚠️ Needs manual push — see diff below |

The session's OAuth token lacks the `workflow` scope, so writes to `.github/workflows/ci.yml` are blocked by GitHub (both via `git push` and the contents API). The diff is minimal and verified locally (33/33 shell tests pass).

## ci.yml diff — apply manually

```diff
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,11 @@ jobs:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: Swatinem/rust-cache@v2
+      - name: Installer shell tests
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          bash installer/tests/swap_test.sh
+          bash installer/tests/integrate_gate_test.sh
       - run: cargo test --workspace
```

## Local verification

```
bash installer/tests/swap_test.sh        # 25 passed, 0 failed
bash installer/tests/integrate_gate_test.sh  # 8 passed, 0 failed
cargo clippy --all-targets -- -D warnings    # clean
cargo test --workspace                       # all passing (pre-existing
                                             # rebuild_rolls_back_writer_after_commit_failure
                                             # flake unrelated to this PR — fails on main too)
```

## Test plan

- [ ] Apply the ci.yml diff above (commit as `chore(ci): wire installer shell tests into ci.yml`)
- [ ] Confirm CI green on this PR
- [ ] Review the two-line `#[allow(dead_code)]` removal in `mcp.rs`

https://claude.ai/code/session_01MiW6Btx9UsS5szj27PMCba

---
_Generated by [Claude Code](https://claude.ai/code/session_01MiW6Btx9UsS5szj27PMCba)_